### PR TITLE
update docstring of to_json method

### DIFF
--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -268,9 +268,9 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         """Utility function that creates a JSON representation of a Credentials
         object.
 
-        The returned JSON representation can be passed to
-        from_authorized_user_info() which constructs a Credentials object
-        from the mapping object (e.g. the returned JSON). 
+        The returned JSON string, when converted into a dictionary, can be passed
+        to from_authorized_user_info() which constructs a Credentials instance
+        from a mapping object (e.g. dict)
 
         Args:
             strip (Sequence[str]): Optional list of members to exclude from the

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -268,13 +268,17 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         """Utility function that creates a JSON representation of a Credentials
         object.
 
+        The returned JSON representation can be passed to
+        from_authorized_user_info() which constructs a Credentials object
+        from the mapping object (e.g. the returned JSON). 
+
         Args:
             strip (Sequence[str]): Optional list of members to exclude from the
                                    generated JSON.
 
         Returns:
             str: A JSON representation of this instance, suitable to pass to
-                 from_json().
+                 from_authorized_user_info().
         """
         prep = {
             "token": self.token,


### PR DESCRIPTION
from #494 
The original docstring of ``to_json`` referenced a method called ``from_json`` which actually exists in the form of ``from_authorized_user_info``. I also added some explanation for the functionality provided by ``from_authorized_user_info``.