### PR TITLE
ComputeEngine ID Tokens to use metadata server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Google Auth Python Library
 ==========================
 
-|build| |docs| |pypi|
+|build| |docs| |pypi| |compat_check_pypi| |compat_check_github|
 
 This library simplifies using Google's various server-to-server authentication
 mechanisms to access Google APIs.
@@ -12,6 +12,10 @@ mechanisms to access Google APIs.
    :target: https://google-auth.readthedocs.io/en/latest/
 .. |pypi| image:: https://img.shields.io/pypi/v/google-auth.svg
    :target: https://pypi.python.org/pypi/google-auth
+.. |compat_check_pypi| image:: https://python-compatibility-tools.appspot.com/one_badge_image?package=google-auth
+   :target: https://python-compatibility-tools.appspot.com/one_badge_target?package=google-auth
+.. |compat_check_github| image:: https://python-compatibility-tools.appspot.com/one_badge_image?package=git%2Bgit%3A//github.com/googleapis/google-auth-library-python.git
+   :target: https://python-compatibility-tools.appspot.com/one_badge_target?package=git%2Bgit%3A//github.com/googleapis/google-auth-library-python.git
 
 Installing
 ----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ also provides integration with several HTTP libraries.
 
 - Support for Google :func:`Application Default Credentials <google.auth.default>`.
 - Support for signing and verifying :mod:`JWTs <google.auth.jwt>`.
+- Support for creating `Google ID Tokens <user-guide.html#identity-tokens>`__.
 - Support for verifying and decoding :mod:`ID Tokens <google.oauth2.id_token>`.
 - Support for Google :mod:`Service Account credentials <google.oauth2.service_account>`.
 - Support for Google :mod:`Impersonated Credentials <google.auth.impersonated_credentials>`.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -56,7 +56,7 @@ Service account private key files
 A service account private key file can be used to obtain credentials for a
 service account. You can create a private key using the `Credentials page of the
 Google Cloud Console`_. Once you have a private key you can either obtain
-credentials one of two ways:
+credentials one of three ways:
 
 1. Set the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable to the full
    path to your service account private key file
@@ -77,6 +77,20 @@ credentials one of two ways:
 
         credentials = service_account.Credentials.from_service_account_file(
             '/path/to/key.json')
+
+        scoped_credentials = credentials.with_scopes(
+            ['https://www.googleapis.com/auth/cloud-platform'])
+
+3. Use :meth:`service_account.Credentials.from_service_account_info
+   <google.oauth2.service_account.Credentials.from_service_account_info>`::
+
+        import json
+
+        from google.oauth2 import service_account
+
+        json_acct_info = json.loads(function_to_get_json_creds())
+        credentials = service_account.Credentials.from_service_account_info(
+            json_acct_info)
 
         scoped_credentials = credentials.with_scopes(
             ['https://www.googleapis.com/auth/cloud-platform'])

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -248,7 +248,6 @@ In the example above `source_credentials` does not have direct access to list bu
 in the target project.  Using `ImpersonatedCredentials` will allow the source_credentials
 to assume the identity of a target_principal that does have access.
 
-<<<<<<< HEAD
 Identity Tokens
 +++++++++++++++
 
@@ -257,16 +256,6 @@ Identity Tokens
 and :mod:`Compute Engine <google.auth.compute_engine>`.  These tokens can be used to
 authenticate against `Cloud Functions`_, `Cloud Run`_, a user service behind
 `Identity Aware Proxy`_ or any other service capable of verifying a `Google ID Token`_.
-=======
-
-Identity Tokens
-+++++++++++++++
-
-`Google OpenID Connect`_ tokens are avaiable through both ServiceAccount and Compute modules.  
-These tokens can be used to authenticate against `Cloud Functions`_, `Cloud Run`_,
-against a service behind `Identity Aware Proxy`_ or any other service capable of verifying
-a `Google ID Token`_.
->>>>>>> 48f5233b8c91aca541188684f2764b5f03d43574
 
 ServiceAccount ::
 
@@ -290,7 +279,6 @@ Compute ::
     creds = compute_engine.IDTokenCredentials(request,
                             target_audience=target_audience)
 
-<<<<<<< HEAD
 Impersonated ::
 
     from google.auth import impersonated_credentials
@@ -332,10 +320,6 @@ A sample end-to-end flow using an ID Token against a Cloud Run endpoint maybe ::
     print(token)
     print(id_token.verify_token(token,request))
 
-=======
-IDToken verification can be done for various type of IDTokens using the :class:`google.oauth2.id_token` module 
-
->>>>>>> 48f5233b8c91aca541188684f2764b5f03d43574
 .. _Cloud Functions: https://cloud.google.com/functions/
 .. _Cloud Run: https://cloud.google.com/run/
 .. _Identity Aware Proxy: https://cloud.google.com/iap/

--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -232,12 +232,17 @@ def get_id_token(request, service_account='default', target_audience=None,
         google.auth.exceptions.TransportError: if an error occurred while
             retrieving metadata.
     """
+    PATH = 'instance/service-accounts/{0}'.format(service_account)
+    base_url = urlparse.urljoin(_METADATA_ROOT, PATH + '/identity')
+    query_params = {'format': token_format, 'licenses': include_license,
+                    'audience': target_audience}
+    url = _helpers.update_query(base_url, query_params)
+    parts = urlparse.urlparse(url)
 
     token_jwt = get(
         request,
-        ('instance/service-accounts/{0}/identity?audience={1}'
-         '&format={2}&licenses={3}').format(
-            service_account, target_audience, token_format, include_license))
+        ('instance/service-accounts/{0}/identity?{1}').format(
+            service_account, parts.query))
     payload = jwt.decode(token_jwt, verify=False)
     expiry = datetime.datetime.utcfromtimestamp(payload['exp'])
     return token_jwt, expiry

--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -209,3 +209,32 @@ def get_service_account_token(request, service_account='default'):
     token_expiry = _helpers.utcnow() + datetime.timedelta(
         seconds=token_json['expires_in'])
     return token_json['access_token'], token_expiry
+
+def get_id_token(request, service_account='default', target_audience=None,
+                 token_format='standard', include_license="FALSE"):
+    """Get the OAuth 2.0 access token for a service account.
+
+    Args:
+        request (google.auth.transport.Request): A callable used to make
+            HTTP requests.
+        service_account (str): The string 'default' or a service account email
+            address. This determines which Authorized party (`azp:`, `email:`)
+            that the token is issued to
+        target_audience (str): The audience for this id_token will be issued
+            (`aud:` field)
+
+    Returns:
+        Union[str, datetime]: The id token and its expiration.
+
+    Raises:
+        google.auth.exceptions.TransportError: if an error occurred while
+            retrieving metadata.
+    """
+
+    token_jwt = get(
+        request,
+        'instance/service-accounts/{0}/identity?audience={1}&format={2}&licenses={3}'.format(
+            service_account, target_audience, token_format, include_license))
+    payload = jwt.decode(token_jwt, verify=False)
+    expiry = datetime.datetime.utcfromtimestamp(payload['exp'])
+    return token_jwt, expiry

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -25,6 +25,7 @@ service account.
         https://cloud.google.com/iam/credentials/reference/rest/
 """
 
+import base64
 import copy
 from datetime import datetime
 import json
@@ -35,6 +36,8 @@ from six.moves import http_client
 from google.auth import _helpers
 from google.auth import credentials
 from google.auth import exceptions
+from google.auth import jwt
+from google.auth.transport.requests import AuthorizedSession
 
 _DEFAULT_TOKEN_LIFETIME_SECS = 3600  # 1 hour in seconds
 
@@ -43,7 +46,17 @@ _IAM_SCOPE = ['https://www.googleapis.com/auth/iam']
 _IAM_ENDPOINT = ('https://iamcredentials.googleapis.com/v1/projects/-' +
                  '/serviceAccounts/{}:generateAccessToken')
 
+_IAM_SIGN_ENDPOINT = ('https://iamcredentials.googleapis.com/v1/projects/-' +
+                      '/serviceAccounts/{}:signBlob')
+
+_IAM_IDTOKEN_ENDPOINT = ('https://iamcredentials.googleapis.com/v1/' +
+                         'projects/-/serviceAccounts/{}:generateIdToken')
+
 _REFRESH_ERROR = 'Unable to acquire impersonated credentials'
+
+_DEFAULT_TOKEN_LIFETIME_SECS = 3600  # 1 hour in seconds
+
+_DEFAULT_TOKEN_URI = 'https://oauth2.googleapis.com/token'
 
 
 def _make_iam_token_request(request, principal, headers, body):
@@ -94,7 +107,7 @@ def _make_iam_token_request(request, principal, headers, body):
         six.raise_from(new_exc, caught_exc)
 
 
-class Credentials(credentials.Credentials):
+class Credentials(credentials.Credentials,  credentials.Signing):
     """This module defines impersonated credentials which are essentially
     impersonated identities.
 
@@ -153,7 +166,7 @@ class Credentials(credentials.Credentials):
         client = storage.Client(credentials=target_credentials)
         buckets = client.list_buckets(project='your_project')
         for bucket in buckets:
-          print bucket.name
+          print(bucket.name)
     """
 
     def __init__(self, source_credentials,  target_principal,
@@ -172,7 +185,8 @@ class Credentials(credentials.Credentials):
                 granted to the prceeding identity.  For example, if set to
                 [serviceAccountB, serviceAccountC], the source_credential
                 must have the Token Creator role on serviceAccountB.
-                serviceAccountB must have the Token Creator on serviceAccountC.
+                serviceAccountB must have the Token Creator on
+                serviceAccountC.
                 Finally, C must have Token Creator on target_principal.
                 If left unset, source_credential must have that role on
                 target_principal.
@@ -229,3 +243,108 @@ class Credentials(credentials.Credentials):
             principal=self._target_principal,
             headers=headers,
             body=body)
+
+    def sign_bytes(self, message):
+
+        iam_sign_endpoint = _IAM_SIGN_ENDPOINT.format(self._target_principal)
+
+        body = {
+            "payload": base64.b64encode(message),
+            "delegates": self._delegates
+        }
+
+        headers = {
+            'Content-Type': 'application/json',
+        }
+
+        authed_session = AuthorizedSession(self._source_credentials)
+
+        response = authed_session.post(
+            url=iam_sign_endpoint,
+            headers=headers,
+            json=body)
+
+        return base64.b64decode(response.json()['signedBlob'])
+
+    @property
+    def signer_email(self):
+        return self._target_principal
+
+    @property
+    def service_account_email(self):
+        return self._target_principal
+
+    @property
+    def signer(self):
+        return self
+
+
+class IDTokenCredentials(credentials.Credentials):
+    """Open ID Connect ID Token-based service account credentials.
+
+    """
+    def __init__(self, target_credentials,
+                 target_audience=None, include_email=False):
+        """
+        Args:
+            target_credentials (google.auth.Credentials): The target
+                credential used as to acquire the id tokens for.
+            target_audience (string): Audience to issue the token for.
+            include_email (bool): Include email in IdToken
+        """
+        super(IDTokenCredentials, self).__init__()
+
+        if not isinstance(target_credentials,
+                          Credentials):
+            raise exceptions.GoogleAuthError("Provided Credential must be "
+                                             "impersonated_credentials")
+        self._target_credentials = target_credentials
+        self._target_audience = target_audience
+        self._include_email = include_email
+
+    def from_credentials(self, target_credentials,
+                         target_audience=None):
+        return self.__class__(
+            target_credentials=self._target_credentials,
+            target_audience=target_audience)
+
+    def with_target_audience(self, target_audience):
+        return self.__class__(
+            target_credentials=self._target_credentials,
+            target_audience=target_audience)
+
+    def with_include_email(self, include_email):
+        return self.__class__(
+            target_credentials=self._target_credentials,
+            target_audience=self._target_audience,
+            include_email=include_email)
+
+    @_helpers.copy_docstring(credentials.Credentials)
+    def refresh(self, request):
+
+        iam_sign_endpoint = _IAM_IDTOKEN_ENDPOINT.format(self.
+                                                         _target_credentials.
+                                                         signer_email)
+
+        body = {
+            "audience": self._target_audience,
+            "delegates": self._target_credentials._delegates,
+            "includeEmail": self._include_email
+        }
+
+        headers = {
+            'Content-Type': 'application/json',
+        }
+
+        authed_session = AuthorizedSession(self._target_credentials.
+                                           _source_credentials)
+
+        response = authed_session.post(
+            url=iam_sign_endpoint,
+            headers=headers,
+            data=json.dumps(body).encode('utf-8'))
+
+        id_token = response.json()['token']
+        self.token = id_token
+        self.expiry = datetime.fromtimestamp(jwt.decode(id_token,
+                                             verify=False)['exp'])

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -179,7 +179,7 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
                 'Authorized user info was not in the expected format, missing '
                 'fields {}.'.format(', '.join(missing)))
 
-        return Credentials(
+        return cls(
             None,  # No access token, must be refreshed.
             refresh_token=info['refresh_token'],
             token_uri=_GOOGLE_OAUTH2_TOKEN_ENDPOINT,

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "config:base",  ":preserveSemverRanges"
+  ]
+}

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup
 DEPENDENCIES = (
     'cachetools>=2.0.0,<3.0',
     'pyasn1-modules>=0.2.1',
-    'rsa>=3.1.4,<4.0',
+    'rsa>=3.1.4,<4.1',
     'setuptools>=40.3.0',
     'six>=1.9.0',
 )

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ from setuptools import setup
 
 
 DEPENDENCIES = (
-    'cachetools>=2.0.0',
+    'cachetools>=2.0.0,<3.0',
     'pyasn1-modules>=0.2.1',
-    'rsa>=3.1.4',
+    'rsa>=3.1.4,<4.0',
     'setuptools>=40.3.0',
     'six>=1.9.0',
 )

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 
 DEPENDENCIES = (
-    'cachetools>=2.0.0,<3.0',
+    'cachetools>=2.0.0,<3.2',
     'pyasn1-modules>=0.2.1',
     'rsa>=3.1.4,<4.1',
     'setuptools>=40.3.0',

--- a/tests/compute_engine/test__metadata.py
+++ b/tests/compute_engine/test__metadata.py
@@ -20,7 +20,7 @@ import mock
 import pytest
 from six.moves import http_client
 from six.moves import reload_module
-from six.moves import urllib
+from six.moves.urllib import parse as urlparse
 
 from google.auth import _helpers
 from google.auth import crypt
@@ -275,11 +275,14 @@ def test_get_id_token_default(token_factory):
       request, service_account=service_account,
       target_audience=target_audience)
 
+    base_url = urlparse.urljoin(_metadata._METADATA_ROOT, PATH + '/identity')
+    query_params = {'format': 'standard', 'licenses': 'FALSE',
+                    'audience': target_audience}
+    url = _helpers.update_query(base_url, query_params)
+
     request.assert_called_once_with(
         method='GET',
-        url=_metadata._METADATA_ROOT + PATH + '/identity?audience=' +
-        urllib.parse.quote_plus(target_audience) +
-        '&format=standard&licenses=FALSE',
+        url=url,
         headers=_metadata._METADATA_HEADERS)
 
     assert token == tok.decode("utf-8")
@@ -305,11 +308,14 @@ def test_get_id_token_full(token_factory):
       target_audience=target_audience, token_format="full",
       include_license="FALSE")
 
+    base_url = urlparse.urljoin(_metadata._METADATA_ROOT, PATH + '/identity')
+    query_params = {'format': 'full', 'licenses': 'FALSE',
+                    'audience': target_audience}
+    url = _helpers.update_query(base_url, query_params)
+
     request.assert_called_once_with(
         method='GET',
-        url=_metadata._METADATA_ROOT + PATH + '/identity?audience=' +
-        urllib.parse.quote_plus(target_audience) +
-        '&format=full&licenses=FALSE',
+        url=url,
         headers=_metadata._METADATA_HEADERS)
 
     assert token == tok.decode("utf-8")
@@ -335,11 +341,14 @@ def test_get_id_token_with_license(token_factory):
       target_audience=target_audience, token_format="full",
       include_license="TRUE")
 
+    base_url = urlparse.urljoin(_metadata._METADATA_ROOT, PATH + '/identity')
+    query_params = {'format': 'full', 'licenses': 'TRUE',
+                    'audience': target_audience}
+    url = _helpers.update_query(base_url, query_params)
+
     request.assert_called_once_with(
         method='GET',
-        url=_metadata._METADATA_ROOT + PATH + '/identity?audience=' +
-        urllib.parse.quote_plus(target_audience) +
-        '&format=full&licenses=TRUE',
+        url=url,
         headers=_metadata._METADATA_HEADERS)
 
     assert token == tok.decode("utf-8")

--- a/tests/compute_engine/test_credentials.py
+++ b/tests/compute_engine/test_credentials.py
@@ -137,37 +137,6 @@ class TestIDTokenCredentials(object):
         return_value=datetime.datetime.utcfromtimestamp(0))
     @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
     @mock.patch('google.auth.iam.Signer.sign', autospec=True)
-    def test_make_authorization_grant_assertion(self, sign, get, utcnow):
-        get.side_effect = [{
-            'email': 'service-account@example.com',
-            'scopes': ['one', 'two']
-        }]
-        sign.side_effect = [b'signature']
-
-        request = mock.create_autospec(transport.Request, instance=True)
-        self.credentials = credentials.IDTokenCredentials(
-            request=request, target_audience="https://audience.com")
-
-        # Generate authorization grant:
-        token = self.credentials._make_authorization_grant_assertion()
-        payload = jwt.decode(token, verify=False)
-
-        # The JWT token signature is 'signature' encoded in base 64:
-        assert token.endswith(b'.c2lnbmF0dXJl')
-
-        # Check that the credentials have the token and proper expiration
-        assert payload == {
-            'aud': 'https://www.googleapis.com/oauth2/v4/token',
-            'exp': 3600,
-            'iat': 0,
-            'iss': 'service-account@example.com',
-            'target_audience': 'https://audience.com'}
-
-    @mock.patch(
-        'google.auth._helpers.utcnow',
-        return_value=datetime.datetime.utcfromtimestamp(0))
-    @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
-    @mock.patch('google.auth.iam.Signer.sign', autospec=True)
     def test_with_service_account(self, sign, get, utcnow):
         sign.side_effect = [b'signature']
 

--- a/tests/test__default.py
+++ b/tests/test__default.py
@@ -92,7 +92,7 @@ def test__load_credentials_from_file_authorized_user_bad_format(tmpdir):
 
 
 def test__load_credentials_from_file_authorized_user_cloud_sdk():
-    with pytest.warns(UserWarning, matches='Cloud SDK'):
+    with pytest.warns(UserWarning, match='Cloud SDK'):
         credentials, project_id = _default._load_credentials_from_file(
             AUTHORIZED_USER_CLOUD_SDK_FILE)
     assert isinstance(credentials, google.oauth2.credentials.Credentials)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
   flask
   mock
   oauth2client
-  pytest<5.0
+  pytest
   pytest-cov
   pytest-localserver
   requests

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
   flask
   mock
   oauth2client
-  pytest
+  pytest<5.0
   pytest-cov
   pytest-localserver
   requests


### PR DESCRIPTION
Fixes:
  - https://github.com/googleapis/google-auth-library-python/issues/344

Refactors [google.auth.compute_engine](https://google-auth.readthedocs.io/en/latest/_modules/google/auth/compute_engine/credentials.html#IDTokenCredentials)  implementation to use the  metadata server (which is present in GCP's compute implementations (gce, gke*, cloud run, gcf, gae new runtimes)