### PR TITLE
feat: add quota_project_id to service accounts; add with_quota_project methods

### DIFF
--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -48,7 +48,13 @@ _GOOGLE_OAUTH2_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
 
 
 class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
-    """Credentials using OAuth 2.0 access and refresh tokens."""
+    """Credentials using OAuth 2.0 access and refresh tokens.
+
+    The credentials are considered immutable. If you want to modify the
+    quota project, use :meth:`with_quota_project` or ::
+
+        credentials = credentials.with_quota_project('myproject-123)
+    """
 
     def __init__(
         self,
@@ -159,6 +165,27 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         """False: OAuth 2.0 credentials have their scopes set when
         the initial token is requested and can not be changed."""
         return False
+
+    def with_quota_project(self, quota_project_id):
+        """Returns a copy of these credentials with a modified quota project
+
+        Args:
+            quota_project_id (str): The project to use for quota and
+            billing purposes
+
+        Returns:
+            google.oauth2.credentials.Credentials: A new credentials instance.
+        """
+        return self.__class__(
+            self.token,
+            refresh_token=self.refresh_token,
+            id_token=self.id_token,
+            token_uri=self.token_uri,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            scopes=self.scopes,
+            quota_project_id=quota_project_id,
+        )
 
     @_helpers.copy_docstring(credentials.Credentials)
     def refresh(self, request):

--- a/google/oauth2/service_account.py
+++ b/google/oauth2/service_account.py
@@ -333,7 +333,6 @@ class Credentials(credentials.Signing, credentials.Scoped, credentials.Credentia
             additional_claims=self._additional_claims.copy(),
         )
 
-
     def _make_authorization_grant_assertion(self):
         """Create the OAuth 2.0 assertion.
 

--- a/google/oauth2/service_account.py
+++ b/google/oauth2/service_account.py
@@ -112,6 +112,10 @@ class Credentials(credentials.Signing, credentials.Scoped, credentials.Credentia
 
         scoped_credentials = credentials.with_scopes(['email'])
         delegated_credentials = credentials.with_subject(subject)
+
+    To add a quota project, use :meth:`with_quota_project`::
+
+        credentials = credentials.with_quota_project('myproject-123')
     """
 
     def __init__(
@@ -122,6 +126,7 @@ class Credentials(credentials.Signing, credentials.Scoped, credentials.Credentia
         scopes=None,
         subject=None,
         project_id=None,
+        quota_project_id=None,
         additional_claims=None,
     ):
         """
@@ -135,6 +140,8 @@ class Credentials(credentials.Signing, credentials.Scoped, credentials.Credentia
                 user to for which to request delegated access.
             project_id  (str): Project ID associated with the service account
                 credential.
+            quota_project_id (Optional[str]): The project ID used for quota and
+                billing.
             additional_claims (Mapping[str, str]): Any additional claims for
                 the JWT assertion used in the authorization grant.
 
@@ -150,6 +157,7 @@ class Credentials(credentials.Signing, credentials.Scoped, credentials.Credentia
         self._service_account_email = service_account_email
         self._subject = subject
         self._project_id = project_id
+        self._quota_project_id = quota_project_id
         self._token_uri = token_uri
 
         if additional_claims is not None:
@@ -230,6 +238,11 @@ class Credentials(credentials.Signing, credentials.Scoped, credentials.Credentia
         return self._project_id
 
     @property
+    def quota_project_id(self):
+        """Project ID to use for quota and billing purposes."""
+        return self._quota_project_id
+
+    @property
     def requires_scopes(self):
         """Checks if the credentials requires scopes.
 
@@ -247,6 +260,7 @@ class Credentials(credentials.Signing, credentials.Scoped, credentials.Credentia
             token_uri=self._token_uri,
             subject=self._subject,
             project_id=self._project_id,
+            quota_project_id=self._quota_project_id,
             additional_claims=self._additional_claims.copy(),
         )
 
@@ -267,6 +281,7 @@ class Credentials(credentials.Signing, credentials.Scoped, credentials.Credentia
             token_uri=self._token_uri,
             subject=subject,
             project_id=self._project_id,
+            quota_project_id=self._quota_project_id,
             additional_claims=self._additional_claims.copy(),
         )
 
@@ -292,8 +307,32 @@ class Credentials(credentials.Signing, credentials.Scoped, credentials.Credentia
             token_uri=self._token_uri,
             subject=self._subject,
             project_id=self._project_id,
+            quota_project_id=self._quota_project_id,
             additional_claims=new_additional_claims,
         )
+
+    def with_quota_project(self, quota_project_id):
+        """Returns a copy of these credentials with a modified quota project.
+
+        Args:
+            quota_project_id (str): The project to use for quota and
+            billing purposes
+
+        Returns:
+            google.auth.service_account.Credentials: A new credentials
+                instance.
+        """
+        return self.__class__(
+            self._signer,
+            service_account_email=self._service_account_email,
+            scopes=self._scopes,
+            token_uri=self._token_uri,
+            subject=self._subject,
+            project_id=self._project_id,
+            quota_project_id=quota_project_id,
+            additional_claims=self._additional_claims.copy(),
+        )
+
 
     def _make_authorization_grant_assertion(self):
         """Create the OAuth 2.0 assertion.
@@ -334,6 +373,12 @@ class Credentials(credentials.Signing, credentials.Scoped, credentials.Credentia
         access_token, expiry, _ = _client.jwt_grant(request, self._token_uri, assertion)
         self.token = access_token
         self.expiry = expiry
+
+    @_helpers.copy_docstring(credentials.Credentials)
+    def apply(self, headers, token=None):
+        super(Credentials, self).apply(headers, token=token)
+        if self.quota_project_id is not None:
+            headers["x-goog-user-project"] = self.quota_project_id
 
     @_helpers.copy_docstring(credentials.Signing)
     def sign_bytes(self, message):

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -330,7 +330,7 @@ class TestCredentials(object):
             token_uri=self.TOKEN_URI,
             client_id=self.CLIENT_ID,
             client_secret=self.CLIENT_SECRET,
-            quota_project_id="quota-project-123"
+            quota_project_id="quota-project-123",
         )
 
         new_creds = creds.with_quota_project("new-project-456")

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -323,6 +323,20 @@ class TestCredentials(object):
         creds.apply(headers)
         assert "x-goog-user-project" not in headers
 
+    def test_with_quota_project(self):
+        creds = credentials.Credentials(
+            token="token",
+            refresh_token=self.REFRESH_TOKEN,
+            token_uri=self.TOKEN_URI,
+            client_id=self.CLIENT_ID,
+            client_secret=self.CLIENT_SECRET,
+            quota_project_id="quota-project-123"
+        )
+
+        new_creds = creds.with_quota_project("new-project-456")
+
+        assert new_creds.quota_project_id == "new-project-456"
+
     def test_from_authorized_user_info(self):
         info = AUTH_USER_INFO.copy()
 

--- a/tests/oauth2/test_service_account.py
+++ b/tests/oauth2/test_service_account.py
@@ -147,6 +147,11 @@ class TestCredentials(object):
         new_credentials = credentials.with_claims({"meep": "moop"})
         assert new_credentials._additional_claims == {"meep": "moop"}
 
+    def test_with_quota_project(self):
+        credentials = self.make_credentials()
+        new_credentials = credentials.with_quota_project("new-project-456")
+        assert new_credentials.quota_project_id == "new-project-456"
+
     def test__make_authorization_grant_assertion(self):
         credentials = self.make_credentials()
         token = credentials._make_authorization_grant_assertion()


### PR DESCRIPTION
Adds `quota_project_id` to service account credentials, making it possible to set `quota_project_id` on OAuth2 credentials and service account credentials.

This PR also adds the method `with_quota_project` to both classes.