### PR TITLE
follow rfc 7515 : strip padding from JWS segments

### DIFF
--- a/google/auth/_helpers.py
+++ b/google/auth/_helpers.py
@@ -215,3 +215,20 @@ def padded_urlsafe_b64decode(value):
     b64string = to_bytes(value)
     padded = b64string + b'=' * (-len(b64string) % 4)
     return base64.urlsafe_b64decode(padded)
+
+
+def unpadded_urlsafe_b64encode(value):
+    """Encodes base64 strings removing any padding characters.
+
+    `rfc 7515`_ defines Base64url to NOT include any padding
+    characters, but the stdlib doesn't do that by default.
+
+    _rfc7515: https://tools.ietf.org/html/rfc7515#page-6
+
+    Args:
+        value (Union[str|bytes]): The bytes-like value to encode
+
+    Returns:
+        Union[str|bytes]: The encoded value
+    """
+    return base64.urlsafe_b64encode(value).rstrip(b'=')

--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -40,7 +40,6 @@ You can also skip verification::
 
 """
 
-import base64
 import collections
 import copy
 import datetime

--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -86,13 +86,19 @@ def encode(signer, payload, header=None, key_id=None):
         header['kid'] = key_id
 
     segments = [
-        base64.urlsafe_b64encode(json.dumps(header).encode('utf-8')),
-        base64.urlsafe_b64encode(json.dumps(payload).encode('utf-8')),
+        _helpers.unpadded_urlsafe_b64encode(
+            json.dumps(header).encode('utf-8')
+        ),
+        _helpers.unpadded_urlsafe_b64encode(
+            json.dumps(payload).encode('utf-8')
+        ),
     ]
 
     signing_input = b'.'.join(segments)
     signature = signer.sign(signing_input)
-    segments.append(base64.urlsafe_b64encode(signature))
+    segments.append(
+        _helpers.unpadded_urlsafe_b64encode(signature)
+    )
 
     return b'.'.join(segments)
 

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -167,3 +167,15 @@ def test_padded_urlsafe_b64decode():
 
     for case, expected in cases:
         assert _helpers.padded_urlsafe_b64decode(case) == expected
+
+
+def test_unpadded_urlsafe_b64encode():
+    cases = [
+        (b'', b''),
+        (b'a', b'YQ'),
+        (b'aa', b'YWE'),
+        (b'aaa', b'YWFh'),
+    ]
+
+    for case, expected in cases:
+        assert _helpers.unpadded_urlsafe_b64encode(case) == expected


### PR DESCRIPTION
# Preface

So, I was writing something that used this library to sign JWTs in GCP to authenticate with Vault using the GCP engine. While I was able to generate tokens (parsing them locally) just fine, I was failing authentication with an error regarding illegal byte sequences during base-64 decoding.

Turns out the vault plugin, which is written in Go, uses a [`RawUrlEncoding`](https://golang.org/pkg/encoding/base64/#pkg-variables) to decode the incoming JWT. My tokens were failing to decode because each segment included the `=` padding. Oh.

# Why this PR

According to the [RFC 7515](https://tools.ietf.org/html/rfc7515#page-6):

> Base64 encoding [... has] _all trailing '=' characters omitted_ (as permitted by Section 3.2)
> and [is] without the inclusion of any line breaks, whitespace, or other additional
> characters. ... (See Appendix C for notes on
> implementing base64url encoding without padding.)

and unfortunately taking a look at the [python stdlib `urlsafe_b64encode`](https://docs.python.org/2/library/base64.html#base64.urlsafe_b64encode) function's docs:

> The result can still contain =.

Also, it's kinda funny that there's a function `padded_urlsafe_b64decode`, perhaps missing an `un-` in its name, to re-pad unpadded segments on the decoding side noting:

>     Google infrastructure tends to omit the base64 padding characters.

As I've learnt recently, it appears to follow the spec. Is there historical knowledge I might not know as to why this was implemented differently?

# What

This PR:
  - strips off trailing `=`'s from encoded chunks during creation
  - adds a test to confirm it encodes, strips and does no damage


