### PR TITLE
feat: add `to_json` method to google.oauth2.credentials.Credentials

### DIFF
--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -237,12 +237,13 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
                  from_json().
         """
         prep = {
-            'token': self.token,
-            'refresh_token': self.refresh_token,
-            'token_uri': self.token_uri,
-            'client_id': self.client_id,
-            'client_secret': self.client_secret,
-            'scopes': self.scopes}
+            "token": self.token,
+            "refresh_token": self.refresh_token,
+            "token_uri": self.token_uri,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "scopes": self.scopes,
+        }
 
         # Remove empty entries
         prep = {k: v for k, v in prep.items() if v is not None}

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -223,3 +223,32 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         with io.open(filename, "r", encoding="utf-8") as json_file:
             data = json.load(json_file)
             return cls.from_authorized_user_info(data, scopes)
+
+    def to_json(self, strip=None):
+        """Utility function that creates a JSON representation of a Credentials
+        object.
+
+        Args:
+            strip (Sequence[str]): Optional list of members to exclude from the
+                                   generated JSON.
+
+        Returns:
+            str: A JSON representation of this instance, suitable to pass to
+                 from_json().
+        """
+        prep = {
+            'token': self.token,
+            'refresh_token': self.refresh_token,
+            'token_uri': self.token_uri,
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'scopes': self.scopes}
+
+        # Remove empty entries
+        prep = {k: v for k, v in prep.items() if v is not None}
+
+        # Remove entries that explicitely need to be removed
+        if strip is not None:
+            prep = {k: v for k, v in prep.items() if k not in strip}
+
+        return json.dumps(prep)

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -339,19 +339,19 @@ class TestCredentials(object):
         # Test with no `strip` arg
         json_output = creds.to_json()
         json_asdict = json.loads(json_output)
-        assert json_asdict.get('token') == creds.token
-        assert json_asdict.get('refresh_token') == creds.refresh_token
-        assert json_asdict.get('token_uri') == creds.token_uri
-        assert json_asdict.get('client_id') == creds.client_id
-        assert json_asdict.get('scopes') == creds.scopes
-        assert json_asdict.get('client_secret') == creds.client_secret
+        assert json_asdict.get("token") == creds.token
+        assert json_asdict.get("refresh_token") == creds.refresh_token
+        assert json_asdict.get("token_uri") == creds.token_uri
+        assert json_asdict.get("client_id") == creds.client_id
+        assert json_asdict.get("scopes") == creds.scopes
+        assert json_asdict.get("client_secret") == creds.client_secret
 
         # Test with a `strip` arg
-        json_output = creds.to_json(strip=['client_secret'])
+        json_output = creds.to_json(strip=["client_secret"])
         json_asdict = json.loads(json_output)
-        assert json_asdict.get('token') == creds.token
-        assert json_asdict.get('refresh_token') == creds.refresh_token
-        assert json_asdict.get('token_uri') == creds.token_uri
-        assert json_asdict.get('client_id') == creds.client_id
-        assert json_asdict.get('scopes') == creds.scopes
-        assert json_asdict.get('client_secret') is None
+        assert json_asdict.get("token") == creds.token
+        assert json_asdict.get("refresh_token") == creds.refresh_token
+        assert json_asdict.get("token_uri") == creds.token_uri
+        assert json_asdict.get("client_id") == creds.client_id
+        assert json_asdict.get("scopes") == creds.scopes
+        assert json_asdict.get("client_secret") is None

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -331,3 +331,27 @@ class TestCredentials(object):
         assert creds.refresh_token == info["refresh_token"]
         assert creds.token_uri == credentials._GOOGLE_OAUTH2_TOKEN_ENDPOINT
         assert creds.scopes == scopes
+
+    def test_to_json(self):
+        info = AUTH_USER_INFO.copy()
+        creds = credentials.Credentials.from_authorized_user_info(info)
+
+        # Test with no `strip` arg
+        json_output = creds.to_json()
+        json_asdict = json.loads(json_output)
+        assert json_asdict.get('token') == creds.token
+        assert json_asdict.get('refresh_token') == creds.refresh_token
+        assert json_asdict.get('token_uri') == creds.token_uri
+        assert json_asdict.get('client_id') == creds.client_id
+        assert json_asdict.get('scopes') == creds.scopes
+        assert json_asdict.get('client_secret') == creds.client_secret
+
+        # Test with a `strip` arg
+        json_output = creds.to_json(strip=['client_secret'])
+        json_asdict = json.loads(json_output)
+        assert json_asdict.get('token') == creds.token
+        assert json_asdict.get('refresh_token') == creds.refresh_token
+        assert json_asdict.get('token_uri') == creds.token_uri
+        assert json_asdict.get('client_id') == creds.client_id
+        assert json_asdict.get('scopes') == creds.scopes
+        assert json_asdict.get('client_secret') is None


### PR DESCRIPTION
This adds a `Storage` base interface class and a `file` module based on `Storage` to save and load credentials.
The `credentials` module was modified to rely on the newer `Storage` class while retaining compatibility.