### PR TITLE
docs: link to docs on googleapis, edit old links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,11 @@
 Google Auth Python Library
 ==========================
 
-|docs| |pypi|
+|pypi|
 
 This library simplifies using Google's various server-to-server authentication
 mechanisms to access Google APIs.
 
-.. |docs| image:: https://readthedocs.org/projects/google-auth/badge/?version=latest
-   :target: https://google-auth.readthedocs.io/en/latest/
 .. |pypi| image:: https://img.shields.io/pypi/v/google-auth.svg
    :target: https://pypi.python.org/pypi/google-auth
 
@@ -35,7 +33,7 @@ Python == 2.7. Python 2.7 support will be removed on January 1, 2020.
 Documentation
 -------------
 
-Google Auth Python Library has usage and reference documentation at `google-auth.readthedocs.io <https://google-auth.readthedocs.io>`_.
+Google Auth Python Library has usage and reference documentation at https://googleapis.dev/python/google-auth/latest/index.html.
 
 Current Maintainers
 -------------------
@@ -55,11 +53,11 @@ Contributions to this library are always welcome and highly encouraged.
 
 See `CONTRIBUTING.rst`_ for more information on how to get started.
 
-.. _CONTRIBUTING.rst: https://github.com/GoogleCloudPlatform/google-auth-library-python/blob/master/CONTRIBUTING.rst
+.. _CONTRIBUTING.rst: https://github.com/googleapis/google-auth-library-python/blob/master/CONTRIBUTING.rst
 
 License
 -------
 
 Apache 2.0 - See `the LICENSE`_ for more information.
 
-.. _the LICENSE: https://github.com/GoogleCloudPlatform/google-auth-library-python/blob/master/LICENSE
+.. _the LICENSE: https://github.com/googleapis/google-auth-library-python/blob/master/LICENSE


### PR DESCRIPTION
* Link to docs on googleapis.dev, not readthedocs
* Edit old repo links to use org googleapis, not GoogleCloudPlatform

Addresses part of #431 