### PR TITLE
Support for `?scopes=` in metadata server

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -231,11 +231,11 @@ def default(scopes=None, request=None):
 
             gcloud config set project
 
-    3. If the application is running in the `App Engine standard Generation 1
-       environment`_ then the credentials and project ID from the `App Identity
-       Service`_ are used.
+    3. If the application is running in the `App Engine standard first
+       generation environment`_ then the credentials and project ID from the
+       `App Identity Service`_ are used.
     4. If the application is running in `Compute Engine`_, the `App Engine
-       Standard Generation 2 environment`_, or the `App Engine flexible
+       standard second generation environment`_, or the `App Engine flexible
        environment`_ then the credentials and project ID are obtained from the
        `Metadata Service`_.
     5. If no credentials are found,

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -231,12 +231,13 @@ def default(scopes=None, request=None):
 
             gcloud config set project
 
-    3. If the application is running in the `App Engine standard environment`_
-       then the credentials and project ID from the `App Identity Service`_
-       are used.
-    4. If the application is running in `Compute Engine`_ or the
-       `App Engine flexible environment`_ then the credentials and project ID
-       are obtained from the `Metadata Service`_.
+    3. If the application is running in the `App Engine standard Generation 1
+       environment`_ then the credentials and project ID from the `App Identity
+       Service`_ are used.
+    4. If the application is running in `Compute Engine`_, the `App Engine
+       Standard Generation 2 environment`_, or the `App Engine flexible
+       environment`_ then the credentials and project ID are obtained from the
+       `Metadata Service`_.
     5. If no credentials are found,
        :class:`~google.auth.exceptions.DefaultCredentialsError` will be raised.
 

--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -179,7 +179,7 @@ def get_service_account_info(request, service_account='default'):
         recursive=True)
 
 
-def get_service_account_token(request, service_account='default'):
+def get_service_account_token(request, service_account='default', scopes=['cloud-platform']):
     """Get the OAuth 2.0 access token for a service account.
 
     Args:
@@ -188,6 +188,8 @@ def get_service_account_token(request, service_account='default'):
         service_account (str): The string 'default' or a service account email
             address. The determines which service account for which to acquire
             an access token.
+        scopes (Sequence[str]): A list of OAuth scopes the token should contain.
+            Defaults to cloud-platform if not provided.
 
     Returns:
         Union[str, datetime]: The access token and its expiration.
@@ -198,7 +200,7 @@ def get_service_account_token(request, service_account='default'):
     """
     token_json = get(
         request,
-        'instance/service-accounts/{0}/token'.format(service_account))
+        'instance/service-accounts/{0}/token?scopes={1}'.format(service_account, ",".join(scopes)))
     token_expiry = _helpers.utcnow() + datetime.timedelta(
         seconds=token_json['expires_in'])
     return token_json['access_token'], token_expiry

--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -180,7 +180,7 @@ def get_service_account_info(request, service_account='default'):
 
 
 def get_service_account_token(request, service_account='default',
-                              scopes=['https://www.googleapis.com/auth/cloud-platform']):
+                              scopes=('https://www.googleapis.com/auth/cloud-platform')):
     """Get the OAuth 2.0 access token for a service account.
 
     Args:

--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -179,7 +179,8 @@ def get_service_account_info(request, service_account='default'):
         recursive=True)
 
 
-def get_service_account_token(request, service_account='default', scopes=['cloud-platform']):
+def get_service_account_token(request, service_account='default',
+                              scopes=['https://www.googleapis.com/auth/cloud-platform']):
     """Get the OAuth 2.0 access token for a service account.
 
     Args:


### PR DESCRIPTION
Adds support for requesting access tokens with arbitrary metadata scopes from the compute metadata server.

Note: even though this feature is implemented in the metadata server, this feature is only available in the implementations on GAE Second Generation and GCF, not on GCE or GKE (where this functionality is already available by setting instance scopes).