### PR TITLE
docs: remove 3.4 from supported versions list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ For more information on setting up your Python development environment, please r
 
 Supported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Python >= 3.4
+Python >= 3.5
 
 Deprecated Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Remove 3.4 from the supported versions list. We no longer actively test it and it has been EOL since March. https://www.python.org/downloads/release/python-3410/