### PR TITLE
feat: verify 'iss' claims in ID tokens

### DIFF
--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -295,9 +295,7 @@ def decode(token, certs=None, verify=True, audience=None, issuer=None):
             issuer = [issuer]
         if claim_issuer not in issuer:
             raise ValueError(
-                "Token has wrong issuer: {} (expected {})".format(
-                    claim_issuer, issuer
-                )
+                "Token has wrong issuer: {} (expected {})".format(claim_issuer, issuer)
             )
 
     return payload

--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -296,7 +296,7 @@ def decode(token, certs=None, verify=True, audience=None, issuer=None):
         if claim_issuer not in issuer:
             raise ValueError(
                 "Token has wrong issuer: {} (expected {})".format(
-                    claim_audience, audience
+                    claim_issuer, issuer
                 )
             )
 

--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -205,7 +205,7 @@ def _verify_iat_and_exp(payload):
         raise ValueError("Token expired, {} < {}".format(latest, now))
 
 
-def decode(token, certs=None, verify=True, audience=None):
+def decode(token, certs=None, verify=True, audience=None, issuer=None):
     """Decode and verify a JWT.
 
     Args:
@@ -220,6 +220,9 @@ def decode(token, certs=None, verify=True, audience=None):
             Verification is done by default.
         audience (str): The audience claim, 'aud', that this JWT should
             contain. If None then the JWT's 'aud' parameter is not verified.
+        issuer (Union[str, list]): The issuer claim ('iss') or claims this
+            JWT can contain. If None then the JWT's 'iss' claim is not
+            verified.
 
     Returns:
         Mapping[str, str]: The deserialized JSON payload in the JWT.
@@ -281,6 +284,18 @@ def decode(token, certs=None, verify=True, audience=None):
         if audience != claim_audience:
             raise ValueError(
                 "Token has wrong audience {}, expected {}".format(
+                    claim_audience, audience
+                )
+            )
+
+    # Check issuer.
+    if issuer is not None:
+        claim_issuer = payload.get("iss")
+        if isinstance(issuer, str):
+            issuer = [issuer]
+        if claim_issuer not in issuer:
+            raise ValueError(
+                "Token has wrong issuer: {} (expected {})".format(
                     claim_audience, audience
                 )
             )

--- a/google/oauth2/id_token.py
+++ b/google/oauth2/id_token.py
@@ -78,10 +78,7 @@ _GOOGLE_APIS_CERTS_URL = (
 )
 
 # Valid 'iss' claims for Google-issued ID tokens.
-_GOOGLE_ISSUERS = [
-    'accounts.google.com',
-    'https://accounts.google.com',
-]
+_GOOGLE_ISSUERS = ["accounts.google.com", "https://accounts.google.com"]
 
 
 def _fetch_certs(request, certs_url):
@@ -110,8 +107,7 @@ def _fetch_certs(request, certs_url):
 
 
 def verify_token(
-    id_token, request, audience=None, issuer=None,
-    certs_url=_GOOGLE_OAUTH2_CERTS_URL
+    id_token, request, audience=None, issuer=None, certs_url=_GOOGLE_OAUTH2_CERTS_URL
 ):
     """Verifies an ID token and returns the decoded token.
 
@@ -150,8 +146,11 @@ def verify_oauth2_token(id_token, request, audience=None):
         Mapping[str, Any]: The decoded token.
     """
     return verify_token(
-        id_token, request, audience=audience, issuer=_GOOGLE_ISSUERS,
-        certs_url=_GOOGLE_OAUTH2_CERTS_URL
+        id_token,
+        request,
+        audience=audience,
+        issuer=_GOOGLE_ISSUERS,
+        certs_url=_GOOGLE_OAUTH2_CERTS_URL,
     )
 
 

--- a/tests/oauth2/test_id_token.py
+++ b/tests/oauth2/test_id_token.py
@@ -70,7 +70,7 @@ def test_verify_token(_fetch_certs, decode):
         mock.sentinel.request, id_token._GOOGLE_OAUTH2_CERTS_URL
     )
     decode.assert_called_once_with(
-        mock.sentinel.token, certs=_fetch_certs.return_value, audience=None
+        mock.sentinel.token, certs=_fetch_certs.return_value, audience=None, issuer=None
     )
 
 
@@ -81,6 +81,7 @@ def test_verify_token_args(_fetch_certs, decode):
         mock.sentinel.token,
         mock.sentinel.request,
         audience=mock.sentinel.audience,
+        issuer=mock.sentinel.issuer,
         certs_url=mock.sentinel.certs_url,
     )
 
@@ -90,6 +91,7 @@ def test_verify_token_args(_fetch_certs, decode):
         mock.sentinel.token,
         certs=_fetch_certs.return_value,
         audience=mock.sentinel.audience,
+        issuer=mock.sentinel.issuer,
     )
 
 
@@ -104,6 +106,7 @@ def test_verify_oauth2_token(verify_token):
         mock.sentinel.token,
         mock.sentinel.request,
         audience=mock.sentinel.audience,
+        issuer=id_token._GOOGLE_ISSUERS,
         certs_url=id_token._GOOGLE_OAUTH2_CERTS_URL,
     )
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -150,6 +150,17 @@ def test_decode_valid_with_issuer(token_factory):
     assert payload["metadata"]["meta"] == "data"
 
 
+def test_decode_valid_with_wrong_issuer(token_factory):
+    token = token_factory(claims={"issuer": "accounts.alphabet.com"})
+    with pytest.raises(ValueError) as excinfo:
+        jwt.decode(
+            token,
+            certs=PUBLIC_CERT_BYTES,
+            issuer=["https://accounts.google.com", "accounts.google.com"],
+        )
+    assert excinfo.match(r"Token has wrong issuer")
+
+
 def test_decode_valid_unverified(token_factory):
     payload = jwt.decode(token_factory(), certs=OTHER_CERT_BYTES, verify=False)
     assert payload["aud"] == "audience@example.com"

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -92,6 +92,7 @@ def token_factory(signer, es256_signer):
         now = _helpers.datetime_to_secs(_helpers.utcnow())
         payload = {
             "aud": "audience@example.com",
+            "iss": "https://accounts.google.com",
             "iat": now,
             "exp": now + 300,
             "user": "billy bob",
@@ -134,6 +135,16 @@ def test_decode_valid_with_audience(token_factory):
         token_factory(), certs=PUBLIC_CERT_BYTES, audience="audience@example.com"
     )
     assert payload["aud"] == "audience@example.com"
+    assert payload["user"] == "billy bob"
+    assert payload["metadata"]["meta"] == "data"
+
+
+def test_decode_valid_with_issuer(token_factory):
+    payload = jwt.decode(
+        token_factory(), certs=PUBLIC_CERT_BYTES,
+        issuer=["https://accounts.google.com", "accounts.google.com"]
+    )
+    assert payload["iss"] == "https://accounts.google.com"
     assert payload["user"] == "billy bob"
     assert payload["metadata"]["meta"] == "data"
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -141,8 +141,9 @@ def test_decode_valid_with_audience(token_factory):
 
 def test_decode_valid_with_issuer(token_factory):
     payload = jwt.decode(
-        token_factory(), certs=PUBLIC_CERT_BYTES,
-        issuer=["https://accounts.google.com", "accounts.google.com"]
+        token_factory(),
+        certs=PUBLIC_CERT_BYTES,
+        issuer=["https://accounts.google.com", "accounts.google.com"],
     )
     assert payload["iss"] == "https://accounts.google.com"
     assert payload["user"] == "billy bob"


### PR DESCRIPTION
I hadn't noticed https://github.com/googleapis/google-auth-library-python/pull/500 before I did this, but this PR also adds an iss check option to google.auth.jwt if you want it.

Closes #499 