### PR TITLE
setup.py: set an upper bound on dependencies version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ from setuptools import setup
 
 
 DEPENDENCIES = (
-    'cachetools>=2.0.0',
+    'cachetools>=2.0.0,<3.0',
     'pyasn1-modules>=0.2.1',
-    'rsa>=3.1.4',
+    'rsa>=3.1.4,<4.0',
     'setuptools>=40.3.0',
     'six>=1.9.0',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
   flask
   mock
   oauth2client
-  pytest
+  pytest<5.0
   pytest-cov
   pytest-localserver
   requests


### PR DESCRIPTION
This should make this library more robust in case of breaking changes in one of
its dependencies.