### PR TITLE
fix: no warning if quota_project_id is given

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -50,7 +50,7 @@ https://cloud.google.com/docs/authentication/getting-started
 _CLOUD_SDK_CREDENTIALS_WARNING = """\
 Your application has authenticated using end user credentials from Google \
 Cloud SDK without a quota project. You might receive a "quota exceeded" \
-or "API not enabled" error. We recommend rerun \
+or "API not enabled" error. We recommend you rerun \
 `gcloud auth application-default login` and make sure a quota project is \
 added. Or you can use service accounts instead. For more information \
 about service accounts, see https://cloud.google.com/docs/authentication/"""

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -49,11 +49,11 @@ https://cloud.google.com/docs/authentication/getting-started
 # Warning when using Cloud SDK user credentials
 _CLOUD_SDK_CREDENTIALS_WARNING = """\
 Your application has authenticated using end user credentials from Google \
-Cloud SDK. We recommend that most server applications use service accounts \
-instead. If your application continues to use end user credentials from Cloud \
-SDK, you might receive a "quota exceeded" or "API not enabled" error. For \
-more information about service accounts, see \
-https://cloud.google.com/docs/authentication/"""
+Cloud SDK without a quota project. You might receive a "quota exceeded" \
+or "API not enabled" error. We recommend rerun \
+`gcloud auth application-default login` and make sure a quota project is \
+added. Or you can use service accounts instead. For more information \
+about service accounts, see https://cloud.google.com/docs/authentication/"""
 
 
 def _warn_about_problematic_credentials(credentials):
@@ -114,8 +114,8 @@ def _load_credentials_from_file(filename):
             msg = "Failed to load authorized user credentials from {}".format(filename)
             new_exc = exceptions.DefaultCredentialsError(msg, caught_exc)
             six.raise_from(new_exc, caught_exc)
-        # Authorized user credentials do not contain the project ID.
-        _warn_about_problematic_credentials(credentials)
+        if not credentials.quota_project_id:
+            _warn_about_problematic_credentials(credentials)
         return credentials, None
 
     elif credential_type == _SERVICE_ACCOUNT_TYPE:

--- a/tests/data/authorized_user_cloud_sdk_with_quota_project_id.json
+++ b/tests/data/authorized_user_cloud_sdk_with_quota_project_id.json
@@ -1,0 +1,7 @@
+{
+  "client_id": "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com",
+  "client_secret": "secret",
+  "refresh_token": "alabalaportocala",
+  "type": "authorized_user",
+  "quota_project_id": "quota_project_id"
+}

--- a/tests/test__default.py
+++ b/tests/test__default.py
@@ -37,6 +37,10 @@ AUTHORIZED_USER_CLOUD_SDK_FILE = os.path.join(
     DATA_DIR, "authorized_user_cloud_sdk.json"
 )
 
+AUTHORIZED_USER_CLOUD_SDK_WITH_QUOTA_PROJECT_ID_FILE = os.path.join(
+    DATA_DIR, "authorized_user_cloud_sdk_with_quota_project_id.json"
+)
+
 SERVICE_ACCOUNT_FILE = os.path.join(DATA_DIR, "service_account.json")
 
 with open(SERVICE_ACCOUNT_FILE) as fh:
@@ -98,6 +102,13 @@ def test__load_credentials_from_file_authorized_user_cloud_sdk():
         credentials, project_id = _default._load_credentials_from_file(
             AUTHORIZED_USER_CLOUD_SDK_FILE
         )
+    assert isinstance(credentials, google.oauth2.credentials.Credentials)
+    assert project_id is None
+
+    # No warning if the json file has quota project id.
+    credentials, project_id = _default._load_credentials_from_file(
+        AUTHORIZED_USER_CLOUD_SDK_WITH_QUOTA_PROJECT_ID_FILE
+    )
     assert isinstance(credentials, google.oauth2.credentials.Credentials)
     assert project_id is None
 


### PR DESCRIPTION
If user account cred has 'quota_project_id', ignore the warning.

Implementing http://shortn/_YUlAgzL40H