### PR TITLE
Stop falling back to `pkgutil`

### DIFF
--- a/google/__init__.py
+++ b/google/__init__.py
@@ -14,9 +14,7 @@
 
 """Google namespace package."""
 
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)
+import pkg_resources
+
+
+pkg_resources.declare_namespace(__name__)


### PR DESCRIPTION
Falling back to `pkgutil` is now [discouraged](https://packaging.python.org/guides/packaging-namespace-packages/):
> Note Some older recommendations advise the following in the namespace package `__init__.py`:
>```
> try:
>     __import__('pkg_resources').declare_namespace(__name__)
> except ImportError:
>     __path__ = __import__('pkgutil').extend_path(__path__, __name__)
>```
> The idea behind this was that in the rare case that `setuptools` isn’t available packages would fall-back to the `pkgutil`-style packages. This isn’t advisable because `pkgutil` and `pkg_resources`-style namespace packages are not cross-compatible. If the presence of `setuptools` is a concern then the package should just explicitly depend on `setuptools` via `install_requires`.