### PR TITLE
fix: in token endpoint request, do not decode the response data if it is not encoded

### DIFF
--- a/google/oauth2/_client.py
+++ b/google/oauth2/_client.py
@@ -103,8 +103,11 @@ def _token_endpoint_request(request, token_uri, body):
     # occurs.
     while True:
         response = request(method="POST", url=token_uri, headers=headers, body=body)
-        response_body = response.data.decode('utf-8') if hasattr(
-            response.data, 'decode') else response.data
+        response_body = (
+            response.data.decode("utf-8")
+            if hasattr(response.data, "decode")
+            else response.data
+        )
         response_data = json.loads(response_body)
 
         if response.status == http_client.OK:

--- a/google/oauth2/_client.py
+++ b/google/oauth2/_client.py
@@ -103,7 +103,8 @@ def _token_endpoint_request(request, token_uri, body):
     # occurs.
     while True:
         response = request(method="POST", url=token_uri, headers=headers, body=body)
-        response_body = response.data.decode("utf-8")
+        response_body = response.data.decode('utf-8') if hasattr(
+            response.data, 'decode') else response.data
         response_data = json.loads(response_body)
 
         if response.status == http_client.OK:


### PR DESCRIPTION
The interface of the underlying transport
'google.auth.transport.Request' that makes the token
request does not guarantee the response is encoded. In Python 3, the
non-encoded strings do not have 'decode' attribute. Blindly decoding all
the response could have the token refresh throw here.