### PR TITLE
test: add no cover for py2 collections import

### DIFF
--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -42,7 +42,8 @@ You can also skip verification::
 
 try:
     from collections.abc import Mapping
-except ImportError: # Python 2.7 compatibility
+# Python 2.7 compatibility
+except ImportError:  # pragma: NO COVER
     from collections import Mapping
 import copy
 import datetime


### PR DESCRIPTION
The coverage report is generated from the unit test session that runs last (3.7), which won't invoke the 'except' clause. 