### PR TITLE
fix: invalid expiry type

### DIFF
--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -275,8 +275,7 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
                 HTTP requests.
 
         Returns:
-            str: The ID token.
-            datetime.datetime: Expiry of the ID token.
+            Tuple[str, datetime.datetime]: The ID token and the expiry of the ID token.
 
         Raises:
             google.auth.exceptions.RefreshError: If the Compute Engine metadata

--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -274,6 +274,10 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
             request (google.auth.transport.Request): The object used to make
                 HTTP requests.
 
+        Returns:
+            str: The ID token.
+            datetime.datetime: Expiry of the ID token.
+
         Raises:
             google.auth.exceptions.RefreshError: If the Compute Engine metadata
                 service can't be reached or if the instance has no credentials.
@@ -291,7 +295,7 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
             six.raise_from(new_exc, caught_exc)
 
         _, payload, _, _ = jwt._unverified_decode(id_token)
-        return id_token, payload["exp"]
+        return id_token, datetime.datetime.fromtimestamp(payload["exp"])
 
     def refresh(self, request):
         """Refreshes the ID token.

--- a/system_tests/test_compute_engine.py
+++ b/system_tests/test_compute_engine.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
+
 import pytest
 
 import google.auth
@@ -61,8 +63,9 @@ def test_id_token_from_metadata(http_request):
     credentials.refresh(http_request)
 
     _, payload, _, _ = jwt._unverified_decode(credentials.token)
+    assert credentials.valid
     assert payload["aud"] == AUDIENCE
-    assert payload["exp"] == credentials.expiry
+    assert datetime.fromtimestamp(payload["exp"]) == credentials.expiry
 
 
 def test_fetch_id_token(http_request):

--- a/tests/compute_engine/test_credentials.py
+++ b/tests/compute_engine/test_credentials.py
@@ -522,7 +522,7 @@ class TestIDTokenCredentials(object):
         cred.refresh(request=mock.Mock())
 
         assert cred.token == SAMPLE_ID_TOKEN
-        assert cred.expiry == SAMPLE_ID_TOKEN_EXP
+        assert cred.expiry == datetime.datetime.fromtimestamp(SAMPLE_ID_TOKEN_EXP)
         assert cred._use_metadata_identity_endpoint
         assert cred._signer is None
         assert cred._token_uri is None


### PR DESCRIPTION
Fix #479 

`self.expiry` should be a `datetime.datetime` object, treated similar as https://github.com/googleapis/google-auth-library-python/blob/master/google/auth/impersonated_credentials.py#L352