### PR TITLE
docs: update docstring of to_json() method

### DIFF
--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -273,8 +273,9 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
                                    generated JSON.
 
         Returns:
-            str: A JSON representation of this instance, suitable to pass to
-                 from_json().
+            str: A JSON representation of this instance. When converted into
+            a dictionary, it can be passed to from_authorized_user_info()
+            to create a new credential instance.
         """
         prep = {
             "token": self.token,


### PR DESCRIPTION
from #494, 

this PR updated the docstring of ``to_json`` method in the credential so that it points user to ``from_authorized_user_info`` instead of the non-existent ``from_json``