### PR TITLE
feat: add quota project to base credentials class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ docs/_build
 .tox/
 .cache/
 .pytest_cache/
+cert_path
+key_path
 
 # Django test database
 db.sqlite3

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -317,9 +317,7 @@ def default(scopes=None, request=None, quota_project_id=None):
     for checker in checkers:
         credentials, project_id = checker()
         if credentials is not None:
-            credentials = with_scopes_if_required(credentials, scopes)
-            if quota_project_id:
-                credentials = credentials.with_quota_project_id(quota_project_id)
+            credentials = with_scopes_if_required(credentials, scopes).with_quota_project_id(quota_project_id)
             effective_project_id = explicit_project_id or project_id
             if not effective_project_id:
                 _LOGGER.warning(

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -317,7 +317,9 @@ def default(scopes=None, request=None, quota_project_id=None):
     for checker in checkers:
         credentials, project_id = checker()
         if credentials is not None:
-            credentials = with_scopes_if_required(credentials, scopes).with_quota_project_id(quota_project_id)
+            credentials = with_scopes_if_required(
+                credentials, scopes
+            ).with_quota_project(quota_project_id)
             effective_project_id = explicit_project_id or project_id
             if not effective_project_id:
                 _LOGGER.warning(

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -130,7 +130,8 @@ def load_credentials_from_file(filename, scopes=None, quota_project_id=None):
 
         try:
             credentials = service_account.Credentials.from_service_account_info(
-                info, scopes=scopes).with_quota_project(quota_project_id)
+                info, scopes=scopes
+            ).with_quota_project(quota_project_id)
         except ValueError as caught_exc:
             msg = "Failed to load service account credentials from {}".format(filename)
             new_exc = exceptions.DefaultCredentialsError(msg, caught_exc)

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -69,7 +69,7 @@ def _warn_about_problematic_credentials(credentials):
         warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
 
 
-def load_credentials_from_file(filename, scopes=None):
+def load_credentials_from_file(filename, scopes=None, quota_project_id=None):
     """Loads Google credentials from a file.
 
     The credentials file must be a service account key or stored authorized
@@ -79,7 +79,9 @@ def load_credentials_from_file(filename, scopes=None):
         filename (str): The full path to the credentials file.
         scopes (Optional[Sequence[str]]): The list of scopes for the credentials. If
             specified, the credentials will automatically be scoped if
-            necessary.
+            necessary
+        quota_project_id (Optional[str]):  The project ID used for
+                quota and billing.
 
     Returns:
         Tuple[google.auth.credentials.Credentials, Optional[str]]: Loaded
@@ -114,7 +116,7 @@ def load_credentials_from_file(filename, scopes=None):
         try:
             credentials = credentials.Credentials.from_authorized_user_info(
                 info, scopes=scopes
-            )
+            ).with_quota_project(quota_project_id)
         except ValueError as caught_exc:
             msg = "Failed to load authorized user credentials from {}".format(filename)
             new_exc = exceptions.DefaultCredentialsError(msg, caught_exc)
@@ -128,8 +130,7 @@ def load_credentials_from_file(filename, scopes=None):
 
         try:
             credentials = service_account.Credentials.from_service_account_info(
-                info, scopes=scopes
-            )
+                info, scopes=scopes).with_quota_project(quota_project_id)
         except ValueError as caught_exc:
             msg = "Failed to load service account credentials from {}".format(filename)
             new_exc = exceptions.DefaultCredentialsError(msg, caught_exc)
@@ -226,7 +227,7 @@ def _get_gce_credentials(request=None):
         return None, None
 
 
-def default(scopes=None, request=None):
+def default(scopes=None, request=None, quota_project_id=None):
     """Gets the default credentials for the current environment.
 
     `Application Default Credentials`_ provides an easy way to obtain
@@ -286,7 +287,8 @@ def default(scopes=None, request=None):
             HTTP requests. This is used to detect whether the application
             is running on Compute Engine. If not specified, then it will
             use the standard library http client to make requests.
-
+        quota_project_id (Optional[str]):  The project ID used for
+            quota and billing.
     Returns:
         Tuple[~google.auth.credentials.Credentials, Optional[str]]:
             the current environment's credentials and project ID. Project ID
@@ -315,6 +317,8 @@ def default(scopes=None, request=None):
         credentials, project_id = checker()
         if credentials is not None:
             credentials = with_scopes_if_required(credentials, scopes)
+            if quota_project_id:
+                credentials = credentials.with_quota_project_id(quota_project_id)
             effective_project_id = explicit_project_id or project_id
             if not effective_project_id:
                 _LOGGER.warning(

--- a/google/auth/app_engine.py
+++ b/google/auth/app_engine.py
@@ -141,14 +141,16 @@ class Credentials(credentials.Scoped, credentials.Signing, credentials.Credentia
     @_helpers.copy_docstring(credentials.Scoped)
     def with_scopes(self, scopes):
         return self.__class__(
-            scopes=scopes, service_account_id=self._service_account_id,
-            quota_project_id=self.quota_project_id
+            scopes=scopes,
+            service_account_id=self._service_account_id,
+            quota_project_id=self.quota_project_id,
         )
-    
+
     @_helpers.copy_docstring(credentials.Credentials)
-    def with_quota_project(self, quota_project_id,):
+    def with_quota_project(self, quota_project_id):
         return self.__class__(
-            scopes=scopes, service_account_id=self._service_account_id,
+            scopes=scopes,
+            service_account_id=self._service_account_id,
             quota_project_id=quota_project_id,
         )
 

--- a/google/auth/app_engine.py
+++ b/google/auth/app_engine.py
@@ -93,9 +93,8 @@ class Credentials(credentials.Scoped, credentials.Signing, credentials.Credentia
                 :func:`google.appengine.api.app_identity.get_access_token`.
                 If not specified, the default application service account
                 ID will be used.
-            quota_project_id (Optional[str]): The project ID used for quota and billing.
-                This project may be different from the project used to
-                create the credentials.
+            quota_project_id (Optional[str]): The project ID used for quota
+                and billing.
 
         Raises:
             EnvironmentError: If the App Engine APIs are unavailable.

--- a/google/auth/app_engine.py
+++ b/google/auth/app_engine.py
@@ -84,7 +84,7 @@ class Credentials(credentials.Scoped, credentials.Signing, credentials.Credentia
     tokens.
     """
 
-    def __init__(self, scopes=None, service_account_id=None):
+    def __init__(self, scopes=None, service_account_id=None, quota_project_id=None):
         """
         Args:
             scopes (Sequence[str]): Scopes to request from the App Identity
@@ -93,6 +93,9 @@ class Credentials(credentials.Scoped, credentials.Signing, credentials.Credentia
                 :func:`google.appengine.api.app_identity.get_access_token`.
                 If not specified, the default application service account
                 ID will be used.
+            quota_project_id (Optional[str]): The project ID used for quota and billing.
+                This project may be different from the project used to
+                create the credentials.
 
         Raises:
             EnvironmentError: If the App Engine APIs are unavailable.
@@ -107,6 +110,7 @@ class Credentials(credentials.Scoped, credentials.Signing, credentials.Credentia
         self._scopes = scopes
         self._service_account_id = service_account_id
         self._signer = Signer()
+        self._quota_project_id = quota_project_id
 
     @_helpers.copy_docstring(credentials.Credentials)
     def refresh(self, request):
@@ -137,7 +141,15 @@ class Credentials(credentials.Scoped, credentials.Signing, credentials.Credentia
     @_helpers.copy_docstring(credentials.Scoped)
     def with_scopes(self, scopes):
         return self.__class__(
-            scopes=scopes, service_account_id=self._service_account_id
+            scopes=scopes, service_account_id=self._service_account_id,
+            quota_project_id=self.quota_project_id
+        )
+    
+    @_helpers.copy_docstring(credentials.Credentials)
+    def with_quota_project(self, quota_project_id,):
+        return self.__class__(
+            scopes=scopes, service_account_id=self._service_account_id,
+            quota_project_id=quota_project_id,
         )
 
     @_helpers.copy_docstring(credentials.Signing)

--- a/google/auth/app_engine.py
+++ b/google/auth/app_engine.py
@@ -148,7 +148,7 @@ class Credentials(credentials.Scoped, credentials.Signing, credentials.Credentia
     @_helpers.copy_docstring(credentials.Credentials)
     def with_quota_project(self, quota_project_id):
         return self.__class__(
-            scopes=scopes,
+            scopes=self._scopes,
             service_account_id=self._service_account_id,
             quota_project_id=quota_project_id,
         )

--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -54,15 +54,19 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         https://cloud.google.com/compute/docs/authentication#using
     """
 
-    def __init__(self, service_account_email="default"):
+    def __init__(self, service_account_email="default", quota_project_id=None):
         """
         Args:
             service_account_email (str): The service account email to use, or
                 'default'. A Compute Engine instance may have multiple service
                 accounts.
+            quota_project_id (Optional[str]): The project ID used for quota and billing.
+                This project may be different from the project used to
+                create the credentials.
         """
         super(Credentials, self).__init__()
         self._service_account_email = service_account_email
+        self._quota_project_id = quota_project_id
 
     def _retrieve_info(self, request):
         """Retrieve information about the service account.
@@ -115,6 +119,14 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         """False: Compute Engine credentials can not be scoped."""
         return False
 
+    @_helpers.copy_docstring(credentials.Credentials)
+    def with_quota_project(self, quota_project_id):
+
+        return self.__class__(
+            service_account=self._service_account_email,
+            quota_project_id=quota_project_id,
+        )
+
 
 _DEFAULT_TOKEN_LIFETIME_SECS = 3600  # 1 hour in seconds
 _DEFAULT_TOKEN_URI = "https://www.googleapis.com/oauth2/v4/token"
@@ -143,6 +155,7 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
         service_account_email=None,
         signer=None,
         use_metadata_identity_endpoint=False,
+        quota_project_id=None,
     ):
         """
         Args:
@@ -165,6 +178,9 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
                 is False. If set to True, ``token_uri``, ``additional_claims``,
                 ``service_account_email``, ``signer`` argument should not be set;
                 otherwise ValueError will be raised.
+            quota_project_id (Optional[str]): The project ID used for quota and billing.
+                This project may be different from the project used to
+                create the credentials.
 
         Raises:
             ValueError:
@@ -174,6 +190,7 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
         """
         super(IDTokenCredentials, self).__init__()
 
+        self._quota_project_id = quota_project_id
         self._use_metadata_identity_endpoint = use_metadata_identity_endpoint
         self._target_audience = target_audience
 
@@ -226,6 +243,7 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
                 None,
                 target_audience=target_audience,
                 use_metadata_identity_endpoint=True,
+                quota_project_id=self.quota_project_id,
             )
         else:
             return self.__class__(
@@ -236,6 +254,31 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
                 additional_claims=self._additional_claims.copy(),
                 signer=self.signer,
                 use_metadata_identity_endpoint=False,
+                quota_project_id=self.quota_project_id,
+            )
+
+    @_helpers.copy_docstring(credentials.Credentials)
+    def with_quota_project(self, quota_project_id):
+
+        # since the signer is already instantiated,
+        # the request is not needed
+        if self._use_metadata_identity_endpoint:
+            return self.__class__(
+                None,
+                target_audience=self.target_audience,
+                use_metadata_identity_endpoint=True,
+                quota_project_id=quota_project_id,
+            )
+        else:
+            return self.__class__(
+                None,
+                service_account_email=self._service_account_email,
+                token_uri=self._token_uri,
+                target_audience=self.target_audience,
+                additional_claims=self._additional_claims.copy(),
+                signer=self.signer,
+                use_metadata_identity_endpoint=False,
+                quota_project_id=quota_project_id,
             )
 
     def _make_authorization_grant_assertion(self):

--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -121,7 +121,7 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
     @_helpers.copy_docstring(credentials.Credentials)
     def with_quota_project(self, quota_project_id):
         return self.__class__(
-            service_account=self._service_account_email,
+            service_account_email=self._service_account_email,
             quota_project_id=quota_project_id,
         )
 
@@ -240,7 +240,7 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
                 None,
                 target_audience=target_audience,
                 use_metadata_identity_endpoint=True,
-                quota_project_id=self.quota_project_id,
+                quota_project_id=self._quota_project_id,
             )
         else:
             return self.__class__(
@@ -251,7 +251,7 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
                 additional_claims=self._additional_claims.copy(),
                 signer=self.signer,
                 use_metadata_identity_endpoint=False,
-                quota_project_id=self.quota_project_id,
+                quota_project_id=self._quota_project_id,
             )
 
     @_helpers.copy_docstring(credentials.Credentials)
@@ -262,7 +262,7 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
         if self._use_metadata_identity_endpoint:
             return self.__class__(
                 None,
-                target_audience=self.target_audience,
+                target_audience=self._target_audience,
                 use_metadata_identity_endpoint=True,
                 quota_project_id=quota_project_id,
             )
@@ -271,7 +271,7 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
                 None,
                 service_account_email=self._service_account_email,
                 token_uri=self._token_uri,
-                target_audience=self.target_audience,
+                target_audience=self._target_audience,
                 additional_claims=self._additional_claims.copy(),
                 signer=self.signer,
                 use_metadata_identity_endpoint=False,

--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -60,9 +60,8 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
             service_account_email (str): The service account email to use, or
                 'default'. A Compute Engine instance may have multiple service
                 accounts.
-            quota_project_id (Optional[str]): The project ID used for quota and billing.
-                This project may be different from the project used to
-                create the credentials.
+            quota_project_id (Optional[str]): The project ID used for quota and
+                billing.
         """
         super(Credentials, self).__init__()
         self._service_account_email = service_account_email
@@ -121,7 +120,6 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
 
     @_helpers.copy_docstring(credentials.Credentials)
     def with_quota_project(self, quota_project_id):
-
         return self.__class__(
             service_account=self._service_account_email,
             quota_project_id=quota_project_id,
@@ -178,9 +176,8 @@ class IDTokenCredentials(credentials.Credentials, credentials.Signing):
                 is False. If set to True, ``token_uri``, ``additional_claims``,
                 ``service_account_email``, ``signer`` argument should not be set;
                 otherwise ValueError will be raised.
-            quota_project_id (Optional[str]): The project ID used for quota and billing.
-                This project may be different from the project used to
-                create the credentials.
+            quota_project_id (Optional[str]): The project ID used for quota and
+                billing.
 
         Raises:
             ValueError:

--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -133,7 +133,6 @@ class Credentials(object):
             self.refresh(request)
         self.apply(headers)
 
-
     def with_quota_project(self, quota_project_id):
         """Returns a copy of these credentials with a modified quota project
 

--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -139,7 +139,7 @@ class Credentials(object):
 
         Args:
             quota_project_id (str): The project to use for quota and
-            billing purposes
+                billing purposes
 
         Returns:
             google.oauth2.credentials.Credentials: A new credentials instance.

--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -133,7 +133,7 @@ class Credentials(object):
             self.refresh(request)
         self.apply(headers)
 
-    @abc.abstractmethod
+
     def with_quota_project(self, quota_project_id):
         """Returns a copy of these credentials with a modified quota project
 

--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -182,7 +182,7 @@ class AnonymousCredentials(Credentials):
 
     def before_request(self, request, method, url, headers):
         """Anonymous credentials do nothing to the request."""
-    
+
     def with_quota_project(self, quota_project_id):
         raise ValueError("Anonymous credentials don't support quota project.")
 

--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -49,6 +49,8 @@ class Credentials(object):
         self.expiry = None
         """Optional[datetime]: When the token expires and is no longer valid.
         If this is None, the token is assumed to never expire."""
+        self._quota_project_id = None
+        """Optional[str]: Project to use for quota and billing purposes."""
 
     @property
     def expired(self):
@@ -74,6 +76,11 @@ class Credentials(object):
         is not :attr:`expired`.
         """
         return self.token is not None and not self.expired
+
+    @property
+    def quota_project_id(self):
+        """Project to use for quota and billing purposes."""
+        return self._quota_project_id
 
     @abc.abstractmethod
     def refresh(self, request):
@@ -102,6 +109,8 @@ class Credentials(object):
         headers["authorization"] = "Bearer {}".format(
             _helpers.from_bytes(token or self.token)
         )
+        if self.quota_project_id:
+            headers["x-goog-user-project"] = self.quota_project_id
 
     def before_request(self, request, method, url, headers):
         """Performs credential-specific before request logic.
@@ -123,6 +132,19 @@ class Credentials(object):
         if not self.valid:
             self.refresh(request)
         self.apply(headers)
+
+    @abc.abstractmethod
+    def with_quota_project(self, quota_project_id):
+        """Returns a copy of these credentials with a modified quota project
+
+        Args:
+            quota_project_id (str): The project to use for quota and
+            billing purposes
+
+        Returns:
+            google.oauth2.credentials.Credentials: A new credentials instance.
+        """
+        raise NotImplementedError("This class does not support quota project.")
 
 
 class AnonymousCredentials(Credentials):
@@ -160,6 +182,9 @@ class AnonymousCredentials(Credentials):
 
     def before_request(self, request, method, url, headers):
         """Anonymous credentials do nothing to the request."""
+    
+    def with_quota_project(self, quota_project_id):
+        raise ValueError("Anonymous credentials don't support quota project.")
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -339,12 +339,16 @@ class IDTokenCredentials(credentials.Credentials):
 
     def from_credentials(self, target_credentials, target_audience=None):
         return self.__class__(
-            target_credentials=self._target_credentials, target_audience=target_audience
+            target_credentials=self._target_credentials,
+            target_audience=target_audience,
+            quota_project_id=self._quota_project_id,
         )
 
     def with_target_audience(self, target_audience):
         return self.__class__(
-            target_credentials=self._target_credentials, target_audience=target_audience
+            target_credentials=self._target_credentials,
+            target_audience=target_audience,
+            quota_project_id=self._quota_project_id,
         )
 
     def with_include_email(self, include_email):
@@ -352,6 +356,7 @@ class IDTokenCredentials(credentials.Credentials):
             target_credentials=self._target_credentials,
             target_audience=self._target_audience,
             include_email=include_email,
+            quota_project_id=self._quota_project_id,
         )
 
     @_helpers.copy_docstring(credentials.Credentials)

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -184,6 +184,7 @@ class Credentials(credentials.Credentials, credentials.Signing):
         target_scopes,
         delegates=None,
         lifetime=_DEFAULT_TOKEN_LIFETIME_SECS,
+        quota_project_id=None,
     ):
         """
         Args:
@@ -205,6 +206,9 @@ class Credentials(credentials.Credentials, credentials.Signing):
                 target_principal.
             lifetime (int): Number of seconds the delegated credential should
                 be valid for (upto 3600).
+            quota_project_id (Optional[str]): The project ID used for quota and billing.
+                This project may be different from the project used to
+                create the credentials.
         """
 
         super(Credentials, self).__init__()
@@ -221,6 +225,7 @@ class Credentials(credentials.Credentials, credentials.Signing):
         self._lifetime = lifetime
         self.token = None
         self.expiry = _helpers.utcnow()
+        self._quota_project_id = quota_project_id
 
     @_helpers.copy_docstring(credentials.Credentials)
     def refresh(self, request):
@@ -288,19 +293,31 @@ class Credentials(credentials.Credentials, credentials.Signing):
     def signer(self):
         return self
 
+    @_helpers.copy_docstring(credentials.Credentials)
+    def with_quota_project(self, quota_project_id):
+        return self.__class__(
+            self._source_credentials,
+            target_principal=self._target_principal,
+            target_scopes=self._target_scopes,
+            delegates=self._delegates,
+            lifetime=self._lifetime,
+            quota_project_id=quota_project_id,
+        )
 
 class IDTokenCredentials(credentials.Credentials):
     """Open ID Connect ID Token-based service account credentials.
 
     """
 
-    def __init__(self, target_credentials, target_audience=None, include_email=False):
+    def __init__(self, target_credentials, target_audience=None, include_email=False, quota_project_id=None):
         """
         Args:
             target_credentials (google.auth.Credentials): The target
                 credential used as to acquire the id tokens for.
             target_audience (string): Audience to issue the token for.
             include_email (bool): Include email in IdToken
+            quota_project_id (Optional[str]):  The project ID used for
+                quota and billing.
         """
         super(IDTokenCredentials, self).__init__()
 
@@ -311,6 +328,7 @@ class IDTokenCredentials(credentials.Credentials):
         self._target_credentials = target_credentials
         self._target_audience = target_audience
         self._include_email = include_email
+        self._quota_project_id = quota_project_id
 
     def from_credentials(self, target_credentials, target_audience=None):
         return self.__class__(
@@ -327,6 +345,15 @@ class IDTokenCredentials(credentials.Credentials):
             target_credentials=self._target_credentials,
             target_audience=self._target_audience,
             include_email=include_email,
+        )
+
+    @_helpers.copy_docstring(credentials.Credentials)
+    def with_quota_project(self, quota_project_id):
+        return self.__class__(
+            target_credentials=self._target_credentials,
+            target_audience=self._target_audience,
+            include_email=self._include_email,
+            quota_project_id=quota_project_id,
         )
 
     @_helpers.copy_docstring(credentials.Credentials)

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -304,12 +304,19 @@ class Credentials(credentials.Credentials, credentials.Signing):
             quota_project_id=quota_project_id,
         )
 
+
 class IDTokenCredentials(credentials.Credentials):
     """Open ID Connect ID Token-based service account credentials.
 
     """
 
-    def __init__(self, target_credentials, target_audience=None, include_email=False, quota_project_id=None):
+    def __init__(
+        self,
+        target_credentials,
+        target_audience=None,
+        include_email=False,
+        quota_project_id=None,
+    ):
         """
         Args:
             target_credentials (google.auth.Credentials): The target

--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -359,7 +359,8 @@ class Credentials(google.auth.credentials.Signing, google.auth.credentials.Crede
                 the JWT payload.
             token_lifetime (int): The amount of time in seconds for
                 which the token is valid. Defaults to 1 hour.
-            quota_project_id (Optional[str]): The project ID used for quota and billing.
+            quota_project_id (Optional[str]): The project ID used for quota
+                and billing.
         """
         super(Credentials, self).__init__()
         self._signer = signer

--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -346,6 +346,7 @@ class Credentials(google.auth.credentials.Signing, google.auth.credentials.Crede
         audience,
         additional_claims=None,
         token_lifetime=_DEFAULT_TOKEN_LIFETIME_SECS,
+        quota_project_id=None,
     ):
         """
         Args:
@@ -358,6 +359,7 @@ class Credentials(google.auth.credentials.Signing, google.auth.credentials.Crede
                 the JWT payload.
             token_lifetime (int): The amount of time in seconds for
                 which the token is valid. Defaults to 1 hour.
+            quota_project_id (Optional[str]): The project ID used for quota and billing.
         """
         super(Credentials, self).__init__()
         self._signer = signer
@@ -365,6 +367,7 @@ class Credentials(google.auth.credentials.Signing, google.auth.credentials.Crede
         self._subject = subject
         self._audience = audience
         self._token_lifetime = token_lifetime
+        self._quota_project_id = quota_project_id
 
         if additional_claims is None:
             additional_claims = {}
@@ -486,6 +489,18 @@ class Credentials(google.auth.credentials.Signing, google.auth.credentials.Crede
             subject=subject if subject is not None else self._subject,
             audience=audience if audience is not None else self._audience,
             additional_claims=new_additional_claims,
+            quota_project_id=self._quota_project_id,
+        )
+
+    @_helpers.copy_docstring(google.auth.credentials.Credentials)
+    def with_quota_project(self, quota_project_id):
+        return self.__class__(
+            self._signer,
+            issuer=self._issuer,
+            subject=self._subject,
+            audience=self._audience,
+            additional_claims=self._additional_claims,
+            quota_project_id=quota_project_id,
         )
 
     def _make_jwt(self):
@@ -565,6 +580,7 @@ class OnDemandCredentials(
         additional_claims=None,
         token_lifetime=_DEFAULT_TOKEN_LIFETIME_SECS,
         max_cache_size=_DEFAULT_MAX_CACHE_SIZE,
+        quota_project_id=None,
     ):
         """
         Args:
@@ -577,12 +593,16 @@ class OnDemandCredentials(
                 which the token is valid. Defaults to 1 hour.
             max_cache_size (int): The maximum number of JWT tokens to keep in
                 cache. Tokens are cached using :class:`cachetools.LRUCache`.
+            quota_project_id (Optional[str]): The project ID used for quota
+                and billing.
+            
         """
         super(OnDemandCredentials, self).__init__()
         self._signer = signer
         self._issuer = issuer
         self._subject = subject
         self._token_lifetime = token_lifetime
+        self._quota_project_id = quota_project_id
 
         if additional_claims is None:
             additional_claims = {}
@@ -697,6 +717,18 @@ class OnDemandCredentials(
             subject=subject if subject is not None else self._subject,
             additional_claims=new_additional_claims,
             max_cache_size=self._cache.maxsize,
+        )
+
+    @_helpers.copy_docstring(google.auth.credentials.Credentials)
+    def with_quota_project(self, quota_project_id):
+        
+        return self.__class__(
+            self._signer,
+            issuer=self._issuer,
+            subject=self._subject,
+            additional_claims=self._additional_claims,
+            max_cache_size=self._cache_maxsize,
+            quota_project_id=self._quota_project_id
         )
 
     @property

--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -596,7 +596,7 @@ class OnDemandCredentials(
                 cache. Tokens are cached using :class:`cachetools.LRUCache`.
             quota_project_id (Optional[str]): The project ID used for quota
                 and billing.
-            
+
         """
         super(OnDemandCredentials, self).__init__()
         self._signer = signer
@@ -718,6 +718,7 @@ class OnDemandCredentials(
             subject=subject if subject is not None else self._subject,
             additional_claims=new_additional_claims,
             max_cache_size=self._cache.maxsize,
+            quota_project_id=self._quota_project_id,
         )
 
     @_helpers.copy_docstring(google.auth.credentials.Credentials)
@@ -728,8 +729,8 @@ class OnDemandCredentials(
             issuer=self._issuer,
             subject=self._subject,
             additional_claims=self._additional_claims,
-            max_cache_size=self._cache_maxsize,
-            quota_project_id=self._quota_project_id,
+            max_cache_size=self._cache.maxsize,
+            quota_project_id=quota_project_id,
         )
 
     @property

--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -721,14 +721,14 @@ class OnDemandCredentials(
 
     @_helpers.copy_docstring(google.auth.credentials.Credentials)
     def with_quota_project(self, quota_project_id):
-        
+
         return self.__class__(
             self._signer,
             issuer=self._issuer,
             subject=self._subject,
             additional_claims=self._additional_claims,
             max_cache_size=self._cache_maxsize,
-            quota_project_id=self._quota_project_id
+            quota_project_id=self._quota_project_id,
         )
 
     @property

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -326,6 +326,8 @@ class UserAccessTokenCredentials(credentials.Credentials):
 
         Args:
             account (str): Account to get the access token for.
+            quota_project_id (Optional[str]): The project ID used for quota
+                and billing.
 
         Returns:
             google.oauth2.credentials.UserAccessTokenCredentials: The created

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -314,6 +314,9 @@ class UserAccessTokenCredentials(credentials.Credentials):
     Args:
         account (Optional[str]): Account to get the access token for. If not
             specified, the current active account will be used.
+        quota_project_id (Optional[str]): The project ID used for quota
+            and billing.
+
     """
 
     def __init__(self, account=None, quota_project_id=None):
@@ -326,8 +329,6 @@ class UserAccessTokenCredentials(credentials.Credentials):
 
         Args:
             account (str): Account to get the access token for.
-            quota_project_id (Optional[str]): The project ID used for quota
-                and billing.
 
         Returns:
             google.oauth2.credentials.UserAccessTokenCredentials: The created

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -335,10 +335,7 @@ class UserAccessTokenCredentials(credentials.Credentials):
 
     @_helpers.copy_docstring(credentials.Credentials)
     def with_quota_project(self, quota_project_id):
-        return self.__class__(
-            account=self._account,
-            quota_project_id=quota_project_id,
-        )
+        return self.__class__(account=self._account, quota_project_id=quota_project_id)
 
     def refresh(self, request):
         """Refreshes the access token.

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -156,26 +156,14 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
         return self._client_secret
 
     @property
-    def quota_project_id(self):
-        """Optional[str]: The project to use for quota and billing purposes."""
-        return self._quota_project_id
-
-    @property
     def requires_scopes(self):
         """False: OAuth 2.0 credentials have their scopes set when
         the initial token is requested and can not be changed."""
         return False
 
+    @_helpers.copy_docstring(credentials.Credentials)
     def with_quota_project(self, quota_project_id):
-        """Returns a copy of these credentials with a modified quota project
 
-        Args:
-            quota_project_id (str): The project to use for quota and
-            billing purposes
-
-        Returns:
-            google.oauth2.credentials.Credentials: A new credentials instance.
-        """
         return self.__class__(
             self.token,
             refresh_token=self.refresh_token,
@@ -226,12 +214,6 @@ class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
                         ", ".join(scopes_requested_but_not_granted)
                     )
                 )
-
-    @_helpers.copy_docstring(credentials.Credentials)
-    def apply(self, headers, token=None):
-        super(Credentials, self).apply(headers, token=token)
-        if self.quota_project_id is not None:
-            headers["x-goog-user-project"] = self.quota_project_id
 
     @classmethod
     def from_authorized_user_info(cls, info, scopes=None):
@@ -334,9 +316,10 @@ class UserAccessTokenCredentials(credentials.Credentials):
             specified, the current active account will be used.
     """
 
-    def __init__(self, account=None):
+    def __init__(self, account=None, quota_project_id=None):
         super(UserAccessTokenCredentials, self).__init__()
         self._account = account
+        self._quota_project_id = quota_project_id
 
     def with_account(self, account):
         """Create a new instance with the given account.
@@ -348,7 +331,14 @@ class UserAccessTokenCredentials(credentials.Credentials):
             google.oauth2.credentials.UserAccessTokenCredentials: The created
                 credentials with the given account.
         """
-        return self.__class__(account=account)
+        return self.__class__(account=account, quota_project_id=self._quota_project_id)
+
+    @_helpers.copy_docstring(credentials.Credentials)
+    def with_quota_project(self, quota_project_id):
+        return self.__class__(
+            account=self._account,
+            quota_project_id=quota_project_id,
+        )
 
     def refresh(self, request):
         """Refreshes the access token.

--- a/google/oauth2/service_account.py
+++ b/google/oauth2/service_account.py
@@ -535,7 +535,7 @@ class IDTokenCredentials(credentials.Signing, credentials.Credentials):
 
     @_helpers.copy_docstring(credentials.Credentials)
     def with_quota_project(self, quota_project_id):
-        return self.__class_(
+        return self.__class__(
             self._signer,
             service_account_email=self._service_account_email,
             token_uri=self._token_uri,

--- a/google/oauth2/service_account.py
+++ b/google/oauth2/service_account.py
@@ -238,11 +238,6 @@ class Credentials(credentials.Signing, credentials.Scoped, credentials.Credentia
         return self._project_id
 
     @property
-    def quota_project_id(self):
-        """Project ID to use for quota and billing purposes."""
-        return self._quota_project_id
-
-    @property
     def requires_scopes(self):
         """Checks if the credentials requires scopes.
 
@@ -311,17 +306,9 @@ class Credentials(credentials.Signing, credentials.Scoped, credentials.Credentia
             additional_claims=new_additional_claims,
         )
 
+    @_helpers.copy_docstring(credentials.Credentials)
     def with_quota_project(self, quota_project_id):
-        """Returns a copy of these credentials with a modified quota project.
 
-        Args:
-            quota_project_id (str): The project to use for quota and
-            billing purposes
-
-        Returns:
-            google.auth.service_account.Credentials: A new credentials
-                instance.
-        """
         return self.__class__(
             self._signer,
             service_account_email=self._service_account_email,
@@ -372,12 +359,6 @@ class Credentials(credentials.Signing, credentials.Scoped, credentials.Credentia
         access_token, expiry, _ = _client.jwt_grant(request, self._token_uri, assertion)
         self.token = access_token
         self.expiry = expiry
-
-    @_helpers.copy_docstring(credentials.Credentials)
-    def apply(self, headers, token=None):
-        super(Credentials, self).apply(headers, token=token)
-        if self.quota_project_id is not None:
-            headers["x-goog-user-project"] = self.quota_project_id
 
     @_helpers.copy_docstring(credentials.Signing)
     def sign_bytes(self, message):
@@ -443,6 +424,7 @@ class IDTokenCredentials(credentials.Signing, credentials.Credentials):
         token_uri,
         target_audience,
         additional_claims=None,
+        quota_project_id=None,
     ):
         """
         Args:
@@ -454,7 +436,7 @@ class IDTokenCredentials(credentials.Signing, credentials.Credentials):
                 will be set to this string.
             additional_claims (Mapping[str, str]): Any additional claims for
                 the JWT assertion used in the authorization grant.
-
+            quota_project_id (Optional[str]): The project ID used for quota and billing.
         .. note:: Typically one of the helper constructors
             :meth:`from_service_account_file` or
             :meth:`from_service_account_info` are used instead of calling the
@@ -465,6 +447,7 @@ class IDTokenCredentials(credentials.Signing, credentials.Credentials):
         self._service_account_email = service_account_email
         self._token_uri = token_uri
         self._target_audience = target_audience
+        self._quota_project_id = quota_project_id
 
         if additional_claims is not None:
             self._additional_claims = additional_claims
@@ -547,6 +530,18 @@ class IDTokenCredentials(credentials.Signing, credentials.Credentials):
             token_uri=self._token_uri,
             target_audience=target_audience,
             additional_claims=self._additional_claims.copy(),
+            quota_project_id=self.quota_project_id,
+        )
+
+    @_helpers.copy_docstring(credentials.Credentials)
+    def with_quota_project(self, quota_project_id):
+        return self.__class_(
+            self._signer,
+            service_account_email=self._service_account_email,
+            token_uri=self._token_uri,
+            target_audience=self._target_audience,
+            additional_claims=self._additional_claims.copy(),
+            quota_project_id=quota_project_id,
         )
 
     def _make_authorization_grant_assertion(self):

--- a/tests/compute_engine/test_credentials.py
+++ b/tests/compute_engine/test_credentials.py
@@ -463,7 +463,7 @@ class TestIDTokenCredentials(object):
         responses.add(
             responses.GET,
             "http://metadata.google.internal/computeMetadata/v1/instance/"
-            "serviceAccounts/service-account@example.com:signBlob?alt=json",
+            "service-accounts/service-account@example.com/token",
             status=200,
             content_type="application/json",
             json={
@@ -477,8 +477,8 @@ class TestIDTokenCredentials(object):
         signature = base64.b64encode(b"some-signature").decode("utf-8")
         responses.add(
             responses.POST,
-            "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"
-            "service-account@example.com:signBlob?alt=json",
+            "https://iamcredentials.googleapis.com/v1/projects/-/"
+            "serviceAccounts/service-account@example.com:signBlob?alt=json",
             status=200,
             content_type="application/json",
             json={"keyId": "some-key-id", "signedBlob": signature},

--- a/tests/compute_engine/test_credentials.py
+++ b/tests/compute_engine/test_credentials.py
@@ -59,6 +59,8 @@ class TestCredentials(object):
         assert not self.credentials.requires_scopes
         # Service account email hasn't been populated
         assert self.credentials.service_account_email == "default"
+        # No quota project
+        assert not self.credentials._quota_project_id
 
     @mock.patch(
         "google.auth._helpers.utcnow",
@@ -131,6 +133,11 @@ class TestCredentials(object):
         # Credentials should now be valid.
         assert self.credentials.valid
 
+    def test_with_quota_project(self):
+        quota_project_creds = self.credentials.with_quota_project("project-foo")
+
+        assert quota_project_creds._quota_project_id == "project-foo"
+
 
 class TestIDTokenCredentials(object):
     credentials = None
@@ -154,6 +161,8 @@ class TestIDTokenCredentials(object):
         # Signer is initialized
         assert self.credentials.signer
         assert self.credentials.signer_email == "service-account@example.com"
+        # No quota project
+        assert not self.credentials._quota_project_id
 
     @mock.patch(
         "google.auth._helpers.utcnow",
@@ -394,6 +403,121 @@ class TestIDTokenCredentials(object):
     )
     @mock.patch("google.auth.compute_engine._metadata.get", autospec=True)
     @mock.patch("google.auth.iam.Signer.sign", autospec=True)
+    def test_with_quota_project(self, sign, get, utcnow):
+        get.side_effect = [
+            {"email": "service-account@example.com", "scopes": ["one", "two"]}
+        ]
+        sign.side_effect = [b"signature"]
+
+        request = mock.create_autospec(transport.Request, instance=True)
+        self.credentials = credentials.IDTokenCredentials(
+            request=request, target_audience="https://audience.com"
+        )
+        self.credentials = self.credentials.with_quota_project("project-foo")
+
+        assert self.credentials._quota_project_id == "project-foo"
+
+        # Generate authorization grant:
+        token = self.credentials._make_authorization_grant_assertion()
+        payload = jwt.decode(token, verify=False)
+
+        # The JWT token signature is 'signature' encoded in base 64:
+        assert token.endswith(b".c2lnbmF0dXJl")
+
+        # Check that the credentials have the token and proper expiration
+        assert payload == {
+            "aud": "https://www.googleapis.com/oauth2/v4/token",
+            "exp": 3600,
+            "iat": 0,
+            "iss": "service-account@example.com",
+            "target_audience": "https://audience.com",
+        }
+
+        # Check that the signer have been initialized with a Request object
+        assert isinstance(self.credentials._signer._request, transport.Request)
+
+    @responses.activate
+    def test_with_quota_project_integration(self):
+        """ Test that it is possible to refresh credentials
+        generated from `with_quota_project`.
+
+        Instead of mocking the methods, the HTTP responses
+        have been mocked.
+        """
+
+        # mock information about credentials
+        responses.add(
+            responses.GET,
+            "http://metadata.google.internal/computeMetadata/v1/instance/"
+            "service-accounts/default/?recursive=true",
+            status=200,
+            content_type="application/json",
+            json={
+                "scopes": "email",
+                "email": "service-account@example.com",
+                "aliases": ["default"],
+            },
+        )
+
+        # mock token for credentials
+        responses.add(
+            responses.GET,
+            "http://metadata.google.internal/computeMetadata/v1/instance/"
+            "service-accounts/service-account@example.com/token",
+            status=200,
+            content_type="application/json",
+            json={
+                "access_token": "some-token",
+                "expires_in": 3210,
+                "token_type": "Bearer",
+            },
+        )
+
+        # mock sign blob endpoint
+        signature = base64.b64encode(b"some-signature").decode("utf-8")
+        responses.add(
+            responses.POST,
+            "https://iam.googleapis.com/v1/projects/-/serviceAccounts/"
+            "service-account@example.com:signBlob?alt=json",
+            status=200,
+            content_type="application/json",
+            json={"keyId": "some-key-id", "signature": signature},
+        )
+
+        id_token = "{}.{}.{}".format(
+            base64.b64encode(b'{"some":"some"}').decode("utf-8"),
+            base64.b64encode(b'{"exp": 3210}').decode("utf-8"),
+            base64.b64encode(b"token").decode("utf-8"),
+        )
+
+        # mock id token endpoint
+        responses.add(
+            responses.POST,
+            "https://www.googleapis.com/oauth2/v4/token",
+            status=200,
+            content_type="application/json",
+            json={"id_token": id_token, "expiry": 3210},
+        )
+
+        self.credentials = credentials.IDTokenCredentials(
+            request=requests.Request(),
+            service_account_email="service-account@example.com",
+            target_audience="https://audience.com",
+        )
+
+        self.credentials = self.credentials.with_quota_project("project-foo")
+
+        self.credentials.refresh(requests.Request())
+
+        assert self.credentials.token is not None
+        assert self.credentials._quota_project_id == "project-foo"
+
+    @mock.patch(
+        "google.auth._helpers.utcnow",
+        return_value=datetime.datetime.utcfromtimestamp(0),
+    )
+    @mock.patch("google.auth.compute_engine._metadata.get", autospec=True)
+    @mock.patch("google.auth.iam.Signer.sign", autospec=True)
     @mock.patch("google.oauth2._client.id_token_jwt_grant", autospec=True)
     def test_refresh_success(self, id_token_jwt_grant, sign, get, utcnow):
         get.side_effect = [
@@ -543,6 +667,23 @@ class TestIDTokenCredentials(object):
         cred = cred.with_target_audience("new_audience")
 
         assert cred._target_audience == "new_audience"
+        assert cred._use_metadata_identity_endpoint
+        assert cred._signer is None
+        assert cred._token_uri is None
+        assert cred._service_account_email == "foo@example.com"
+
+    @mock.patch(
+        "google.auth.compute_engine._metadata.get_service_account_info", autospec=True
+    )
+    def test_id_token_with_quota_project(self, get_service_account_info):
+        get_service_account_info.return_value = {"email": "foo@example.com"}
+
+        cred = credentials.IDTokenCredentials(
+            mock.Mock(), "audience", use_metadata_identity_endpoint=True
+        )
+        cred = cred.with_quota_project("project-foo")
+
+        assert cred._quota_project_id == "project-foo"
         assert cred._use_metadata_identity_endpoint
         assert cred._signer is None
         assert cred._token_uri is None

--- a/tests/compute_engine/test_credentials.py
+++ b/tests/compute_engine/test_credentials.py
@@ -463,7 +463,7 @@ class TestIDTokenCredentials(object):
         responses.add(
             responses.GET,
             "http://metadata.google.internal/computeMetadata/v1/instance/"
-            "service-accounts/service-account@example.com/token",
+            "serviceAccounts/service-account@example.com:signBlob?alt=json",
             status=200,
             content_type="application/json",
             json={
@@ -477,11 +477,11 @@ class TestIDTokenCredentials(object):
         signature = base64.b64encode(b"some-signature").decode("utf-8")
         responses.add(
             responses.POST,
-            "https://iam.googleapis.com/v1/projects/-/serviceAccounts/"
+            "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"
             "service-account@example.com:signBlob?alt=json",
             status=200,
             content_type="application/json",
-            json={"keyId": "some-key-id", "signature": signature},
+            json={"keyId": "some-key-id", "signedBlob": signature},
         )
 
         id_token = "{}.{}.{}".format(

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -454,6 +454,13 @@ class TestUserAccessTokenCredentials(object):
         cred.refresh(None)
         assert cred.token == "access_token"
 
+    def test_with_quota_project(self):
+        cred = credentials.UserAccessTokenCredentials()
+        quota_project_cred = cred.with_quota_project("project-foo")
+
+        assert quota_project_cred._quota_project_id == "project-foo"
+        assert quota_project_cred._account == cred._account
+
     @mock.patch(
         "google.oauth2.credentials.UserAccessTokenCredentials.apply", autospec=True
     )

--- a/tests/oauth2/test_service_account.py
+++ b/tests/oauth2/test_service_account.py
@@ -291,6 +291,11 @@ class TestIDTokenCredentials(object):
         new_credentials = credentials.with_target_audience("https://new.example.com")
         assert new_credentials._target_audience == "https://new.example.com"
 
+    def test_with_quota_project(self):
+        credentials = self.make_credentials()
+        new_credentials = credentials.with_quota_project("project-foo")
+        assert new_credentials._quota_project_id == "project-foo"
+
     def test__make_authorization_grant_assertion(self):
         credentials = self.make_credentials()
         token = credentials._make_authorization_grant_assertion()

--- a/tests/test_app_engine.py
+++ b/tests/test_app_engine.py
@@ -102,6 +102,7 @@ class TestCredentials(object):
         # Scopes are required
         assert not credentials.scopes
         assert credentials.requires_scopes
+        assert not credentials.quota_project_id
 
     def test_with_scopes(self, app_identity):
         credentials = app_engine.Credentials()
@@ -113,6 +114,16 @@ class TestCredentials(object):
 
         assert scoped_credentials.has_scopes(["email"])
         assert not scoped_credentials.requires_scopes
+
+    def test_with_quota_project(self, app_identity):
+        credentials = app_engine.Credentials()
+
+        assert not credentials.scopes
+        assert not credentials.quota_project_id
+
+        quota_project_creds = credentials.with_quota_project("project-foo")
+
+        assert quota_project_creds.quota_project_id == "project-foo"
 
     def test_service_account_email_implicit(self, app_identity):
         app_identity.get_service_account_name.return_value = (

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -23,6 +23,9 @@ from google.auth import credentials
 class CredentialsImpl(credentials.Credentials):
     def refresh(self, request):
         self.token = request
+    
+    def with_quota_project(self, quota_project_id):
+        self._quota_project_id = quota_project_id
 
 
 def test_credentials_constructor():

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -25,7 +25,7 @@ class CredentialsImpl(credentials.Credentials):
         self.token = request
 
     def with_quota_project(self, quota_project_id):
-        pass
+        raise NotImplementedError()
 
 
 def test_credentials_constructor():
@@ -113,6 +113,12 @@ def test_anonymous_credentials_before_request():
     headers = {}
     anon.before_request(request, method, url, headers)
     assert headers == {}
+
+
+def test_anonymous_credentials_with_quota_project():
+    with pytest.raises(ValueError):
+        anon = credentials.AnonymousCredentials()
+        anon.with_quota_project("project-foo")
 
 
 class ReadOnlyScopedCredentialsImpl(credentials.ReadOnlyScoped, CredentialsImpl):

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -23,7 +23,7 @@ from google.auth import credentials
 class CredentialsImpl(credentials.Credentials):
     def refresh(self, request):
         self.token = request
-    
+
     def with_quota_project(self, quota_project_id):
         self._quota_project_id = quota_project_id
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -25,7 +25,7 @@ class CredentialsImpl(credentials.Credentials):
         self.token = request
 
     def with_quota_project(self, quota_project_id):
-        self._quota_project_id = quota_project_id
+        pass
 
 
 def test_credentials_constructor():

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -51,7 +51,7 @@ def make_credentials():
             pass
 
         def with_quota_project(self, quota_project_id):
-            pass
+            raise NotImplementedError()
 
     return CredentialsImpl()
 

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -49,6 +49,9 @@ def make_credentials():
 
         def refresh(self, request):
             pass
+        
+        def with_quota_project(self, quota_project_id):
+            pass
 
     return CredentialsImpl()
 

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -49,7 +49,7 @@ def make_credentials():
 
         def refresh(self, request):
             pass
-        
+
         def with_quota_project(self, quota_project_id):
             pass
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -363,6 +363,18 @@ class TestCredentials(object):
         assert new_credentials._subject == self.credentials._subject
         assert new_credentials._audience == new_audience
         assert new_credentials._additional_claims == self.credentials._additional_claims
+        assert new_credentials._quota_project_id == self.credentials._quota_project_id
+
+    def test_with_quota_project(self):
+        quota_project_id = "project-foo"
+
+        new_credentials = self.credentials.with_quota_project(quota_project_id)
+        assert new_credentials._signer == self.credentials._signer
+        assert new_credentials._issuer == self.credentials._issuer
+        assert new_credentials._subject == self.credentials._subject
+        assert new_credentials._audience == self.credentials._audience
+        assert new_credentials._additional_claims == self.credentials._additional_claims
+        assert new_credentials._quota_project_id == quota_project_id
 
     def test_sign_bytes(self):
         to_sign = b"123"
@@ -506,6 +518,16 @@ class TestOnDemandCredentials(object):
         assert new_credentials._issuer == self.credentials._issuer
         assert new_credentials._subject == self.credentials._subject
         assert new_credentials._additional_claims == new_claims
+
+    def test_with_quota_project(self):
+        quota_project_id = "project-foo"
+        new_credentials = self.credentials.with_quota_project(quota_project_id)
+
+        assert new_credentials._signer == self.credentials._signer
+        assert new_credentials._issuer == self.credentials._issuer
+        assert new_credentials._subject == self.credentials._subject
+        assert new_credentials._additional_claims == self.credentials._additional_claims
+        assert new_credentials._quota_project_id == quota_project_id
 
     def test_sign_bytes(self):
         to_sign = b"123"

--- a/tests/transport/test_grpc.py
+++ b/tests/transport/test_grpc.py
@@ -51,9 +51,10 @@ class CredentialsStub(credentials.Credentials):
 
     def refresh(self, request):
         self.token += "1"
-    
+
     def with_quota_project(self, quota_project_id):
         pass
+
 
 class TestAuthMetadataPlugin(object):
     def test_call_no_refresh(self):

--- a/tests/transport/test_grpc.py
+++ b/tests/transport/test_grpc.py
@@ -51,7 +51,9 @@ class CredentialsStub(credentials.Credentials):
 
     def refresh(self, request):
         self.token += "1"
-
+    
+    def with_quota_project(self, quota_project_id):
+        pass
 
 class TestAuthMetadataPlugin(object):
     def test_call_no_refresh(self):

--- a/tests/transport/test_grpc.py
+++ b/tests/transport/test_grpc.py
@@ -53,7 +53,7 @@ class CredentialsStub(credentials.Credentials):
         self.token += "1"
 
     def with_quota_project(self, quota_project_id):
-        pass
+        raise NotImplementedError()
 
 
 class TestAuthMetadataPlugin(object):

--- a/tests/transport/test_requests.py
+++ b/tests/transport/test_requests.py
@@ -110,7 +110,7 @@ class CredentialsStub(google.auth.credentials.Credentials):
         self.token += "1"
 
     def with_quota_project(self, quota_project_id):
-        pass
+        raise NotImplementedError()
 
 
 class TimeTickCredentialsStub(CredentialsStub):

--- a/tests/transport/test_requests.py
+++ b/tests/transport/test_requests.py
@@ -108,7 +108,7 @@ class CredentialsStub(google.auth.credentials.Credentials):
 
     def refresh(self, request):
         self.token += "1"
-    
+
     def with_quota_project(self, quota_project_id):
         pass
 

--- a/tests/transport/test_requests.py
+++ b/tests/transport/test_requests.py
@@ -108,6 +108,9 @@ class CredentialsStub(google.auth.credentials.Credentials):
 
     def refresh(self, request):
         self.token += "1"
+    
+    def with_quota_project(self, quota_project_id):
+        pass
 
 
 class TimeTickCredentialsStub(CredentialsStub):

--- a/tests/transport/test_urllib3.py
+++ b/tests/transport/test_urllib3.py
@@ -64,6 +64,9 @@ class CredentialsStub(google.auth.credentials.Credentials):
 
     def refresh(self, request):
         self.token += "1"
+    
+    def with_quota_project(self, quota_project_id):
+        pass
 
 
 class HttpStub(object):

--- a/tests/transport/test_urllib3.py
+++ b/tests/transport/test_urllib3.py
@@ -66,7 +66,7 @@ class CredentialsStub(google.auth.credentials.Credentials):
         self.token += "1"
 
     def with_quota_project(self, quota_project_id):
-        pass
+        raise NotImplementedError()
 
 
 class HttpStub(object):

--- a/tests/transport/test_urllib3.py
+++ b/tests/transport/test_urllib3.py
@@ -64,7 +64,7 @@ class CredentialsStub(google.auth.credentials.Credentials):
 
     def refresh(self, request):
         self.token += "1"
-    
+
     def with_quota_project(self, quota_project_id):
         pass
 


### PR DESCRIPTION
Make `quota_project_id` a property of the base credentials class and add it to the existing credentials types. 

Note that I didn't make `with_quota_project` an abstract method on the base credentials class because that would be a breaking change.

This PR also modifies functions in `default` to allow a `quota_project_id` to be passed.

```py
import google.auth

credentials, project = google.auth.default(quota_project_id='my-project')
```

```py
import google.auth

credentials, project = google.auth.load_credentials_from_file(
    'service_account.json',
    quota_project_id='my-project'
)
```