### PR TITLE
Fix `pex` warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,11 @@ from setuptools import setup
 
 
 DEPENDENCIES = (
+    'cachetools>=2.0.0',
     'pyasn1-modules>=0.2.1',
     'rsa>=3.1.4',
+    'setuptools>=40.3.0',
     'six>=1.9.0',
-    'cachetools>=2.0.0',
 )
 
 


### PR DESCRIPTION
I was using `pex` on an application that lists `google-auth` as a dependency and got the following warning:

    ..../pex/environment.py:330 UserWarning: The `pkg_resources` package was loaded from a pex
    vendored version when declaring namespace packages defined by google-auth 1.6.2. The 
    google-auth 1.6.2 distribution should fix its `install_requires` to include `setuptools`

So adding `setuptools` as a listed dependency to fix this.

Also making the listing alphabetical.