### PR TITLE
build: enable release-please

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,1 @@
+releaseType: python


### PR DESCRIPTION
This will allow release-please to propose new releases based on the commit history.

To be merged after #377, which will be the last release with commits not in the conventional commit format.