### PR TITLE
Revert "feat: send quota project id in x-goog-user-project for OAuth2 credentials"

### DIFF
--- a/docs/reference/google.auth.crypt.base.rst
+++ b/docs/reference/google.auth.crypt.base.rst
@@ -1,7 +1,0 @@
-google.auth.crypt.base module
-=============================
-
-.. automodule:: google.auth.crypt.base
-   :members:
-   :inherited-members:
-   :show-inheritance:

--- a/docs/reference/google.auth.crypt.rsa.rst
+++ b/docs/reference/google.auth.crypt.rsa.rst
@@ -1,7 +1,0 @@
-google.auth.crypt.rsa module
-============================
-
-.. automodule:: google.auth.crypt.rsa
-   :members:
-   :inherited-members:
-   :show-inheritance:

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -58,7 +58,6 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         client_id=None,
         client_secret=None,
         scopes=None,
-        quota_project_id=None,
     ):
         """
         Args:
@@ -82,9 +81,6 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
                 token if refresh information is provided (e.g. The refresh
                 token scopes are a superset of this or contain a wild card
                 scope like 'https://www.googleapis.com/auth/any-api').
-            quota_project_id (Optional[str]): The project ID used for quota and billing.
-                This project may be different from the project used to
-                create the credentials.
         """
         super(Credentials, self).__init__()
         self.token = token
@@ -94,7 +90,6 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         self._token_uri = token_uri
         self._client_id = client_id
         self._client_secret = client_secret
-        self._quota_project_id = quota_project_id
 
     @property
     def refresh_token(self):
@@ -127,11 +122,6 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
     def client_secret(self):
         """Optional[str]: The OAuth 2.0 client secret."""
         return self._client_secret
-
-    @property
-    def quota_project_id(self):
-        """Optional[str]: The project to use for quota and billing purposes."""
-        return self._quota_project_id
 
     @property
     def requires_scopes(self):
@@ -179,12 +169,6 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
                     )
                 )
 
-    @_helpers.copy_docstring(credentials.Credentials)
-    def apply(self, headers, token=None):
-        super(Credentials, self).apply(headers, token=token)
-        if self.quota_project_id is not None:
-            headers["x-goog-user-project"] = self.quota_project_id
-
     @classmethod
     def from_authorized_user_info(cls, info, scopes=None):
         """Creates a Credentials instance from parsed authorized user info.
@@ -218,9 +202,6 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
             scopes=scopes,
             client_id=info["client_id"],
             client_secret=info["client_secret"],
-            quota_project_id=info.get(
-                "quota_project_id"
-            ),  # quota project may not exist
         )
 
     @classmethod

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -294,33 +294,6 @@ class TestCredentials(object):
         # expired.)
         assert creds.valid
 
-    def test_apply_with_quota_project_id(self):
-        creds = credentials.Credentials(
-            token="token",
-            refresh_token=self.REFRESH_TOKEN,
-            token_uri=self.TOKEN_URI,
-            client_id=self.CLIENT_ID,
-            client_secret=self.CLIENT_SECRET,
-            quota_project_id="quota-project-123",
-        )
-
-        headers = {}
-        creds.apply(headers)
-        assert headers["x-goog-user-project"] == "quota-project-123"
-
-    def test_apply_with_no_quota_project_id(self):
-        creds = credentials.Credentials(
-            token="token",
-            refresh_token=self.REFRESH_TOKEN,
-            token_uri=self.TOKEN_URI,
-            client_id=self.CLIENT_ID,
-            client_secret=self.CLIENT_SECRET,
-        )
-
-        headers = {}
-        creds.apply(headers)
-        assert "x-goog-user-project" not in headers
-
     def test_from_authorized_user_info(self):
         info = AUTH_USER_INFO.copy()
 


### PR DESCRIPTION
Reverts googleapis/google-auth-library-python#400

In addition to a comment on the original PR, folks have filed issue #405. Credentials pickled with the previous class definition (with no quota project) cannot be correctly unpickled. Many official docs pages have code to pickle credentials files, so we should make sure this use case is not broken.