### PR TITLE
fix: make gRPC auth plugin non-blocking + add default timeout value f…

### DIFF
--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -95,7 +95,7 @@ class Request(transport.Request):
         self.session = session
 
     def __call__(
-        self, url, method="GET", body=None, headers=None, timeout=None, **kwargs
+        self, url, method="GET", body=None, headers=None, timeout=120, **kwargs
     ):
         """Make an HTTP request using requests.
 

--- a/tests/transport/test_grpc.py
+++ b/tests/transport/test_grpc.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import time
 
 import mock
 import pytest
@@ -58,6 +59,8 @@ class TestAuthMetadataPlugin(object):
 
         plugin(context, callback)
 
+        time.sleep(2)
+
         callback.assert_called_once_with(
             [(u"authorization", u"Bearer {}".format(credentials.token))], None
         )
@@ -75,6 +78,8 @@ class TestAuthMetadataPlugin(object):
         callback = mock.create_autospec(grpc.AuthMetadataPluginCallback)
 
         plugin(context, callback)
+
+        time.sleep(2)
 
         assert credentials.token == "token1"
         callback.assert_called_once_with(


### PR DESCRIPTION
…or requests transport

This commit includes the following changes:
- `transport.grpc.AuthMetadataPlugin` is now non-blocking as gRPC requires
- `transport.requests.Request` now has a default timeout value of 120 seconds so that token refreshing will not be stuck

Resolves: #351