### PR TITLE
Update the upper bound for rsa dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup
 DEPENDENCIES = (
     "cachetools>=2.0.0,<5.0",
     "pyasn1-modules>=0.2.1",
-    "rsa>=3.1.4,<4.1",
+    "rsa>=3.1.4,<5",
     "setuptools>=40.3.0",
     "six>=1.9.0",
 )


### PR DESCRIPTION
RSA 4.1 released today, causing downstream issues because pip is not great at dependency resolution. (https://github.com/pypa/pip/issues/988)