### PR TITLE
Add autorefresh lifetime for impersonated_redentials

### DIFF
--- a/tests/test_impersonated_credentials.py
+++ b/tests/test_impersonated_credentials.py
@@ -133,32 +133,6 @@ class TestImpersonatedCredentials(object):
         assert not credentials.valid
         assert credentials.expired
 
-    def test_refresh_failure_lifetime_specified(self, mock_donor_credentials):
-        credentials = self.make_credentials(lifetime=500)
-        token = 'token'
-
-        expire_time = (
-            _helpers.utcnow().replace(microsecond=0) +
-            datetime.timedelta(seconds=500)).isoformat('T') + 'Z'
-        response_body = {
-            "accessToken": token,
-            "expireTime": expire_time
-        }
-
-        request = self.make_request(
-            data=json.dumps(response_body),
-            status=http_client.OK)
-
-        credentials.refresh(request)
-
-        with pytest.raises(exceptions.RefreshError) as excinfo:
-            credentials.refresh(request)
-
-        assert excinfo.match(impersonated_credentials._LIFETIME_ERROR)
-
-        assert not credentials.valid
-        assert credentials.expired
-
     def test_refresh_failure_unauthorzed(self, mock_donor_credentials):
         credentials = self.make_credentials(lifetime=None)
 


### PR DESCRIPTION
Remove logic that current _does not_ `refresh` credentials if `lifetime=` parameter is set.

After this change, if the `lifetime=` is set, it only applies to the actual token returned for the impesonated credentials.  If either the `source_credential` or or `target_credential` expires, a refresh will get called to regenerate a new one.  If a user just wants a non-expiring access_token for the impersonated credentials, they can extract the access_token and `.apply()` headers.