### PR TITLE
Flip setup.py dependency to python-cryptography.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup
 DEPENDENCIES = (
     'cachetools>=2.0.0',
     'pyasn1-modules>=0.2.1',
-    'rsa>=3.1.4',
+    'cryptography>=1.4.0',
     'setuptools>=40.3.0',
     'six>=1.9.0',
 )


### PR DESCRIPTION
That's the library the implementation prefers, so list that as the dependency.