### PR TITLE
feat: add GOOGLE_API_USE_CLIENT_CERTIFICATE support

### DIFF
--- a/docs/reference/google.auth.transport.mtls.rst
+++ b/docs/reference/google.auth.transport.mtls.rst
@@ -1,0 +1,7 @@
+google.auth.transport.mtls module
+=================================
+
+.. automodule:: google.auth.transport.mtls
+   :members:
+   :inherited-members:
+   :show-inheritance:

--- a/google/auth/environment_vars.py
+++ b/google/auth/environment_vars.py
@@ -53,3 +53,9 @@ the system falls back to the old variable.
 GCE_METADATA_IP = "GCE_METADATA_IP"
 """Environment variable providing an alternate ip:port to be used for ip-only
 GCE metadata requests."""
+
+GOOGLE_API_USE_CLIENT_CERTIFICATE = "GOOGLE_API_USE_CLIENT_CERTIFICATE"
+"""Environment variable controlling whether to use client certificate or not.
+
+The default value is False. Users have to explicitly set this value to True
+in order to use client certificate to establish a mutual TLS channel."""

--- a/google/auth/transport/grpc.py
+++ b/google/auth/transport/grpc.py
@@ -21,6 +21,7 @@ import os
 
 import six
 
+from google.auth import environment_vars
 from google.auth import exceptions
 from google.auth.transport import _mtls_helper
 
@@ -246,7 +247,9 @@ def secure_authorized_channel(
 
     # If SSL credentials are not explicitly set, try client_cert_callback and ADC.
     if not ssl_credentials:
-        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", False)
+        use_client_cert = os.getenv(
+            environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE, False
+        )
         if use_client_cert and client_cert_callback:
             # Use the callback if provided.
             cert, key = client_cert_callback()
@@ -283,7 +286,9 @@ class SslCredentials:
     """
 
     def __init__(self):
-        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", False)
+        use_client_cert = os.getenv(
+            environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE, False
+        )
         if not use_client_cert:
             self._is_mtls = False
         else:

--- a/google/auth/transport/grpc.py
+++ b/google/auth/transport/grpc.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 
 import logging
+import os
 
 import six
 
@@ -96,6 +97,9 @@ def secure_authorized_channel(
 
     This creates a channel with SSL and :class:`AuthMetadataPlugin`. This
     channel can be used to create a stub that can make authorized requests.
+    Users can configure client certificate or rely on device certificates to
+    establish a mutual TLS channel, if the `GOOGLE_API_USE_CLIENT_CERTIFICATE`
+    variable is explicitly set to `True`.
 
     Example::
 
@@ -138,7 +142,9 @@ def secure_authorized_channel(
             ssl_credentials=regular_ssl_credentials)
 
     Option 2: create a mutual TLS channel by calling a callback which returns
-    the client side certificate and the key::
+    the client side certificate and the key (Note that
+    `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable must be explicitly
+    set to `True`)::
 
         def my_client_cert_callback():
             code_to_load_client_cert_and_key()
@@ -155,7 +161,9 @@ def secure_authorized_channel(
 
     Option 3: use application default SSL credentials. It searches and uses
     the command in a context aware metadata file, which is available on devices
-    with endpoint verification support.
+    with endpoint verification support (Note that
+    `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable must be explicitly
+    set to `True`).
     See https://cloud.google.com/endpoint-verification/docs/overview::
 
         try:
@@ -174,7 +182,8 @@ def secure_authorized_channel(
             ssl_credentials=default_ssl_credentials)
 
     Option 4: not setting ssl_credentials and client_cert_callback. For devices
-    without endpoint verification support, a regular TLS channel is created;
+    without endpoint verification support or `GOOGLE_API_USE_CLIENT_CERTIFICATE`
+    environment variable is not `True`, a regular TLS channel is created;
     otherwise, a mutual TLS channel is created, however, the call should be
     wrapped in a try/except block in case of malformed context aware metadata.
 
@@ -205,13 +214,15 @@ def secure_authorized_channel(
             This argument is mutually exclusive with client_cert_callback;
             providing both will raise an exception.
             If ssl_credentials and client_cert_callback are None, application
-            default SSL credentials will be used.
+            default SSL credentials are used if `GOOGLE_API_USE_CLIENT_CERTIFICATE`
+            environment variable is explicitly set to `True`, otherwise one way TLS
+            SSL credentials are used.
         client_cert_callback (Callable[[], (bytes, bytes)]): Optional
             callback function to obtain client certicate and key for mutual TLS
             connection. This argument is mutually exclusive with
             ssl_credentials; providing both will raise an exception.
-            If ssl_credentials and client_cert_callback are None, application
-            default SSL credentials will be used.
+            This argument does nothing unless `GOOGLE_API_USE_CLIENT_CERTIFICATE`
+            environment variable is explicitly set to `True`.
         kwargs: Additional arguments to pass to :func:`grpc.secure_channel`.
 
     Returns:
@@ -235,16 +246,19 @@ def secure_authorized_channel(
 
     # If SSL credentials are not explicitly set, try client_cert_callback and ADC.
     if not ssl_credentials:
-        if client_cert_callback:
+        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", False)
+        if use_client_cert and client_cert_callback:
             # Use the callback if provided.
             cert, key = client_cert_callback()
             ssl_credentials = grpc.ssl_channel_credentials(
                 certificate_chain=cert, private_key=key
             )
-        else:
+        elif use_client_cert:
             # Use application default SSL credentials.
             adc_ssl_credentils = SslCredentials()
             ssl_credentials = adc_ssl_credentils.ssl_credentials
+        else:
+            ssl_credentials = grpc.ssl_channel_credentials()
 
     # Combine the ssl credentials and the authorization credentials.
     composite_credentials = grpc.composite_channel_credentials(
@@ -257,17 +271,27 @@ def secure_authorized_channel(
 class SslCredentials:
     """Class for application default SSL credentials.
 
-    For devices with endpoint verification support, a device certificate will be
-    automatically loaded and mutual TLS will be established.
+    The behavior is controlled by `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment
+    variable whose default value is `False`. Client certificate will not be used
+    unless the environment variable is explicitly set to `True`. See
+    https://google.aip.dev/auth/4114
+
+    If the environment variable is `True`, then for devices with endpoint verification
+    support, a device certificate will be automatically loaded and mutual TLS will
+    be established.
     See https://cloud.google.com/endpoint-verification/docs/overview.
     """
 
     def __init__(self):
-        # Load client SSL credentials.
-        metadata_path = _mtls_helper._check_dca_metadata_path(
-            _mtls_helper.CONTEXT_AWARE_METADATA_PATH
-        )
-        self._is_mtls = metadata_path is not None
+        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", False)
+        if not use_client_cert:
+            self._is_mtls = False
+        else:
+            # Load client SSL credentials.
+            metadata_path = _mtls_helper._check_dca_metadata_path(
+                _mtls_helper.CONTEXT_AWARE_METADATA_PATH
+            )
+            self._is_mtls = metadata_path is not None
 
     @property
     def ssl_credentials(self):

--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 import functools
 import logging
 import numbers
+import os
 import time
 
 try:
@@ -249,13 +250,18 @@ class AuthorizedSession(requests.Session):
     credentials' headers to the request and refreshing credentials as needed.
 
     This class also supports mutual TLS via :meth:`configure_mtls_channel`
-    method. If client_cert_callback is provided, client certificate and private
+    method. In order to use this method, the `GOOGLE_API_USE_CLIENT_CERTIFICATE`
+    environment variable must be explicitly set to `True`, otherwise it does
+    nothing. Assume the environment is set to `True`, the method behaves in the
+    following manner:
+    If client_cert_callback is provided, client certificate and private
     key are loaded using the callback; if client_cert_callback is None,
     application default SSL credentials will be used. Exceptions are raised if
     there are problems with the certificate, private key, or the loading process,
     so it should be called within a try/except block.
 
-    First we create an :class:`AuthorizedSession` instance and specify the endpoints::
+    First we set the environment variable to `True`, then create an :class:`AuthorizedSession`
+    instance and specify the endpoints::
 
         regular_endpoint = 'https://pubsub.googleapis.com/v1/projects/{my_project_id}/topics'
         mtls_endpoint = 'https://pubsub.mtls.googleapis.com/v1/projects/{my_project_id}/topics'
@@ -343,9 +349,11 @@ class AuthorizedSession(requests.Session):
     def configure_mtls_channel(self, client_cert_callback=None):
         """Configure the client certificate and key for SSL connection.
 
-        If client certificate and key are successfully obtained (from the given
-        client_cert_callback or from application default SSL credentials), a
-        :class:`_MutualTlsAdapter` instance will be mounted to "https://" prefix.
+        The function does nothing unless `GOOGLE_API_USE_CLIENT_CERTIFICATE` is
+        explicitly set to `True`. In this case if client certificate and key are
+        successfully obtained (from the given client_cert_callback or from application
+        default SSL credentials), a :class:`_MutualTlsAdapter` instance will be mounted
+        to "https://" prefix.
 
         Args:
             client_cert_callback (Optional[Callable[[], (bytes, bytes)]]):
@@ -358,6 +366,11 @@ class AuthorizedSession(requests.Session):
             google.auth.exceptions.MutualTLSChannelError: If mutual TLS channel
                 creation failed for any reason.
         """
+        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", False)
+        if not use_client_cert:
+            self._is_mtls = False
+            return
+
         try:
             import OpenSSL
         except ImportError as caught_exc:

--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -41,6 +41,7 @@ from requests.packages.urllib3.util.ssl_ import (
 )  # pylint: disable=ungrouped-imports
 import six  # pylint: disable=ungrouped-imports
 
+from google.auth import environment_vars
 from google.auth import exceptions
 from google.auth import transport
 import google.auth.transport._mtls_helper
@@ -366,7 +367,9 @@ class AuthorizedSession(requests.Session):
             google.auth.exceptions.MutualTLSChannelError: If mutual TLS channel
                 creation failed for any reason.
         """
-        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", False)
+        use_client_cert = os.getenv(
+            environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE, False
+        )
         if not use_client_cert:
             self._is_mtls = False
             return

--- a/google/auth/transport/urllib3.py
+++ b/google/auth/transport/urllib3.py
@@ -46,6 +46,7 @@ except ImportError as caught_exc:  # pragma: NO COVER
 import six
 import urllib3.exceptions  # pylint: disable=ungrouped-imports
 
+from google.auth import environment_vars
 from google.auth import exceptions
 from google.auth import transport
 
@@ -310,7 +311,9 @@ class AuthorizedHttp(urllib3.request.RequestMethods):
             google.auth.exceptions.MutualTLSChannelError: If mutual TLS channel
                 creation failed for any reason.
         """
-        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", False)
+        use_client_cert = os.getenv(
+            environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE, False
+        )
         if not use_client_cert:
             return False
 

--- a/google/auth/transport/urllib3.py
+++ b/google/auth/transport/urllib3.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 
 import logging
+import os
 import warnings
 
 # Certifi is Mozilla's certificate bundle. Urllib3 needs a certificate bundle
@@ -202,13 +203,18 @@ class AuthorizedHttp(urllib3.request.RequestMethods):
     credentials' headers to the request and refreshing credentials as needed.
 
     This class also supports mutual TLS via :meth:`configure_mtls_channel`
-    method. If client_cert_callback is provided, client certificate and private
+    method. In order to use this method, the `GOOGLE_API_USE_CLIENT_CERTIFICATE`
+    environment variable must be explicitly set to `True`, otherwise it does
+    nothing. Assume the environment is set to `True`, the method behaves in the
+    following manner:
+    If client_cert_callback is provided, client certificate and private
     key are loaded using the callback; if client_cert_callback is None,
     application default SSL credentials will be used. Exceptions are raised if
     there are problems with the certificate, private key, or the loading process,
     so it should be called within a try/except block.
 
-    First we create an :class:`AuthorizedHttp` instance and specify the endpoints::
+    First we set the environment variable to `True`, then create an :class:`AuthorizedHttp`
+    instance and specify the endpoints::
 
         regular_endpoint = 'https://pubsub.googleapis.com/v1/projects/{my_project_id}/topics'
         mtls_endpoint = 'https://pubsub.mtls.googleapis.com/v1/projects/{my_project_id}/topics'
@@ -282,9 +288,13 @@ class AuthorizedHttp(urllib3.request.RequestMethods):
 
     def configure_mtls_channel(self, client_cert_callback=None):
         """Configures mutual TLS channel using the given client_cert_callback or
-        application default SSL credentials. Returns True if the channel is
-        mutual TLS and False otherwise. Note that the `http` provided in the
-        constructor will be overwritten.
+        application default SSL credentials. The behavior is controlled by
+        `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable.
+        (1) If the environment variable value is `True`, the function returns True
+        if the channel is mutual TLS and False otherwise. The `http` provided
+        in the constructor will be overwritten.
+        (2) If the environment variable is not set or `False`, the function does
+        nothing and it always return False.
 
         Args:
             client_cert_callback (Optional[Callable[[], (bytes, bytes)]]):
@@ -300,6 +310,10 @@ class AuthorizedHttp(urllib3.request.RequestMethods):
             google.auth.exceptions.MutualTLSChannelError: If mutual TLS channel
                 creation failed for any reason.
         """
+        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", False)
+        if not use_client_cert:
+            return False
+
         try:
             import OpenSSL
         except ImportError as caught_exc:

--- a/system_tests/test_mtls_http.py
+++ b/system_tests/test_mtls_http.py
@@ -33,7 +33,8 @@ def test_requests():
     )
 
     authed_session = google.auth.transport.requests.AuthorizedSession(credentials)
-    authed_session.configure_mtls_channel()
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+        authed_session.configure_mtls_channel()
 
     # If the devices has default client cert source, then a mutual TLS channel
     # is supposed to be created.
@@ -57,7 +58,8 @@ def test_urllib3():
     )
 
     authed_http = google.auth.transport.urllib3.AuthorizedHttp(credentials)
-    is_mtls = authed_http.configure_mtls_channel()
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+        is_mtls = authed_http.configure_mtls_channel()
 
     # If the devices has default client cert source, then a mutual TLS channel
     # is supposed to be created.

--- a/system_tests/test_mtls_http.py
+++ b/system_tests/test_mtls_http.py
@@ -18,6 +18,7 @@ import time
 
 import google.auth
 import google.auth.credentials
+from google.auth import environment_vars
 from google.auth.transport import mtls
 import google.auth.transport.requests
 import google.auth.transport.urllib3
@@ -33,7 +34,7 @@ def test_requests():
     )
 
     authed_session = google.auth.transport.requests.AuthorizedSession(credentials)
-    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+    with mock.patch.dict(os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}):
         authed_session.configure_mtls_channel()
 
     # If the devices has default client cert source, then a mutual TLS channel
@@ -58,7 +59,7 @@ def test_urllib3():
     )
 
     authed_http = google.auth.transport.urllib3.AuthorizedHttp(credentials)
-    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+    with mock.patch.dict(os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}):
         is_mtls = authed_http.configure_mtls_channel()
 
     # If the devices has default client cert source, then a mutual TLS channel

--- a/tests/transport/test_grpc.py
+++ b/tests/transport/test_grpc.py
@@ -21,6 +21,7 @@ import pytest
 
 from google.auth import _helpers
 from google.auth import credentials
+from google.auth import environment_vars
 from google.auth import exceptions
 from google.auth import transport
 
@@ -140,7 +141,9 @@ class TestSecureAuthorizedChannel(object):
         )
 
         channel = None
-        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+        with mock.patch.dict(
+            os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
+        ):
             channel = google.auth.transport.grpc.secure_authorized_channel(
                 credentials, request, target, options=mock.sentinel.options
             )
@@ -278,7 +281,9 @@ class TestSecureAuthorizedChannel(object):
         client_cert_callback = mock.Mock()
         client_cert_callback.return_value = (PUBLIC_CERT_BYTES, PRIVATE_KEY_BYTES)
 
-        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+        with mock.patch.dict(
+            os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
+        ):
             google.auth.transport.grpc.secure_authorized_channel(
                 credentials, request, target, client_cert_callback=client_cert_callback
             )
@@ -320,7 +325,7 @@ class TestSecureAuthorizedChannel(object):
 
         with pytest.raises(Exception) as excinfo:
             with mock.patch.dict(
-                os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}
+                os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
             ):
                 google.auth.transport.grpc.secure_authorized_channel(
                     credentials,
@@ -381,7 +386,9 @@ class TestSslCredentials(object):
         # Mock that the metadata file doesn't exist.
         mock_check_dca_metadata_path.return_value = None
 
-        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+        with mock.patch.dict(
+            os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
+        ):
             ssl_credentials = google.auth.transport.grpc.SslCredentials()
 
         # Since no context aware metadata is found, we wouldn't call
@@ -409,7 +416,7 @@ class TestSslCredentials(object):
 
         with pytest.raises(exceptions.MutualTLSChannelError):
             with mock.patch.dict(
-                os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}
+                os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
             ):
                 assert google.auth.transport.grpc.SslCredentials().ssl_credentials
 
@@ -431,7 +438,9 @@ class TestSslCredentials(object):
             None,
         )
 
-        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+        with mock.patch.dict(
+            os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
+        ):
             ssl_credentials = google.auth.transport.grpc.SslCredentials()
 
         assert ssl_credentials.ssl_credentials is not None

--- a/tests/transport/test_grpc.py
+++ b/tests/transport/test_grpc.py
@@ -139,9 +139,11 @@ class TestSecureAuthorizedChannel(object):
             None,
         )
 
-        channel = google.auth.transport.grpc.secure_authorized_channel(
-            credentials, request, target, options=mock.sentinel.options
-        )
+        channel = None
+        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+            channel = google.auth.transport.grpc.secure_authorized_channel(
+                credentials, request, target, options=mock.sentinel.options
+            )
 
         # Check the auth plugin construction.
         auth_plugin = metadata_call_credentials.call_args[0][0]
@@ -153,6 +155,49 @@ class TestSecureAuthorizedChannel(object):
         ssl_channel_credentials.assert_called_once_with(
             certificate_chain=PUBLIC_CERT_BYTES, private_key=PRIVATE_KEY_BYTES
         )
+
+        # Check the composite credentials call.
+        composite_channel_credentials.assert_called_once_with(
+            ssl_channel_credentials.return_value, metadata_call_credentials.return_value
+        )
+
+        # Check the channel call.
+        secure_channel.assert_called_once_with(
+            target,
+            composite_channel_credentials.return_value,
+            options=mock.sentinel.options,
+        )
+        assert channel == secure_channel.return_value
+
+    @mock.patch("google.auth.transport.grpc.SslCredentials", autospec=True)
+    def test_secure_authorized_channel_adc_without_client_cert_env(
+        self,
+        ssl_credentials_adc_method,
+        secure_channel,
+        ssl_channel_credentials,
+        metadata_call_credentials,
+        composite_channel_credentials,
+        get_client_ssl_credentials,
+    ):
+        # Test client cert won't be used if GOOGLE_API_USE_CLIENT_CERTIFICATE
+        # environment variable is not set.
+        credentials = CredentialsStub()
+        request = mock.create_autospec(transport.Request)
+        target = "example.com:80"
+
+        channel = google.auth.transport.grpc.secure_authorized_channel(
+            credentials, request, target, options=mock.sentinel.options
+        )
+
+        # Check the auth plugin construction.
+        auth_plugin = metadata_call_credentials.call_args[0][0]
+        assert isinstance(auth_plugin, google.auth.transport.grpc.AuthMetadataPlugin)
+        assert auth_plugin._credentials == credentials
+        assert auth_plugin._request == request
+
+        # Check the ssl channel call.
+        ssl_channel_credentials.assert_called_once()
+        ssl_credentials_adc_method.assert_not_called()
 
         # Check the composite credentials call.
         composite_channel_credentials.assert_called_once_with(
@@ -233,9 +278,10 @@ class TestSecureAuthorizedChannel(object):
         client_cert_callback = mock.Mock()
         client_cert_callback.return_value = (PUBLIC_CERT_BYTES, PRIVATE_KEY_BYTES)
 
-        google.auth.transport.grpc.secure_authorized_channel(
-            credentials, request, target, client_cert_callback=client_cert_callback
-        )
+        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+            google.auth.transport.grpc.secure_authorized_channel(
+                credentials, request, target, client_cert_callback=client_cert_callback
+            )
 
         client_cert_callback.assert_called_once()
 
@@ -273,11 +319,47 @@ class TestSecureAuthorizedChannel(object):
         client_cert_callback.side_effect = Exception("callback exception")
 
         with pytest.raises(Exception) as excinfo:
-            google.auth.transport.grpc.secure_authorized_channel(
-                credentials, request, target, client_cert_callback=client_cert_callback
-            )
+            with mock.patch.dict(
+                os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}
+            ):
+                google.auth.transport.grpc.secure_authorized_channel(
+                    credentials,
+                    request,
+                    target,
+                    client_cert_callback=client_cert_callback,
+                )
 
         assert str(excinfo.value) == "callback exception"
+
+    def test_secure_authorized_channel_cert_callback_without_client_cert_env(
+        self,
+        secure_channel,
+        ssl_channel_credentials,
+        metadata_call_credentials,
+        composite_channel_credentials,
+        get_client_ssl_credentials,
+    ):
+        # Test client cert won't be used if GOOGLE_API_USE_CLIENT_CERTIFICATE
+        # environment variable is not set.
+        credentials = mock.Mock()
+        request = mock.Mock()
+        target = "example.com:80"
+        client_cert_callback = mock.Mock()
+
+        google.auth.transport.grpc.secure_authorized_channel(
+            credentials, request, target, client_cert_callback=client_cert_callback
+        )
+
+        # Check client_cert_callback is not called because GOOGLE_API_USE_CLIENT_CERTIFICATE
+        # is not set.
+        client_cert_callback.assert_not_called()
+
+        ssl_channel_credentials.assert_called_once()
+
+        # Check the composite credentials call.
+        composite_channel_credentials.assert_called_once_with(
+            ssl_channel_credentials.return_value, metadata_call_credentials.return_value
+        )
 
 
 @mock.patch("grpc.ssl_channel_credentials", autospec=True)
@@ -299,7 +381,8 @@ class TestSslCredentials(object):
         # Mock that the metadata file doesn't exist.
         mock_check_dca_metadata_path.return_value = None
 
-        ssl_credentials = google.auth.transport.grpc.SslCredentials()
+        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+            ssl_credentials = google.auth.transport.grpc.SslCredentials()
 
         # Since no context aware metadata is found, we wouldn't call
         # get_client_ssl_credentials, and the SSL channel credentials created is
@@ -325,7 +408,10 @@ class TestSslCredentials(object):
         mock_get_client_ssl_credentials.side_effect = exceptions.ClientCertError()
 
         with pytest.raises(exceptions.MutualTLSChannelError):
-            assert google.auth.transport.grpc.SslCredentials().ssl_credentials
+            with mock.patch.dict(
+                os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}
+            ):
+                assert google.auth.transport.grpc.SslCredentials().ssl_credentials
 
     def test_get_client_ssl_credentials_success(
         self,
@@ -345,7 +431,8 @@ class TestSslCredentials(object):
             None,
         )
 
-        ssl_credentials = google.auth.transport.grpc.SslCredentials()
+        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+            ssl_credentials = google.auth.transport.grpc.SslCredentials()
 
         assert ssl_credentials.ssl_credentials is not None
         assert ssl_credentials.is_mtls
@@ -353,3 +440,20 @@ class TestSslCredentials(object):
         mock_ssl_channel_credentials.assert_called_once_with(
             certificate_chain=PUBLIC_CERT_BYTES, private_key=PRIVATE_KEY_BYTES
         )
+
+    def test_get_client_ssl_credentials_without_client_cert_env(
+        self,
+        mock_check_dca_metadata_path,
+        mock_read_dca_metadata_file,
+        mock_get_client_ssl_credentials,
+        mock_ssl_channel_credentials,
+    ):
+        # Test client cert won't be used if GOOGLE_API_USE_CLIENT_CERTIFICATE is not set.
+        ssl_credentials = google.auth.transport.grpc.SslCredentials()
+
+        assert ssl_credentials.ssl_credentials is not None
+        assert not ssl_credentials.is_mtls
+        mock_check_dca_metadata_path.assert_not_called()
+        mock_read_dca_metadata_file.assert_not_called()
+        mock_get_client_ssl_credentials.assert_not_called()
+        mock_ssl_channel_credentials.assert_called_once()

--- a/tests/transport/test_requests.py
+++ b/tests/transport/test_requests.py
@@ -25,6 +25,7 @@ import requests
 import requests.adapters
 from six.moves import http_client
 
+from google.auth import environment_vars
 from google.auth import exceptions
 import google.auth.credentials
 import google.auth.transport._mtls_helper
@@ -381,7 +382,9 @@ class TestAuthorizedSession(object):
         auth_session = google.auth.transport.requests.AuthorizedSession(
             credentials=mock.Mock()
         )
-        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+        with mock.patch.dict(
+            os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
+        ):
             auth_session.configure_mtls_channel(mock_callback)
 
         assert auth_session.is_mtls
@@ -403,7 +406,9 @@ class TestAuthorizedSession(object):
         auth_session = google.auth.transport.requests.AuthorizedSession(
             credentials=mock.Mock()
         )
-        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+        with mock.patch.dict(
+            os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
+        ):
             auth_session.configure_mtls_channel()
 
         assert auth_session.is_mtls
@@ -424,7 +429,9 @@ class TestAuthorizedSession(object):
         auth_session = google.auth.transport.requests.AuthorizedSession(
             credentials=mock.Mock()
         )
-        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+        with mock.patch.dict(
+            os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
+        ):
             auth_session.configure_mtls_channel()
 
         assert not auth_session.is_mtls
@@ -443,7 +450,7 @@ class TestAuthorizedSession(object):
         )
         with pytest.raises(exceptions.MutualTLSChannelError):
             with mock.patch.dict(
-                os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}
+                os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
             ):
                 auth_session.configure_mtls_channel()
 
@@ -452,7 +459,8 @@ class TestAuthorizedSession(object):
             sys.modules["OpenSSL"] = None
             with pytest.raises(exceptions.MutualTLSChannelError):
                 with mock.patch.dict(
-                    os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}
+                    os.environ,
+                    {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"},
                 ):
                     auth_session.configure_mtls_channel()
 

--- a/tests/transport/test_urllib3.py
+++ b/tests/transport/test_urllib3.py
@@ -21,6 +21,7 @@ import pytest
 from six.moves import http_client
 import urllib3
 
+from google.auth import environment_vars
 from google.auth import exceptions
 import google.auth.credentials
 import google.auth.transport._mtls_helper
@@ -181,7 +182,7 @@ class TestAuthorizedHttp(object):
 
         with pytest.warns(UserWarning):
             with mock.patch.dict(
-                os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}
+                os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
             ):
                 is_mtls = authed_http.configure_mtls_channel(callback)
 
@@ -206,7 +207,9 @@ class TestAuthorizedHttp(object):
             pytest.public_cert_bytes,
             pytest.private_key_bytes,
         )
-        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+        with mock.patch.dict(
+            os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
+        ):
             is_mtls = authed_http.configure_mtls_channel()
 
         assert is_mtls
@@ -227,7 +230,9 @@ class TestAuthorizedHttp(object):
         )
 
         mock_get_client_cert_and_key.return_value = (False, None, None)
-        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+        with mock.patch.dict(
+            os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
+        ):
             is_mtls = authed_http.configure_mtls_channel()
 
         assert not is_mtls
@@ -245,7 +250,7 @@ class TestAuthorizedHttp(object):
         mock_get_client_cert_and_key.side_effect = exceptions.ClientCertError()
         with pytest.raises(exceptions.MutualTLSChannelError):
             with mock.patch.dict(
-                os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}
+                os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"}
             ):
                 authed_http.configure_mtls_channel()
 
@@ -254,7 +259,8 @@ class TestAuthorizedHttp(object):
             sys.modules["OpenSSL"] = None
             with pytest.raises(exceptions.MutualTLSChannelError):
                 with mock.patch.dict(
-                    os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}
+                    os.environ,
+                    {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "True"},
                 ):
                     authed_http.configure_mtls_channel()
 

--- a/tests/transport/test_urllib3.py
+++ b/tests/transport/test_urllib3.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 
 import mock
@@ -179,7 +180,10 @@ class TestAuthorizedHttp(object):
         )
 
         with pytest.warns(UserWarning):
-            is_mtls = authed_http.configure_mtls_channel(callback)
+            with mock.patch.dict(
+                os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}
+            ):
+                is_mtls = authed_http.configure_mtls_channel(callback)
 
         assert is_mtls
         mock_make_mutual_tls_http.assert_called_once_with(
@@ -202,7 +206,8 @@ class TestAuthorizedHttp(object):
             pytest.public_cert_bytes,
             pytest.private_key_bytes,
         )
-        is_mtls = authed_http.configure_mtls_channel()
+        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+            is_mtls = authed_http.configure_mtls_channel()
 
         assert is_mtls
         mock_get_client_cert_and_key.assert_called_once()
@@ -222,7 +227,8 @@ class TestAuthorizedHttp(object):
         )
 
         mock_get_client_cert_and_key.return_value = (False, None, None)
-        is_mtls = authed_http.configure_mtls_channel()
+        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+            is_mtls = authed_http.configure_mtls_channel()
 
         assert not is_mtls
         mock_get_client_cert_and_key.assert_called_once()
@@ -238,10 +244,38 @@ class TestAuthorizedHttp(object):
 
         mock_get_client_cert_and_key.side_effect = exceptions.ClientCertError()
         with pytest.raises(exceptions.MutualTLSChannelError):
-            authed_http.configure_mtls_channel()
+            with mock.patch.dict(
+                os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}
+            ):
+                authed_http.configure_mtls_channel()
 
         mock_get_client_cert_and_key.return_value = (False, None, None)
         with mock.patch.dict("sys.modules"):
             sys.modules["OpenSSL"] = None
             with pytest.raises(exceptions.MutualTLSChannelError):
-                authed_http.configure_mtls_channel()
+                with mock.patch.dict(
+                    os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}
+                ):
+                    authed_http.configure_mtls_channel()
+
+    @mock.patch(
+        "google.auth.transport._mtls_helper.get_client_cert_and_key", autospec=True
+    )
+    def test_configure_mtls_channel_without_client_cert_env(
+        self, get_client_cert_and_key
+    ):
+        callback = mock.Mock()
+
+        authed_http = google.auth.transport.urllib3.AuthorizedHttp(
+            credentials=mock.Mock(), http=mock.Mock()
+        )
+
+        # Test the callback is not called if GOOGLE_API_USE_CLIENT_CERTIFICATE is not set.
+        is_mtls = authed_http.configure_mtls_channel(callback)
+        assert not is_mtls
+        callback.assert_not_called()
+
+        # Test ADC client cert is not used if GOOGLE_API_USE_CLIENT_CERTIFICATE is not set.
+        is_mtls = authed_http.configure_mtls_channel(callback)
+        assert not is_mtls
+        get_client_cert_and_key.assert_not_called()


### PR DESCRIPTION
Implement the GOOGLE_API_USE_CLIENT_CERTIFICATE variable from https://google.aip.dev/auth/4114. Unless users explicitly set this environment to True, we don't use the default client certificate from device (from the context_aware_metadata.json) and the user provided client certificate (via callback). 