### PR TITLE
fix: reduce refresh clock skew to 10 seconds

### DIFF
--- a/google/auth/_helpers.py
+++ b/google/auth/_helpers.py
@@ -22,7 +22,7 @@ import six
 from six.moves import urllib
 
 
-CLOCK_SKEW_SECS = 300  # 5 minutes in seconds
+CLOCK_SKEW_SECS = 10  # 10 seconds
 CLOCK_SKEW = datetime.timedelta(seconds=CLOCK_SKEW_SECS)
 
 


### PR DESCRIPTION
Reduce clock skew from 5 minutes to 10 seconds, since metadata server token endpoint doesn't generate a new token until 30s before the expiration, it just returns the same token and the corresponding expires_in value. google-auth will keep calling token endpoint for around 4 minutes 30 seconds because of this.