### PR TITLE
docs: add 3.8 support to contributing

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,7 +19,7 @@ A few notes on making changes to ``google-auth-library-python``.
   using ``nox -s docgen``.
 
 - The change must work fully on the following CPython versions: 2.7,
-  3.5, 3.6, 3.7 across macOS, Linux, and Windows.
+  3.5, 3.6, 3.7, 3.8 across macOS, Linux, and Windows.
 
 - The codebase *must* have 100% test statement coverage after each commit.
   You can test coverage via ``nox -e cover``.


### PR DESCRIPTION
Release-As: 1.19.2

Trying to get a release for #563