### PR TITLE
chore: support string type response.data for gcloud

### DIFF
--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -88,13 +88,17 @@ def _make_iam_token_request(request, principal, headers, body):
 
     response = request(url=iam_endpoint, method="POST", headers=headers, body=body)
 
-    response_body = response.data.decode("utf-8")
+    response_body = (
+        response.data.decode("utf-8")
+        if hasattr(response.data, "decode")
+        else response.data
+    )
 
     if response.status != http_client.OK:
         exceptions.RefreshError(_REFRESH_ERROR, response_body)
 
     try:
-        token_response = json.loads(response.data.decode("utf-8"))
+        token_response = json.loads(response_body)
         token = token_response["accessToken"]
         expiry = datetime.strptime(token_response["expireTime"], "%Y-%m-%dT%H:%M:%SZ")
 

--- a/tests/test_impersonated_credentials.py
+++ b/tests/test_impersonated_credentials.py
@@ -132,10 +132,17 @@ class TestImpersonatedCredentials(object):
         assert not credentials.valid
         assert credentials.expired
 
-    def make_request(self, data, status=http_client.OK, headers=None, side_effect=None):
+    def make_request(
+        self,
+        data,
+        status=http_client.OK,
+        headers=None,
+        side_effect=None,
+        use_data_bytes=True,
+    ):
         response = mock.create_autospec(transport.Response, instance=False)
         response.status = status
-        response.data = _helpers.to_bytes(data)
+        response.data = _helpers.to_bytes(data) if use_data_bytes else data
         response.headers = headers or {}
 
         request = mock.create_autospec(transport.Request, instance=False)
@@ -144,7 +151,8 @@ class TestImpersonatedCredentials(object):
 
         return request
 
-    def test_refresh_success(self, mock_donor_credentials):
+    @pytest.mark.parametrize("use_data_bytes", [True, False])
+    def test_refresh_success(self, use_data_bytes, mock_donor_credentials):
         credentials = self.make_credentials(lifetime=None)
         token = "token"
 
@@ -154,7 +162,9 @@ class TestImpersonatedCredentials(object):
         response_body = {"accessToken": token, "expireTime": expire_time}
 
         request = self.make_request(
-            data=json.dumps(response_body), status=http_client.OK
+            data=json.dumps(response_body),
+            status=http_client.OK,
+            use_data_bytes=use_data_bytes,
         )
 
         credentials.refresh(request)


### PR DESCRIPTION
gcloud uses httplib2 for the underlying http where response.data is string instead of bytes.