### PR TITLE
fix: catch exceptions.RefreshError

### DIFF
--- a/google/oauth2/id_token.py
+++ b/google/oauth2/id_token.py
@@ -212,7 +212,7 @@ def fetch_id_token(request, audience):
         )
         credentials.refresh(request)
         return credentials.token
-    except (ImportError, exceptions.TransportError):
+    except (ImportError, exceptions.TransportError, exceptions.RefreshError):
         pass
 
     # 2. Try to use service account credentials to get ID token.


### PR DESCRIPTION
Should catch the `RefreshError` raised by `credentials.refresh(request)`. This should be the cause or at least part of the cause of issue: https://github.com/GoogleCloudPlatform/python-docs-samples/issues/3712
