### PR TITLE
feat: send quota project id in x-goog-user-project for OAuth2 credentials

### DIFF
--- a/docs/reference/google.auth.crypt.base.rst
+++ b/docs/reference/google.auth.crypt.base.rst
@@ -1,0 +1,7 @@
+google.auth.crypt.base module
+=============================
+
+.. automodule:: google.auth.crypt.base
+   :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/reference/google.auth.crypt.rsa.rst
+++ b/docs/reference/google.auth.crypt.rsa.rst
@@ -1,0 +1,7 @@
+google.auth.crypt.rsa module
+============================
+
+.. automodule:: google.auth.crypt.rsa
+   :members:
+   :inherited-members:
+   :show-inheritance:

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -58,7 +58,7 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         client_id=None,
         client_secret=None,
         scopes=None,
-        quota_project=None,
+        quota_project_id=None,
     ):
         """
         Args:
@@ -82,7 +82,7 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
                 token if refresh information is provided (e.g. The refresh
                 token scopes are a superset of this or contain a wild card
                 scope like 'https://www.googleapis.com/auth/any-api').
-            quota_project (Optional[str]): The project ID used for quota and billing.
+            quota_project_id (Optional[str]): The project ID used for quota and billing.
                 This project may be different from the project used to
                 create the credentials.
         """
@@ -94,7 +94,7 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         self._token_uri = token_uri
         self._client_id = client_id
         self._client_secret = client_secret
-        self._quota_project = quota_project
+        self._quota_project_id = quota_project_id
 
     @property
     def refresh_token(self):
@@ -129,9 +129,9 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         return self._client_secret
 
     @property
-    def quota_project(self):
+    def quota_project_id(self):
         """Optional[str]: The project to use for quota and billing purposes."""
-        return self._quota_project
+        return self._quota_project_id
 
     @property
     def requires_scopes(self):
@@ -182,8 +182,8 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
     @_helpers.copy_docstring(credentials.Credentials)
     def apply(self, headers, token=None):
         super(Credentials, self).apply(headers, token=token)
-        if self.quota_project is not None:
-            headers["x-goog-user-project"] = self.quota_project
+        if self.quota_project_id is not None:
+            headers["x-goog-user-project"] = self.quota_project_id
 
     @classmethod
     def from_authorized_user_info(cls, info, scopes=None):
@@ -218,7 +218,9 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
             scopes=scopes,
             client_id=info["client_id"],
             client_secret=info["client_secret"],
-            quota_project=info.get("quota_project"),  # quota project may not exist
+            quota_project_id=info.get(
+                "quota_project_id"
+            ),  # quota project may not exist
         )
 
     @classmethod

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -58,6 +58,7 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         client_id=None,
         client_secret=None,
         scopes=None,
+        quota_project=None,
     ):
         """
         Args:
@@ -81,6 +82,9 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
                 token if refresh information is provided (e.g. The refresh
                 token scopes are a superset of this or contain a wild card
                 scope like 'https://www.googleapis.com/auth/any-api').
+            quota_project (Optional[str]): The project ID used for quota and billing.
+                This project may be different from the project used to
+                create the credentials.
         """
         super(Credentials, self).__init__()
         self.token = token
@@ -90,6 +94,7 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         self._token_uri = token_uri
         self._client_id = client_id
         self._client_secret = client_secret
+        self._quota_project = quota_project
 
     @property
     def refresh_token(self):
@@ -122,6 +127,11 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
     def client_secret(self):
         """Optional[str]: The OAuth 2.0 client secret."""
         return self._client_secret
+
+    @property
+    def quota_project(self):
+        """Optional[str]: The project to use for quota and billing purposes."""
+        return self._quota_project
 
     @property
     def requires_scopes(self):
@@ -169,6 +179,12 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
                     )
                 )
 
+    @_helpers.copy_docstring(credentials.Credentials)
+    def apply(self, headers, token=None):
+        super().apply(headers, token=token)
+        if self.quota_project is not None:
+            headers["x-goog-user-project"] = self.quota_project
+
     @classmethod
     def from_authorized_user_info(cls, info, scopes=None):
         """Creates a Credentials instance from parsed authorized user info.
@@ -202,6 +218,7 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
             scopes=scopes,
             client_id=info["client_id"],
             client_secret=info["client_secret"],
+            quota_project=info.get("quota_project"),  # quota project may not exist
         )
 
     @classmethod

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -181,7 +181,7 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
 
     @_helpers.copy_docstring(credentials.Credentials)
     def apply(self, headers, token=None):
-        super().apply(headers, token=token)
+        super(Credentials, self).apply(headers, token=token)
         if self.quota_project is not None:
             headers["x-goog-user-project"] = self.quota_project
 

--- a/tests/data/authorized_user.json
+++ b/tests/data/authorized_user.json
@@ -2,6 +2,5 @@
   "client_id": "123",
   "client_secret": "secret",
   "refresh_token": "alabalaportocala",
-  "type": "authorized_user",
-  "quota_project": "offiredulassed"
+  "type": "authorized_user"
 }

--- a/tests/data/authorized_user.json
+++ b/tests/data/authorized_user.json
@@ -2,5 +2,6 @@
   "client_id": "123",
   "client_secret": "secret",
   "refresh_token": "alabalaportocala",
-  "type": "authorized_user"
+  "type": "authorized_user",
+  "quota_project": "offiredulassed"
 }

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -303,6 +303,7 @@ class TestCredentials(object):
         assert creds.refresh_token == info["refresh_token"]
         assert creds.token_uri == credentials._GOOGLE_OAUTH2_TOKEN_ENDPOINT
         assert creds.scopes is None
+        assert creds.quota_project = info["quota_project"]
 
         scopes = ["email", "profile"]
         creds = credentials.Credentials.from_authorized_user_info(info, scopes)
@@ -311,6 +312,7 @@ class TestCredentials(object):
         assert creds.refresh_token == info["refresh_token"]
         assert creds.token_uri == credentials._GOOGLE_OAUTH2_TOKEN_ENDPOINT
         assert creds.scopes == scopes
+        assert creds.quota_project = info["quota_project"]
 
     def test_from_authorized_user_file(self):
         info = AUTH_USER_INFO.copy()
@@ -321,6 +323,7 @@ class TestCredentials(object):
         assert creds.refresh_token == info["refresh_token"]
         assert creds.token_uri == credentials._GOOGLE_OAUTH2_TOKEN_ENDPOINT
         assert creds.scopes is None
+        assert creds.quota_project = info["quota_project"]
 
         scopes = ["email", "profile"]
         creds = credentials.Credentials.from_authorized_user_file(
@@ -331,3 +334,4 @@ class TestCredentials(object):
         assert creds.refresh_token == info["refresh_token"]
         assert creds.token_uri == credentials._GOOGLE_OAUTH2_TOKEN_ENDPOINT
         assert creds.scopes == scopes
+        assert creds.quota_project = info["quota_project"]

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -294,21 +294,21 @@ class TestCredentials(object):
         # expired.)
         assert creds.valid
 
-    def test_apply_with_quota_project(self):
+    def test_apply_with_quota_project_id(self):
         creds = credentials.Credentials(
             token="token",
             refresh_token=self.REFRESH_TOKEN,
             token_uri=self.TOKEN_URI,
             client_id=self.CLIENT_ID,
             client_secret=self.CLIENT_SECRET,
-            quota_project="quota-project-123",
+            quota_project_id="quota-project-123",
         )
 
         headers = {}
         creds.apply(headers)
         assert headers["x-goog-user-project"] == "quota-project-123"
 
-    def test_apply_with_no_quota_project(self):
+    def test_apply_with_no_quota_project_id(self):
         creds = credentials.Credentials(
             token="token",
             refresh_token=self.REFRESH_TOKEN,

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -294,6 +294,33 @@ class TestCredentials(object):
         # expired.)
         assert creds.valid
 
+    def test_apply_with_quota_project(self):
+        creds = credentials.Credentials(
+            token="token",
+            refresh_token=self.REFRESH_TOKEN,
+            token_uri=self.TOKEN_URI,
+            client_id=self.CLIENT_ID,
+            client_secret=self.CLIENT_SECRET,
+            quota_project="quota-project-123",
+        )
+
+        headers = {}
+        creds.apply(headers)
+        assert headers["x-goog-user-project"] == "quota-project-123"
+
+    def test_apply_with_no_quota_project(self):
+        creds = credentials.Credentials(
+            token="token",
+            refresh_token=self.REFRESH_TOKEN,
+            token_uri=self.TOKEN_URI,
+            client_id=self.CLIENT_ID,
+            client_secret=self.CLIENT_SECRET,
+        )
+
+        headers = {}
+        creds.apply(headers)
+        assert "x-goog-user-project" not in headers
+
     def test_from_authorized_user_info(self):
         info = AUTH_USER_INFO.copy()
 
@@ -303,7 +330,6 @@ class TestCredentials(object):
         assert creds.refresh_token == info["refresh_token"]
         assert creds.token_uri == credentials._GOOGLE_OAUTH2_TOKEN_ENDPOINT
         assert creds.scopes is None
-        assert creds.quota_project = info["quota_project"]
 
         scopes = ["email", "profile"]
         creds = credentials.Credentials.from_authorized_user_info(info, scopes)
@@ -312,7 +338,6 @@ class TestCredentials(object):
         assert creds.refresh_token == info["refresh_token"]
         assert creds.token_uri == credentials._GOOGLE_OAUTH2_TOKEN_ENDPOINT
         assert creds.scopes == scopes
-        assert creds.quota_project = info["quota_project"]
 
     def test_from_authorized_user_file(self):
         info = AUTH_USER_INFO.copy()
@@ -323,7 +348,6 @@ class TestCredentials(object):
         assert creds.refresh_token == info["refresh_token"]
         assert creds.token_uri == credentials._GOOGLE_OAUTH2_TOKEN_ENDPOINT
         assert creds.scopes is None
-        assert creds.quota_project = info["quota_project"]
 
         scopes = ["email", "profile"]
         creds = credentials.Credentials.from_authorized_user_file(
@@ -334,4 +358,3 @@ class TestCredentials(object):
         assert creds.refresh_token == info["refresh_token"]
         assert creds.token_uri == credentials._GOOGLE_OAUTH2_TOKEN_ENDPOINT
         assert creds.scopes == scopes
-        assert creds.quota_project = info["quota_project"]


### PR DESCRIPTION
When the 3LO credentials are used, the quota project ("quota_project_id") should be sent on every outgoing request in the x-goog-user-project HTTP header/grpc metadata.