### PR TITLE
fix(dependencies): Further restrict RSA versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ from setuptools import setup
 DEPENDENCIES = (
     "cachetools>=2.0.0,<5.0",
     "pyasn1-modules>=0.2.1",
-    # rsa 4.1, 4.1.1, 4.2 are broken on Py2: https://github.com/sybrenstuvel/python-rsa/issues/152
-    'rsa>=3.1.4,!=4.1,!=4.1.1,!=4.2,<5; python_version < "3"',
+    # rsa >= 4.1 no longer supports python 2 https://github.com/sybrenstuvel/python-rsa/issues/152
+    'rsa<4.1; python_version < "3"',
     'rsa>=3.1.4,<5; python_version >= "3"',
     "setuptools>=40.3.0",
     "six>=1.9.0",


### PR DESCRIPTION
Related to #528. RSA seems to have released another version without `python_requires` being enforced. This will guard against that for our package.