### PR TITLE
fix: fix check for 'internal_failure' condition

### DIFF
--- a/google/oauth2/_client.py
+++ b/google/oauth2/_client.py
@@ -104,17 +104,20 @@ def _token_endpoint_request(request, token_uri, body):
     while True:
         response = request(method="POST", url=token_uri, headers=headers, body=body)
         response_body = response.data.decode("utf-8")
+        response_data = json.loads(response_body)
 
         if response.status == http_client.OK:
             break
         else:
-            error_desc = json.loads(response_body).get("error_description") or ""
-            if error_desc == "internal_failure" and retry < 1:
+            error_desc = response_data.get("error_description") or ""
+            error_code = response_data.get("error") or ""
+            if (
+                any(e == "internal_failure" for e in (error_code, error_desc))
+                and retry < 1
+            ):
                 retry += 1
                 continue
             _handle_error_response(response_body)
-
-    response_data = json.loads(response_body)
 
     return response_data
 

--- a/tests/oauth2/test__client.py
+++ b/tests/oauth2/test__client.py
@@ -123,6 +123,15 @@ def test__token_endpoint_request_internal_failure_error():
             {"error": "internal_failure", "error_description": "internal_failure"},
         )
 
+    request = make_request(
+        {"error": "internal_failure"}, status=http_client.BAD_REQUEST
+    )
+
+    with pytest.raises(exceptions.RefreshError):
+        _client._token_endpoint_request(
+            request, "http://example.com", {"error": "internal_failure"}
+        )
+
 
 def verify_request_params(request, params):
     request_body = request.call_args[1]["body"]

--- a/tests/oauth2/test__client.py
+++ b/tests/oauth2/test__client.py
@@ -112,15 +112,12 @@ def test__token_endpoint_request_error():
 
 def test__token_endpoint_request_internal_failure_error():
     request = make_request(
-        {"error": "internal_failure", "error_description": "internal_failure"},
-        status=http_client.BAD_REQUEST,
+        {"error_description": "internal_failure"}, status=http_client.BAD_REQUEST
     )
 
     with pytest.raises(exceptions.RefreshError):
         _client._token_endpoint_request(
-            request,
-            "http://example.com",
-            {"error": "internal_failure", "error_description": "internal_failure"},
+            request, "http://example.com", {"error_description": "internal_failure"}
         )
 
     request = make_request(


### PR DESCRIPTION
As I was saying in [this comment](https://github.com/googleapis/google-auth-library-python/pull/368#issuecomment-553357310)
In some cases response doesn't contain `error_description` field. So the retry won't work. The solution is to look at both `error` and `error_description` fields.