### PR TITLE
Revert "fix: update `_GOOGLE_OAUTH2_CERTS_URL` (#365)"

### DIFF
--- a/google/oauth2/id_token.py
+++ b/google/oauth2/id_token.py
@@ -67,7 +67,7 @@ from google.auth import jwt
 
 # The URL that provides public certificates for verifying ID tokens issued
 # by Google's OAuth 2.0 authorization server.
-_GOOGLE_OAUTH2_CERTS_URL = "https://www.googleapis.com/oauth2/v3/certs"
+_GOOGLE_OAUTH2_CERTS_URL = "https://www.googleapis.com/oauth2/v1/certs"
 
 # The URL that provides public certificates for verifying ID tokens issued
 # by Firebase and the Google APIs infrastructure


### PR DESCRIPTION
## Issue
The new certificate (https://www.googleapis.com/oauth2/v3/certs) is in a jwk format and it doesn't match the format expected when decoding a jwt here.
https://github.com/googleapis/google-auth-library-python/blob/master/google/auth/jwt.py#L220

## Fix
A quick fix is to revert this update and continue using the /v1 uri.
The decode() function mentioned above should be fixed to accept jwk format certificates in the future.