### PR TITLE
feat: support passphrase in context aware metadata parser

### DIFF
--- a/google/auth/transport/_mtls_helper.py
+++ b/google/auth/transport/_mtls_helper.py
@@ -131,6 +131,8 @@ def get_client_ssl_credentials(metadata_json, encrypted_key_supported=False):
         raise ValueError("Encrypted private key is not supported")
     if b"ENCRYPTED" in key_match[0] and len(passphrase_match) != 1:
         raise ValueError("Passphrase is missing or invalid for encrypted key")
+    if b"ENCRYPTED" not in key_match[0] and len(passphrase_match) > 0:
+        raise ValueError("Passphrase is provided for unencrypted key")
     passphrase = (len(passphrase_match) == 1) and passphrase_match[0].strip() or None
 
     return cert_match[0], key_match[0], passphrase

--- a/google/auth/transport/grpc.py
+++ b/google/auth/transport/grpc.py
@@ -293,7 +293,7 @@ class SslCredentials:
                 metadata = _mtls_helper._read_dca_metadata_file(
                     self._context_aware_metadata_path
                 )
-                cert, key = _mtls_helper.get_client_ssl_credentials(metadata)
+                cert, key, _ = _mtls_helper.get_client_ssl_credentials(metadata)
                 self._ssl_credentials = grpc.ssl_channel_credentials(
                     certificate_chain=cert, private_key=key
                 )

--- a/tests/transport/test__mtls_helper.py
+++ b/tests/transport/test__mtls_helper.py
@@ -210,6 +210,16 @@ class TestGetClientSslCredentials(object):
                 CONTEXT_AWARE_METADATA, encrypted_key_supported=True
             )
 
+    @mock.patch("subprocess.Popen", autospec=True)
+    def test_unencrypted_key_with_passphrase(self, mock_popen):
+        mock_popen.return_value = self.create_mock_process(
+            pytest.public_cert_bytes + pytest.private_key_bytes + PASSPHRASE, b""
+        )
+        with pytest.raises(ValueError):
+            _mtls_helper.get_client_ssl_credentials(
+                CONTEXT_AWARE_METADATA, encrypted_key_supported=True
+            )
+
     def test_missing_cert_provider_command(self):
         with pytest.raises(ValueError):
             assert _mtls_helper.get_client_ssl_credentials(

--- a/tests/transport/test_grpc.py
+++ b/tests/transport/test_grpc.py
@@ -129,7 +129,11 @@ class TestSecureAuthorizedChannel(object):
         read_dca_metadata_file.return_value = {
             "cert_provider_command": ["some command"]
         }
-        get_client_ssl_credentials.return_value = (PUBLIC_CERT_BYTES, PRIVATE_KEY_BYTES)
+        get_client_ssl_credentials.return_value = (
+            PUBLIC_CERT_BYTES,
+            PRIVATE_KEY_BYTES,
+            None,
+        )
 
         channel = google.auth.transport.grpc.secure_authorized_channel(
             credentials, request, target, options=mock.sentinel.options
@@ -333,6 +337,7 @@ class TestSslCredentials(object):
         mock_get_client_ssl_credentials.return_value = (
             PUBLIC_CERT_BYTES,
             PRIVATE_KEY_BYTES,
+            None,
         )
 
         ssl_credentials = google.auth.transport.grpc.SslCredentials()


### PR DESCRIPTION
If the `cert_provider_command` in `metadata_json` has `--with_passphrase` option, then running it will produce encrypted key with a passphrase. This PR adds the support in the parser. 