### PR TITLE
Add pyopenssl requirement to package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ DEPENDENCIES = (
     'rsa>=3.1.4,<5; python_version >= "3"',
     "setuptools>=40.3.0",
     "six>=1.9.0",
+    "pyOpenSSL",
 )
 
 


### PR DESCRIPTION
Pyopenssl is imported from multiple modules in the package.