### PR TITLE
Refactor IDToken source for compute_engine

### DIFF
--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -213,7 +213,7 @@ def get_service_account_token(request, service_account='default'):
 
 
 def get_id_token(request, service_account='default', target_audience=None,
-                 token_format='standard', include_license="FALSE"):
+                 token_format='standard', include_license=False):
     """Get the OAuth 2.0 access token for a service account.
 
     Args:
@@ -224,6 +224,9 @@ def get_id_token(request, service_account='default', target_audience=None,
             that the token is issued to
         target_audience (str): The audience for this id_token will be issued
             (`aud:` field)
+        token_format (str): ID token format.  Either 'full' or 'standard'
+            (default)
+        include_license (bool):  Include any license information in the token.
 
     Returns:
         Union[str, datetime]: The id token and its expiration.

--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -122,9 +122,9 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
     These credentials relies on the default service account and metadata
     server of a GCE instance.
 
-    The ID Token provided by this credential is provideb by the Compute
-    metadata server service account.  For more information about the ID,
-    see `Obtaining the instance identity token`_.
+    The ID Token provided by this credential is by the Compute
+    metadata server service account.  For more information about this token
+    type, see `Obtaining the instance identity token`_.
 
     In order to use the signer or sign_bytes capability directly, the GCE
     instance must have been started with a service account that has access
@@ -198,9 +198,11 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
     def with_target_audience(self, audience):
         """Create a copy of these credentials with the specified target
         audience.
+
         Args:
             audience (str): The intended audience for these credentials,
-            used when requesting the ID Token.
+                used when requesting the ID Token.
+
         Returns:
             google.auth.service_account.IDTokenCredentials: A new credentials
                 instance.
@@ -244,9 +246,11 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
     def with_token_format(self, token_format):
         """Create a copy of these credentials but also add on the specified
         format to the id_token
+
         Args:
             token_format (str): Format for the id_token:  valid values
-            (standard or full)
+                (standard or full)
+
         Returns:
             google.auth.service_account.IDTokenCredentials: A new credentials
                 instance.
@@ -263,8 +267,10 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
     def with_license(self, include_license=False):
         """Create a copy of these credentials but also add on license
         informaton to the id_token
+
         Args:
             include_license (bool): Add license information to the id_token
+
         Returns:
             google.auth.service_account.IDTokenCredentials: A new credentials
                 instance.

--- a/tests/compute_engine/test__metadata.py
+++ b/tests/compute_engine/test__metadata.py
@@ -276,7 +276,7 @@ def test_get_id_token_default(token_factory):
       target_audience=target_audience)
 
     base_url = urlparse.urljoin(_metadata._METADATA_ROOT, PATH + '/identity')
-    query_params = {'format': 'standard', 'licenses': 'FALSE',
+    query_params = {'format': 'standard', 'licenses': False,
                     'audience': target_audience}
     url = _helpers.update_query(base_url, query_params)
 
@@ -306,10 +306,10 @@ def test_get_id_token_full(token_factory):
     token, expiry = _metadata.get_id_token(
       request, service_account=service_account,
       target_audience=target_audience, token_format="full",
-      include_license="FALSE")
+      include_license=False)
 
     base_url = urlparse.urljoin(_metadata._METADATA_ROOT, PATH + '/identity')
-    query_params = {'format': 'full', 'licenses': 'FALSE',
+    query_params = {'format': 'full', 'licenses': False,
                     'audience': target_audience}
     url = _helpers.update_query(base_url, query_params)
 
@@ -339,10 +339,10 @@ def test_get_id_token_with_license(token_factory):
     token, expiry = _metadata.get_id_token(
       request, service_account=service_account,
       target_audience=target_audience, token_format="full",
-      include_license="TRUE")
+      include_license=True)
 
     base_url = urlparse.urljoin(_metadata._METADATA_ROOT, PATH + '/identity')
-    query_params = {'format': 'full', 'licenses': 'TRUE',
+    query_params = {'format': 'full', 'licenses': True,
                     'audience': target_audience}
     url = _helpers.update_query(base_url, query_params)
 

--- a/tests/compute_engine/test__metadata.py
+++ b/tests/compute_engine/test__metadata.py
@@ -20,14 +20,73 @@ import mock
 import pytest
 from six.moves import http_client
 from six.moves import reload_module
+from six.moves.urllib import parse as urlparse
 
 from google.auth import _helpers
+from google.auth import crypt
 from google.auth import environment_vars
 from google.auth import exceptions
+from google.auth import jwt
 from google.auth import transport
 from google.auth.compute_engine import _metadata
 
 PATH = 'instance/service-accounts/default'
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+
+with open(os.path.join(DATA_DIR, 'privatekey.pem'), 'rb') as fh:
+    PRIVATE_KEY_BYTES = fh.read()
+
+with open(os.path.join(DATA_DIR, 'public_cert.pem'), 'rb') as fh:
+    PUBLIC_CERT_BYTES = fh.read()
+
+with open(os.path.join(DATA_DIR, 'other_cert.pem'), 'rb') as fh:
+    OTHER_CERT_BYTES = fh.read()
+
+SERVICE_ACCOUNT_JSON_FILE = os.path.join(DATA_DIR, 'service_account.json')
+
+with open(SERVICE_ACCOUNT_JSON_FILE, 'r') as fh:
+    SERVICE_ACCOUNT_INFO = json.load(fh)
+
+
+@pytest.fixture
+def signer():
+    return crypt.RSASigner.from_string(PRIVATE_KEY_BYTES, '1')
+
+
+@pytest.fixture
+def token_factory(signer):
+    def factory(claims=None, use_full_format=False, include_license=False):
+        now = _helpers.datetime_to_secs(_helpers.utcnow())
+        payload = {
+            'aud': 'https://example.com',
+            'iat': now,
+            'exp': now + 300
+        }
+        payload.update(claims or {})
+        extended_format = {}
+        if use_full_format:
+            extended_format = {
+                "google": {
+                    "compute_engine": {
+                        "project_id": "foo"
+                    }
+                }
+            }
+        if include_license:
+            extended_format = {
+                "google": {
+                    "compute_engine": {
+                        "project_id": "foo",
+                        "license_id": [
+                            "bar"
+                            ]
+                    }
+                }
+            }
+        payload.update(extended_format)
+        return jwt.encode(signer, payload)
+    return factory
 
 
 def make_request(data, status=http_client.OK, headers=None):
@@ -196,6 +255,104 @@ def test_get_service_account_token(utcnow):
         headers=_metadata._METADATA_HEADERS)
     assert token == 'token'
     assert expiry == utcnow() + datetime.timedelta(seconds=ttl)
+
+
+def test_get_id_token_default(token_factory):
+    service_account = 'default'
+    target_audience = 'https://example.com'
+
+    expire_at = _helpers.datetime_to_secs(
+        _helpers.utcnow() + datetime.timedelta(hours=1))
+    claims = {'exp': expire_at, 'aud': target_audience}
+
+    tok = token_factory(claims=claims)
+
+    request = make_request(
+        tok,
+        headers={'content-type': 'text/html'})
+
+    token, expiry = _metadata.get_id_token(
+      request, service_account=service_account,
+      target_audience=target_audience)
+
+    base_url = urlparse.urljoin(_metadata._METADATA_ROOT, PATH + '/identity')
+    query_params = {'format': 'standard', 'licenses': 'FALSE',
+                    'audience': target_audience}
+    url = _helpers.update_query(base_url, query_params)
+
+    request.assert_called_once_with(
+        method='GET',
+        url=url,
+        headers=_metadata._METADATA_HEADERS)
+
+    assert token == tok.decode("utf-8")
+    assert expiry == datetime.datetime.utcfromtimestamp(expire_at)
+
+
+def test_get_id_token_full(token_factory):
+    service_account = 'default'
+    target_audience = 'https://example.com'
+
+    expire_at = _helpers.datetime_to_secs(
+        _helpers.utcnow() + datetime.timedelta(hours=1))
+    claims = {'exp': expire_at, 'aud': target_audience}
+
+    tok = token_factory(claims=claims, use_full_format=True)
+
+    request = make_request(
+        tok,
+        headers={'content-type': 'text/html'})
+
+    token, expiry = _metadata.get_id_token(
+      request, service_account=service_account,
+      target_audience=target_audience, token_format="full",
+      include_license="FALSE")
+
+    base_url = urlparse.urljoin(_metadata._METADATA_ROOT, PATH + '/identity')
+    query_params = {'format': 'full', 'licenses': 'FALSE',
+                    'audience': target_audience}
+    url = _helpers.update_query(base_url, query_params)
+
+    request.assert_called_once_with(
+        method='GET',
+        url=url,
+        headers=_metadata._METADATA_HEADERS)
+
+    assert token == tok.decode("utf-8")
+    assert expiry == datetime.datetime.utcfromtimestamp(expire_at)
+
+
+def test_get_id_token_with_license(token_factory):
+    service_account = 'default'
+    target_audience = 'https://example.com'
+
+    expire_at = _helpers.datetime_to_secs(
+        _helpers.utcnow() + datetime.timedelta(hours=1))
+    claims = {'exp': expire_at, 'aud': target_audience}
+
+    tok = token_factory(claims=claims, include_license=True)
+
+    request = make_request(
+        tok,
+        headers={'content-type': 'text/html'})
+
+    token, expiry = _metadata.get_id_token(
+      request, service_account=service_account,
+      target_audience=target_audience, token_format="full",
+      include_license="TRUE")
+
+    base_url = urlparse.urljoin(_metadata._METADATA_ROOT, PATH + '/identity')
+    query_params = {'format': 'full', 'licenses': 'TRUE',
+                    'audience': target_audience}
+    url = _helpers.update_query(base_url, query_params)
+
+    request.assert_called_once_with(
+        method='GET',
+        url=url,
+        headers=_metadata._METADATA_HEADERS)
+
+    assert token == tok.decode("utf-8")
+    assert expiry == datetime.datetime.utcfromtimestamp(expire_at)
 
 
 def test_get_service_account_info():

--- a/tests/compute_engine/test_credentials.py
+++ b/tests/compute_engine/test_credentials.py
@@ -13,15 +13,73 @@
 # limitations under the License.
 
 import datetime
+import json
+import os
 
 import mock
 import pytest
 
 from google.auth import _helpers
+from google.auth import crypt
 from google.auth import exceptions
 from google.auth import jwt
 from google.auth import transport
 from google.auth.compute_engine import credentials
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+
+with open(os.path.join(DATA_DIR, 'privatekey.pem'), 'rb') as fh:
+    PRIVATE_KEY_BYTES = fh.read()
+
+with open(os.path.join(DATA_DIR, 'public_cert.pem'), 'rb') as fh:
+    PUBLIC_CERT_BYTES = fh.read()
+
+with open(os.path.join(DATA_DIR, 'other_cert.pem'), 'rb') as fh:
+    OTHER_CERT_BYTES = fh.read()
+
+SERVICE_ACCOUNT_JSON_FILE = os.path.join(DATA_DIR, 'service_account.json')
+
+with open(SERVICE_ACCOUNT_JSON_FILE, 'r') as fh:
+    SERVICE_ACCOUNT_INFO = json.load(fh)
+
+
+@pytest.fixture
+def signer():
+    return crypt.RSASigner.from_string(PRIVATE_KEY_BYTES, '1')
+
+
+@pytest.fixture
+def token_factory(signer):
+    def factory(claims=None, use_full_format=False, include_license=False):
+        now = _helpers.datetime_to_secs(_helpers.utcnow())
+        payload = {
+            'aud': 'https://example.com',
+            'iat': now,
+            'exp': now + 300
+        }
+        payload.update(claims or {})
+        if use_full_format:
+            extended_format = {
+                "google": {
+                    "compute_engine": {
+                        "project_id": "foo"
+                    }
+                }
+            }
+            if include_license:
+                extended_format = {
+                    "google": {
+                        "compute_engine": {
+                           "project_id": "foo",
+                           "license_id": [
+                               "bar"
+                            ]
+                        }
+                    }
+                }
+            payload.update(extended_format)
+        return jwt.encode(signer, payload)
+    return factory
 
 
 class TestCredentials(object):
@@ -110,6 +168,7 @@ class TestCredentials(object):
 
 class TestIDTokenCredentials(object):
     credentials = None
+    test_audience = 'https://example.com'
 
     @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
     def test_default_state(self, get):
@@ -132,217 +191,95 @@ class TestIDTokenCredentials(object):
         assert self.credentials.signer
         assert self.credentials.signer_email == 'service-account@example.com'
 
-    @mock.patch(
-        'google.auth._helpers.utcnow',
-        return_value=datetime.datetime.utcfromtimestamp(0))
     @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
-    @mock.patch('google.auth.iam.Signer.sign', autospec=True)
-    def test_make_authorization_grant_assertion(self, sign, get, utcnow):
+    def test_with_target_audience(self, get, token_factory):
+        expire_at = _helpers.datetime_to_secs(
+            _helpers.utcnow() + datetime.timedelta(hours=1))
+        claims = {'exp': expire_at, 'aud': self.test_audience}
+
+        tok = token_factory(claims=claims)
+
         get.side_effect = [{
             'email': 'service-account@example.com',
             'scopes': ['one', 'two']
-        }]
-        sign.side_effect = [b'signature']
+        }, tok]
 
         request = mock.create_autospec(transport.Request, instance=True)
         self.credentials = credentials.IDTokenCredentials(
-            request=request, target_audience="https://audience.com")
-
-        # Generate authorization grant:
-        token = self.credentials._make_authorization_grant_assertion()
-        payload = jwt.decode(token, verify=False)
-
-        # The JWT token signature is 'signature' encoded in base 64:
-        assert token.endswith(b'.c2lnbmF0dXJl')
-
-        # Check that the credentials have the token and proper expiration
-        assert payload == {
-            'aud': 'https://www.googleapis.com/oauth2/v4/token',
-            'exp': 3600,
-            'iat': 0,
-            'iss': 'service-account@example.com',
-            'target_audience': 'https://audience.com'}
-
-    @mock.patch(
-        'google.auth._helpers.utcnow',
-        return_value=datetime.datetime.utcfromtimestamp(0))
-    @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
-    @mock.patch('google.auth.iam.Signer.sign', autospec=True)
-    def test_with_service_account(self, sign, get, utcnow):
-        sign.side_effect = [b'signature']
-
-        request = mock.create_autospec(transport.Request, instance=True)
-        self.credentials = credentials.IDTokenCredentials(
-            request=request, target_audience="https://audience.com",
-            service_account_email="service-account@other.com")
-
-        # Generate authorization grant:
-        token = self.credentials._make_authorization_grant_assertion()
-        payload = jwt.decode(token, verify=False)
-
-        # The JWT token signature is 'signature' encoded in base 64:
-        assert token.endswith(b'.c2lnbmF0dXJl')
-
-        # Check that the credentials have the token and proper expiration
-        assert payload == {
-            'aud': 'https://www.googleapis.com/oauth2/v4/token',
-            'exp': 3600,
-            'iat': 0,
-            'iss': 'service-account@other.com',
-            'target_audience': 'https://audience.com'}
-
-    @mock.patch(
-        'google.auth._helpers.utcnow',
-        return_value=datetime.datetime.utcfromtimestamp(0))
-    @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
-    @mock.patch('google.auth.iam.Signer.sign', autospec=True)
-    def test_additional_claims(self, sign, get, utcnow):
-        get.side_effect = [{
-            'email': 'service-account@example.com',
-            'scopes': ['one', 'two']
-        }]
-        sign.side_effect = [b'signature']
-
-        request = mock.create_autospec(transport.Request, instance=True)
-        self.credentials = credentials.IDTokenCredentials(
-            request=request, target_audience="https://audience.com",
-            additional_claims={'foo': 'bar'})
-
-        # Generate authorization grant:
-        token = self.credentials._make_authorization_grant_assertion()
-        payload = jwt.decode(token, verify=False)
-
-        # The JWT token signature is 'signature' encoded in base 64:
-        assert token.endswith(b'.c2lnbmF0dXJl')
-
-        # Check that the credentials have the token and proper expiration
-        assert payload == {
-            'aud': 'https://www.googleapis.com/oauth2/v4/token',
-            'exp': 3600,
-            'iat': 0,
-            'iss': 'service-account@example.com',
-            'target_audience': 'https://audience.com',
-            'foo': 'bar'}
-
-    @mock.patch(
-        'google.auth._helpers.utcnow',
-        return_value=datetime.datetime.utcfromtimestamp(0))
-    @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
-    @mock.patch('google.auth.iam.Signer.sign', autospec=True)
-    def test_with_target_audience(self, sign, get, utcnow):
-        get.side_effect = [{
-            'email': 'service-account@example.com',
-            'scopes': ['one', 'two']
-        }]
-        sign.side_effect = [b'signature']
-
-        request = mock.create_autospec(transport.Request, instance=True)
-        self.credentials = credentials.IDTokenCredentials(
-            request=request, target_audience="https://audience.com")
+            request=request, target_audience=None)
         self.credentials = (
-            self.credentials.with_target_audience("https://actually.not"))
+            self.credentials.with_target_audience(self.test_audience))
 
-        # Generate authorization grant:
-        token = self.credentials._make_authorization_grant_assertion()
+        self.credentials.refresh(None)
+        token = self.credentials.token
         payload = jwt.decode(token, verify=False)
 
-        # The JWT token signature is 'signature' encoded in base 64:
-        assert token.endswith(b'.c2lnbmF0dXJl')
-
-        # Check that the credentials have the token and proper expiration
-        assert payload == {
-            'aud': 'https://www.googleapis.com/oauth2/v4/token',
-            'exp': 3600,
-            'iat': 0,
-            'iss': 'service-account@example.com',
-            'target_audience': 'https://actually.not'}
-
-    @mock.patch(
-        'google.auth._helpers.utcnow',
-        return_value=datetime.datetime.utcfromtimestamp(0))
-    @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
-    @mock.patch('google.auth.iam.Signer.sign', autospec=True)
-    @mock.patch('google.oauth2._client.id_token_jwt_grant', autospec=True)
-    def test_refresh_success(self, id_token_jwt_grant, sign, get, utcnow):
-        get.side_effect = [{
-            'email': 'service-account@example.com',
-            'scopes': ['one', 'two']
-        }]
-        sign.side_effect = [b'signature']
-        id_token_jwt_grant.side_effect = [(
-            'idtoken',
-            datetime.datetime.utcfromtimestamp(3600),
-            {},
-        )]
-
-        request = mock.create_autospec(transport.Request, instance=True)
-        self.credentials = credentials.IDTokenCredentials(
-            request=request, target_audience="https://audience.com")
-
-        # Refresh credentials
-        self.credentials.refresh(None)
-
-        # Check that the credentials have the token and proper expiration
-        assert self.credentials.token == 'idtoken'
+        assert self.credentials.token == tok
         assert self.credentials.expiry == (
-            datetime.datetime.utcfromtimestamp(3600))
-
-        # Check the credential info
-        assert (self.credentials.service_account_email ==
-                'service-account@example.com')
-
-        # Check that the credentials are valid (have a token and are not
-        # expired)
+            datetime.datetime.utcfromtimestamp(expire_at))
+        assert payload['aud'] == self.test_audience
         assert self.credentials.valid
 
-    @mock.patch(
-        'google.auth._helpers.utcnow',
-        return_value=datetime.datetime.utcfromtimestamp(0))
     @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
-    @mock.patch('google.auth.iam.Signer.sign', autospec=True)
-    def test_refresh_error(self, sign, get, utcnow):
+    def test_refresh_success(self, get, token_factory):
+        expire_at = _helpers.datetime_to_secs(
+            _helpers.utcnow() + datetime.timedelta(hours=1))
+        claims = {'exp': expire_at, 'aud': self.test_audience}
+
+        tok = token_factory(claims=claims)
+
         get.side_effect = [{
             'email': 'service-account@example.com',
-            'scopes': ['one', 'two'],
-        }]
-        sign.side_effect = [b'signature']
-
-        request = mock.create_autospec(transport.Request, instance=True)
-        response = mock.Mock()
-        response.data = b'{"error": "http error"}'
-        response.status = 500
-        request.side_effect = [response]
-
-        self.credentials = credentials.IDTokenCredentials(
-            request=request, target_audience="https://audience.com")
-
-        with pytest.raises(exceptions.RefreshError) as excinfo:
-            self.credentials.refresh(request)
-
-        assert excinfo.match(r'http error')
-
-    @mock.patch(
-        'google.auth._helpers.utcnow',
-        return_value=datetime.datetime.utcfromtimestamp(0))
-    @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
-    @mock.patch('google.auth.iam.Signer.sign', autospec=True)
-    @mock.patch('google.oauth2._client.id_token_jwt_grant', autospec=True)
-    def test_before_request_refreshes(
-            self, id_token_jwt_grant, sign, get, utcnow):
-        get.side_effect = [{
-            'email': 'service-account@example.com',
-            'scopes': 'one two'
-        }]
-        sign.side_effect = [b'signature']
-        id_token_jwt_grant.side_effect = [(
-            'idtoken',
-            datetime.datetime.utcfromtimestamp(3600),
-            {},
-        )]
+            'scopes': ['one', 'two']
+        },  tok]
 
         request = mock.create_autospec(transport.Request, instance=True)
         self.credentials = credentials.IDTokenCredentials(
-            request=request, target_audience="https://audience.com")
+            request=request, target_audience=None)
+
+        self.credentials.refresh(None)
+        token = self.credentials.token
+        payload = jwt.decode(token, verify=False)
+
+        assert self.credentials.token == tok
+        assert self.credentials.expiry == (
+            datetime.datetime.utcfromtimestamp(expire_at))
+        assert payload['aud'] == self.test_audience
+
+        assert self.credentials.valid
+
+    @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
+    def test_refresh_error(self, get):
+        get.side_effect = [{
+            'email': 'service-account@example.com',
+            'scopes': ['one', 'two']
+        }, exceptions.TransportError('not found')]
+
+        request = mock.create_autospec(transport.Request, instance=True)
+        self.credentials = credentials.IDTokenCredentials(
+            request=request, target_audience=self.test_audience)
+
+        with pytest.raises(exceptions.TransportError) as excinfo:
+            self.credentials.refresh(None)
+
+        assert excinfo.match(r'not found')
+
+    @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
+    def test_before_request_refreshes(self, get, token_factory):
+        expire_at = _helpers.datetime_to_secs(
+            _helpers.utcnow() + datetime.timedelta(hours=1))
+        claims = {'exp': expire_at, 'aud': self.test_audience}
+
+        tok = token_factory(claims=claims)
+
+        get.side_effect = [{
+            'email': 'service-account@example.com',
+            'scopes': ['one', 'two']
+        },  tok]
+
+        request = mock.create_autospec(transport.Request, instance=True)
+        self.credentials = credentials.IDTokenCredentials(
+            request=request, target_audience=None)
 
         # Credentials should start as invalid
         assert not self.credentials.valid
@@ -381,3 +318,69 @@ class TestIDTokenCredentials(object):
 
         # The JWT token signature is 'signature' encoded in base 64:
         assert signature == b'signature'
+
+    @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
+    def test_with_token_format(self, get, token_factory):
+        expire_at = _helpers.datetime_to_secs(
+            _helpers.utcnow() + datetime.timedelta(hours=1))
+
+        claims = {'exp': expire_at, 'aud': self.test_audience}
+
+        tok = token_factory(claims=claims, use_full_format=True)
+
+        get.side_effect = [{
+            'email': 'service-account@example.com',
+            'scopes': ['one', 'two']
+        }, tok]
+
+        request = mock.create_autospec(transport.Request, instance=True)
+        self.credentials = credentials.IDTokenCredentials(
+            request=request, target_audience=None)
+        self.credentials = (
+            self.credentials.with_token_format('full'))
+
+        self.credentials.refresh(None)
+        token = self.credentials.token
+        payload = jwt.decode(token, verify=False)
+
+        assert self.credentials.token == tok
+        assert self.credentials.expiry == (
+            datetime.datetime.utcfromtimestamp(expire_at))
+        assert payload['google'] == {
+            'compute_engine': {
+                'project_id': 'foo'
+            }
+        }
+        assert self.credentials.valid
+
+    @mock.patch('google.auth.compute_engine._metadata.get', autospec=True)
+    def test_with_license(self, get, token_factory):
+        expire_at = _helpers.datetime_to_secs(
+            _helpers.utcnow() + datetime.timedelta(hours=1))
+
+        claims = {'exp': expire_at, 'aud': self.test_audience}
+
+        tok = token_factory(claims=claims, use_full_format=True,
+                            include_license=True)
+
+        get.side_effect = [{
+            'email': 'service-account@example.com',
+            'scopes': ['one', 'two']
+        }, tok]
+
+        request = mock.create_autospec(transport.Request, instance=True)
+        self.credentials = credentials.IDTokenCredentials(
+            request=request, target_audience=None)
+        self.credentials = (
+            self.credentials.with_license(True))
+        self.credentials.refresh(None)
+        token = self.credentials.token
+        payload = jwt.decode(token, verify=False)
+
+        assert self.credentials.token == tok
+        assert self.credentials.expiry == (
+            datetime.datetime.utcfromtimestamp(expire_at))
+        assert payload['google']['compute_engine']['license_id'] == [
+                'bar'
+            ]
+        assert self.credentials.valid


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-auth-library-python/issues/344

and as a continuation of https://github.com/googleapis/google-auth-library-python/pull/347

_ do not merge_

This PR alters the internal behavior of how an IDToken is acquired through `compute_engine` credentials.  Previously, an idtoken was acquired through (basically) the IAM api and impersonation.  This credential type shoudl get the id_token from the metadata server.   This change alters the source of the token but keeps the IAM signer capability for now.

The token format returned by metadata may include additional fields but in its defaults, is in the same IDToken format provided by the existing IAM credentials signer mechanism.  This pr basically ignores one of the exiting parameters provided, `additioal_claims=`, since that would not work anyway with any credential type.