### PR TITLE
Use cls parameter instead of class

### DIFF
--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -165,7 +165,7 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
                 'Authorized user info was not in the expected format, missing '
                 'fields {}.'.format(', '.join(missing)))
 
-        return Credentials(
+        return cls(
             None,  # No access token, must be refreshed.
             refresh_token=info['refresh_token'],
             token_uri=_GOOGLE_OAUTH2_TOKEN_ENDPOINT,


### PR DESCRIPTION
Use cls parameter instead of explicit `Credentials` reference to allow subclassing