### PR TITLE
docs: fix note rendering for `service_account_email`

### DIFF
--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -105,7 +105,7 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
     def service_account_email(self):
         """The service account email.
 
-        .. note: This is not guaranteed to be set until :meth`refresh` has been
+        .. note:: This is not guaranteed to be set until :meth:`refresh` has been
             called.
         """
         return self._service_account_email


### PR DESCRIPTION
Closes #382 

Manually built the docs to verify that the note is rendered.

![image](https://user-images.githubusercontent.com/8822365/68612852-52ca6480-0472-11ea-965c-6b1095923e87.png)
