### PR TITLE
Add support for imersonated_credentials.Sign, IDToken

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ also provides integration with several HTTP libraries.
 
 - Support for Google :func:`Application Default Credentials <google.auth.default>`.
 - Support for signing and verifying :mod:`JWTs <google.auth.jwt>`.
+- Support for creating `Google ID Tokens <user-guide.html#identity-tokens>`__.
 - Support for verifying and decoding :mod:`ID Tokens <google.oauth2.id_token>`.
 - Support for Google :mod:`Service Account credentials <google.oauth2.service_account>`.
 - Support for Google :mod:`Impersonated Credentials <google.auth.impersonated_credentials>`.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -234,6 +234,56 @@ In the example above `source_credentials` does not have direct access to list bu
 in the target project.  Using `ImpersonatedCredentials` will allow the source_credentials
 to assume the identity of a target_principal that does have access.
 
+Identity Tokens
++++++++++++++++
+
+`Google OpenID Connect`_ tokens are avaiable through both ServiceAccount, ImpersonatedCredentials,
+and Compute modules.  These tokens can be used to authenticate against `Cloud Functions`_,
+`Cloud Run`_, a user service behind `Identity Aware Proxy`_ or any other service capable
+of verifying a `Google ID Token`_.
+
+ServiceAccount ::
+
+    from google.oauth2 import service_account
+
+    target_audience = 'https://example.com'
+
+    creds = service_account.IDTokenCredentials.from_service_account_file(
+            '/path/to/svc.json',
+            target_audience=target_audience)
+
+
+Compute ::
+
+    from google.auth import compute_engine
+    import google.auth.transport.requests
+
+    target_audience = 'https://example.com'
+
+    request = google.auth.transport.requests.Request()
+    creds = compute_engine.IDTokenCredentials(request,
+                            target_audience=target_audience)
+
+Impersonated ::
+
+    from google.auth import impersonated_credentials
+
+    # get target_credentials from a source_credentials
+
+    target_audience = 'https://example.com'
+
+    creds = impersonated_credentials.IDTokenCredentials(
+                                      target_credentials,
+                                      target_audience=target_audience)
+
+IDToken verification can be done for various type of IDTokens using the :class:`google.oauth2.id_token` module 
+
+.. _Cloud Functions: https://cloud.google.com/functions/
+.. _Cloud Run: https://cloud.google.com/run/
+.. _Identity Aware Proxy: https://cloud.google.com/iap/
+.. _Google OpenID Connect: https://developers.google.com/identity/protocols/OpenIDConnect
+.. _Google ID Token: https://developers.google.com/identity/protocols/OpenIDConnect#validatinganidtoken
+
 Making authenticated requests
 -----------------------------
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -227,7 +227,7 @@ the "Service Account Token Creator" IAM role. ::
     client = storage.Client(credentials=target_credentials)
     buckets = client.list_buckets(project='your_project')
     for bucket in buckets:
-        print bucket.name
+        print(bucket.name)
 
 
 In the example above `source_credentials` does not have direct access to list buckets
@@ -297,14 +297,14 @@ A sample end-to-end flow using an ID Token against a Cloud Run endpoint maybe ::
 
     # make authenticated request and print the response, status_code
     resp = authed_session.get(url)
-    print resp.status_code
-    print resp.text
+    print(resp.status_code)
+    print(resp.text)
 
     # to verify an ID Token
     request = google.auth.transport.requests.Request()
     token = creds.token
-    print token
-    print id_token.verify_token(token,request)
+    print(token)
+    print(id_token.verify_token(token,request))
 
 .. _Cloud Functions: https://cloud.google.com/functions/
 .. _Cloud Run: https://cloud.google.com/run/

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -237,10 +237,11 @@ to assume the identity of a target_principal that does have access.
 Identity Tokens
 +++++++++++++++
 
-`Google OpenID Connect`_ tokens are avaiable through both ServiceAccount, ImpersonatedCredentials,
-and Compute modules.  These tokens can be used to authenticate against `Cloud Functions`_,
-`Cloud Run`_, a user service behind `Identity Aware Proxy`_ or any other service capable
-of verifying a `Google ID Token`_.
+`Google OpenID Connect`_ tokens are avaiable through :mod:`Service Account <google.oauth2.service_account>`,
+:mod:`Impersonated <google.auth.impersonated_credentials>`,
+and :mod:`Compute Engine <google.auth.compute_engine>`.  These tokens can be used to
+authenticate against `Cloud Functions`_, `Cloud Run`_, a user service behind
+`Identity Aware Proxy`_ or any other service capable of verifying a `Google ID Token`_.
 
 ServiceAccount ::
 
@@ -268,7 +269,7 @@ Impersonated ::
 
     from google.auth import impersonated_credentials
 
-    # get target_credentials from a source_credentials
+    # get target_credentials from a source_credential
 
     target_audience = 'https://example.com'
 
@@ -277,6 +278,33 @@ Impersonated ::
                                       target_audience=target_audience)
 
 IDToken verification can be done for various type of IDTokens using the :class:`google.oauth2.id_token` module 
+
+A sample end-to-end flow using an ID Token against a Cloud Run endpoint maybe ::
+
+    from google.oauth2 import id_token
+    from google.oauth2 import service_account
+    import google.auth
+    import google.auth.transport.requests
+    from google.auth.transport.requests import AuthorizedSession
+
+    target_audience = 'https://your-cloud-run-app.a.run.app'
+    url = 'https://your-cloud-run-app.a.run.app'
+
+    creds = service_account.IDTokenCredentials.from_service_account_file(
+            '/path/to/svc.json', target_audience=target_audience)
+
+    authed_session = AuthorizedSession(creds)
+
+    # make authenticated request and print the response, status_code
+    resp = authed_session.get(url)
+    print resp.status_code
+    print resp.text
+
+    # to verify an ID Token
+    request = google.auth.transport.requests.Request()
+    token = creds.token
+    print token
+    print id_token.verify_token(token,request)
 
 .. _Cloud Functions: https://cloud.google.com/functions/
 .. _Cloud Run: https://cloud.google.com/run/

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -166,7 +166,7 @@ class Credentials(credentials.Credentials,  credentials.Signing):
         client = storage.Client(credentials=target_credentials)
         buckets = client.list_buckets(project='your_project')
         for bucket in buckets:
-          print bucket.name
+          print(bucket.name)
     """
 
     def __init__(self, source_credentials,  target_principal,

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -258,7 +258,7 @@ class Credentials(credentials.Credentials,  credentials.Signing):
         response = authed_session.post(
             url=iam_sign_endpoint,
             headers=headers,
-            data=json.dumps(body))
+            data=json.dumps(body).encode('utf-8'))
 
         return base64.b64decode(response.json()['signedBlob'])
 
@@ -289,8 +289,7 @@ class IDTokenCredentials(credentials.Credentials):
         Args:
             targete_credentials (google.auth.Credentials): The target
                 credential used as to acquire the id tokens for.
-            target_audience (string):
-            additional_claims (Sequece[str]):
+            target_audience (string): Audience to issue the token for.
         """
         super(IDTokenCredentials, self).__init__()
 
@@ -334,7 +333,7 @@ class IDTokenCredentials(credentials.Credentials):
         response = authed_session.post(
             url=iam_sign_endpoint,
             headers=headers,
-            data=json.dumps(body))
+            data=json.dumps(body).encode('utf-8'))
 
         id_token = response.json()['token']
         self.token = id_token

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -185,7 +185,7 @@ class Credentials(credentials.Credentials,  credentials.Signing):
                 granted to the prceeding identity.  For example, if set to
                 [serviceAccountB, serviceAccountC], the source_credential
                 must have the Token Creator role on serviceAccountB.
-                credentials.refresh(request) must have the Token Creator on
+                serviceAccountB must have the Token Creator on
                 serviceAccountC.
                 Finally, C must have Token Creator on target_principal.
                 If left unset, source_credential must have that role on

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -262,7 +262,7 @@ class Credentials(credentials.Credentials,  credentials.Signing):
         response = authed_session.post(
             url=iam_sign_endpoint,
             headers=headers,
-            data=json.dumps(body).encode('utf-8'))
+            json=body)
 
         return base64.b64decode(response.json()['signedBlob'])
 

--- a/tests/test_impersonated_credentials.py
+++ b/tests/test_impersonated_credentials.py
@@ -62,9 +62,8 @@ class TestImpersonatedCredentials(object):
     SOURCE_CREDENTIALS = service_account.Credentials(
             SIGNER, SERVICE_ACCOUNT_EMAIL, TOKEN_URI)
 
-    def make_credentials(self, lifetime=LIFETIME, target_principal=None):
-        if target_principal is None:
-            target_principal = self.TARGET_PRINCIPAL
+    def make_credentials(self, lifetime=LIFETIME,
+                         target_principal=TARGET_PRINCIPAL):
 
         return Credentials(
             source_credentials=self.SOURCE_CREDENTIALS,


### PR DESCRIPTION
Adds support for `impersonated_credentials` to sign and issue IDTokens. 

impersonated_credentials uses IAMCredentials api at its core which also provides interfaces to `generateIDToken()` and `signBlob()`:
 - https://cloud.google.com/iam/credentials/reference/rest/v1/projects.serviceAccounts

This PR seesk to add support for those.

Some benefits:  
* makes it easy to get GoogleOIDC tokens
* `Singer` interface allows users to 'generate SignedURLs' too. ref: Issue: https://github.com/googleapis/google-auth-library-python/issues/338

---

The PR at the moment does not have sufficient test coverage (its a solid "C" at 75%).  I'm unsure how to mock the internal request/responses since i used `AuthorizedSession()` internally within `imersonated_credentials.py`.  Any tips or pointers there would let me add on coverage.  I've left the anticipated responses i would like as comments in this current commit

---

Anyway, usage would be like this to sign and genrate ID tokens (i've verified the following works)

```python
from google.oauth2 import id_token
from google.oauth2 import service_account
from google.auth import impersonated_credentials
import json
import google.auth
from google.auth import jwt
import google.auth.transport.requests
import base64
import os
from datetime import datetime, timedelta
from google.cloud import storage

from google.auth.transport.requests import AuthorizedSession


source_credentials = service_account.Credentials.from_service_account_file(
    '/path/to/svc.json')
target_scopes = ['https://www.googleapis.com/auth/cloud-platform']

target_credentials = impersonated_credentials.Credentials(
    source_credentials = source_credentials,
    target_principal='impersonated-account@fabled-ray-104117.iam.gserviceaccount.com',
    target_scopes = target_scopes,
    delegates=[],
    lifetime=300)

# =====================   Sign

# signer anything you want as the impersonated credentials
b = target_credentials.sign_bytes('badff')
print base64.b64encode(b)


storage_client = storage.Client('fabled-ray-104117', target_credentials)
data_bucket = storage_client.lookup_bucket('fabled-ray-104117')
signed_blob_path = data_bucket.blob("FILENAME")
expires_at_ms = 30 * 60 *60
print expires_at_ms
signed_url = signed_blob_path.generate_signed_url(expires_at_ms, credentials=target_credentials, version="v4")

print signed_url

# =====================   IDToken

target_audience = 'https://your.cloud.run.app'

id_creds = impersonated_credentials.IDTokenCredentials(
    target_credentials, target_audience=target_audience)

url = 'https://your.cloud.run.app'
authed_session = AuthorizedSession(id_creds)
r = authed_session.get(url)

```