### PR TITLE
Use new pytest api to keep building with pytest 5

### DIFF
--- a/tests/test__default.py
+++ b/tests/test__default.py
@@ -92,7 +92,7 @@ def test__load_credentials_from_file_authorized_user_bad_format(tmpdir):
 
 
 def test__load_credentials_from_file_authorized_user_cloud_sdk():
-    with pytest.warns(UserWarning, matches='Cloud SDK'):
+    with pytest.warns(UserWarning, match='Cloud SDK'):
         credentials, project_id = _default._load_credentials_from_file(
             AUTHORIZED_USER_CLOUD_SDK_FILE)
     assert isinstance(credentials, google.oauth2.credentials.Credentials)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
   flask
   mock
   oauth2client
-  pytest<5.0
+  pytest
   pytest-cov
   pytest-localserver
   requests


### PR DESCRIPTION
Matches was changed to match with at least pytest4 and from pytest 5.0+ it does not work.