### PR TITLE
fix: narrow acceptable RSA versions to maintain Python 2 compatability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup
 DEPENDENCIES = (
     "cachetools>=2.0.0,<5.0",
     "pyasn1-modules>=0.2.1",
-    "rsa>=3.1.4,<5.0",
+    "rsa>=3.1.4,<4.1.0",
     "setuptools>=40.3.0",
     "six>=1.9.0",
 )

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ DEPENDENCIES = (
     "cachetools>=2.0.0,<5.0",
     "pyasn1-modules>=0.2.1",
     # rsa 4.1, 4.1.1, 4.2 are broken on Py2: https://github.com/sybrenstuvel/python-rsa/issues/152
-    'rsa>=3.1.4,!=4.1,!=4.1.1,!=4.2,<5; python_version < 3',
-    'rsa>=3.1.4,<5; python_version >= 3'
+    "rsa>=3.1.4,!=4.1,!=4.1.1,!=4.2,<5; python_version < 3",
+    "rsa>=3.1.4,<5; python_version >= 3",
     "setuptools>=40.3.0",
     "six>=1.9.0",
 )

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,9 @@ from setuptools import setup
 DEPENDENCIES = (
     "cachetools>=2.0.0,<5.0",
     "pyasn1-modules>=0.2.1",
-    # TODO: rsa >= 4.1.0 doesn't support Python 2. Remove pinning after dropping support for Python 2. 
-    "rsa>=3.1.4,<4.1.0",
+    # rsa 4.1, 4.1.1, 4.2 are broken on Py2: https://github.com/sybrenstuvel/python-rsa/issues/152
+    'rsa>=3.1.4,!=4.1,!=4.1.1,!=4.2,<5; python_version < 3',
+    'rsa>=3.1.4,<5; python_version >= 3'
     "setuptools>=40.3.0",
     "six>=1.9.0",
 )

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ DEPENDENCIES = (
     "cachetools>=2.0.0,<5.0",
     "pyasn1-modules>=0.2.1",
     # rsa 4.1, 4.1.1, 4.2 are broken on Py2: https://github.com/sybrenstuvel/python-rsa/issues/152
-    "rsa>=3.1.4,!=4.1,!=4.1.1,!=4.2,<5; python_version < 3",
-    "rsa>=3.1.4,<5; python_version >= 3",
+    'rsa>=3.1.4,!=4.1,!=4.1.1,!=4.2,<5; python_version < "3"',
+    'rsa>=3.1.4,<5; python_version >= "3"',
     "setuptools>=40.3.0",
     "six>=1.9.0",
 )

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ from setuptools import setup
 DEPENDENCIES = (
     "cachetools>=2.0.0,<5.0",
     "pyasn1-modules>=0.2.1",
+    # TODO: rsa >= 4.1.0 doesn't support Python 2. Remove pinning after dropping support for Python 2. 
     "rsa>=3.1.4,<4.1.0",
     "setuptools>=40.3.0",
     "six>=1.9.0",


### PR DESCRIPTION
Version 4.0 was the last version to support Python 2 and 3.4. Version 4.1 is compatible with Python 3.5+ only.

