### PR TITLE
_default.default() now handles ImportErrors for optional dependencies.

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -173,9 +173,9 @@ def _get_explicit_environ_credentials():
 def _get_gae_credentials():
     """Gets Google App Engine App Identity credentials and project ID."""
     try:
-      from google.auth import app_engine
+        from google.auth import app_engine
     except ImportError:
-      return None, None
+        return None, None
 
     try:
         credentials = app_engine.Credentials()
@@ -192,10 +192,10 @@ def _get_gce_credentials(request=None):
     # uses http.client. This is only acceptable because the metadata server
     # doesn't do SSL and never requires proxies.
     try:
-      from google.auth import compute_engine
-      from google.auth.compute_engine import _metadata
+        from google.auth import compute_engine
+        from google.auth.compute_engine import _metadata
     except ImportError:
-      return None, None
+        return None, None
 
     if request is None:
         request = google.auth.transport._http_client.Request()

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -172,8 +172,8 @@ def _get_explicit_environ_credentials():
 
 def _get_gae_credentials():
     """Gets Google App Engine App Identity credentials and project ID."""
-    # While this library is normally bundled with app_engine, there are some
-    # cases where it's not available, so we tolerate ImportError.
+    # While this library is normally bundled with app_engine, there are
+    # some cases where it's not available, so we tolerate ImportError.
     try:
         from google.auth import app_engine
     except ImportError:
@@ -194,8 +194,8 @@ def _get_gce_credentials(request=None):
     # uses http.client. This is only acceptable because the metadata server
     # doesn't do SSL and never requires proxies.
 
-    # While this library is normally bundled with compute_engine, there are some
-    # cases where it's not available, so we tolerate ImportError.
+    # While this library is normally bundled with compute_engine, there are
+    # some cases where it's not available, so we tolerate ImportError.
     try:
         from google.auth import compute_engine
         from google.auth.compute_engine import _metadata

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -172,7 +172,10 @@ def _get_explicit_environ_credentials():
 
 def _get_gae_credentials():
     """Gets Google App Engine App Identity credentials and project ID."""
-    from google.auth import app_engine
+    try:
+      from google.auth import app_engine
+    except ImportError:
+      return None, None
 
     try:
         credentials = app_engine.Credentials()
@@ -188,8 +191,11 @@ def _get_gce_credentials(request=None):
     # to require no arguments. So, we'll use the _http_client transport which
     # uses http.client. This is only acceptable because the metadata server
     # doesn't do SSL and never requires proxies.
-    from google.auth import compute_engine
-    from google.auth.compute_engine import _metadata
+    try:
+      from google.auth import compute_engine
+      from google.auth.compute_engine import _metadata
+    except ImportError:
+      return None, None
 
     if request is None:
         request = google.auth.transport._http_client.Request()

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -172,6 +172,8 @@ def _get_explicit_environ_credentials():
 
 def _get_gae_credentials():
     """Gets Google App Engine App Identity credentials and project ID."""
+    # While this library is normally bundled with app_engine, there are some
+    # cases where it's not available, so we tolerate ImportError.
     try:
         from google.auth import app_engine
     except ImportError:
@@ -191,6 +193,9 @@ def _get_gce_credentials(request=None):
     # to require no arguments. So, we'll use the _http_client transport which
     # uses http.client. This is only acceptable because the metadata server
     # doesn't do SSL and never requires proxies.
+
+    # While this library is normally bundled with compute_engine, there are some
+    # cases where it's not available, so we tolerate ImportError.
     try:
         from google.auth import compute_engine
         from google.auth.compute_engine import _metadata

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -175,7 +175,7 @@ def _get_gae_credentials():
     # While this library is normally bundled with app_engine, there are
     # some cases where it's not available, so we tolerate ImportError.
     try:
-        from google.auth import app_engine
+        import google.auth.app_engine as app_engine
     except ImportError:
         return None, None
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with io.open('README.rst', 'r') as fh:
 
 setup(
     name='google-auth',
-    version='1.6.1',
+    version='1.6.2',
     author='Google Cloud Platform',
     author_email='jonwayne+google-auth@google.com',
     description='Google Authentication Library',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with io.open('README.rst', 'r') as fh:
 
 setup(
     name='google-auth',
-    version='1.6.2',
+    version='1.6.1',
     author='Google Cloud Platform',
     author_email='jonwayne+google-auth@google.com',
     description='Google Authentication Library',


### PR DESCRIPTION
Handle ImportError when importing optional dependencies such as app_engine and compute_engine.

No unit tests yet pending input from maintainers.