### PR TITLE
feat: add non-None default timeout to AuthorizedSession.request()

### DIFF
--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -42,6 +42,8 @@ from google.auth import transport
 
 _LOGGER = logging.getLogger(__name__)
 
+_DEFAULT_TIMEOUT = 120  # in seconds
+
 
 class _Response(transport.Response):
     """Requests transport response adapter.
@@ -141,7 +143,13 @@ class Request(transport.Request):
         self.session = session
 
     def __call__(
-        self, url, method="GET", body=None, headers=None, timeout=120, **kwargs
+        self,
+        url,
+        method="GET",
+        body=None,
+        headers=None,
+        timeout=_DEFAULT_TIMEOUT,
+        **kwargs,
     ):
         """Make an HTTP request using requests.
 
@@ -246,8 +254,8 @@ class AuthorizedSession(requests.Session):
         data=None,
         headers=None,
         max_allowed_time=None,
-        timeout=None,
-        **kwargs
+        timeout=_DEFAULT_TIMEOUT,
+        **kwargs,
     ):
         """Implementation of Requests' request.
 
@@ -306,7 +314,7 @@ class AuthorizedSession(requests.Session):
                 data=data,
                 headers=request_headers,
                 timeout=timeout,
-                **kwargs
+                **kwargs,
             )
         remaining_time = guard.remaining_timeout
 
@@ -349,7 +357,7 @@ class AuthorizedSession(requests.Session):
                 max_allowed_time=remaining_time,
                 timeout=timeout,
                 _credential_refresh_attempt=_credential_refresh_attempt + 1,
-                **kwargs
+                **kwargs,
             )
 
         return response

--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -149,7 +149,7 @@ class Request(transport.Request):
         body=None,
         headers=None,
         timeout=_DEFAULT_TIMEOUT,
-        **kwargs,
+        **kwargs
     ):
         """Make an HTTP request using requests.
 
@@ -255,7 +255,7 @@ class AuthorizedSession(requests.Session):
         headers=None,
         max_allowed_time=None,
         timeout=_DEFAULT_TIMEOUT,
-        **kwargs,
+        **kwargs
     ):
         """Implementation of Requests' request.
 
@@ -314,7 +314,7 @@ class AuthorizedSession(requests.Session):
                 data=data,
                 headers=request_headers,
                 timeout=timeout,
-                **kwargs,
+                **kwargs
             )
         remaining_time = guard.remaining_timeout
 
@@ -357,7 +357,7 @@ class AuthorizedSession(requests.Session):
                 max_allowed_time=remaining_time,
                 timeout=timeout,
                 _credential_refresh_attempt=_credential_refresh_attempt + 1,
-                **kwargs,
+                **kwargs
             )
 
         return response

--- a/tests/transport/test_requests.py
+++ b/tests/transport/test_requests.py
@@ -177,6 +177,21 @@ class TestAuthorizedHttp(object):
 
         assert authed_session._auth_request == auth_request
 
+    def test_request_default_timeout(self):
+        credentials = mock.Mock(wraps=CredentialsStub())
+        response = make_response()
+        adapter = AdapterStub([response])
+
+        authed_session = google.auth.transport.requests.AuthorizedSession(credentials)
+        authed_session.mount(self.TEST_URL, adapter)
+
+        patcher = mock.patch("google.auth.transport.requests.requests.Session.request")
+        with patcher as patched_request:
+            authed_session.request("GET", self.TEST_URL)
+
+        expected_timeout = google.auth.transport.requests._DEFAULT_TIMEOUT
+        assert patched_request.call_args.kwargs.get("timeout") == expected_timeout
+
     def test_request_no_refresh(self):
         credentials = mock.Mock(wraps=CredentialsStub())
         response = make_response()


### PR DESCRIPTION
Closes #434.

This PR adds a non-`None` default timeout to `AuthorizedSession.request()` to prevent requests from hanging indefinitely in a default case.

Should help with https://github.com/googleapis/google-cloud-python/issues/10182 