### PR TITLE
feat: add GOOGLE_API_USE_CLIENT_CERTIFICATE support

### DIFF
--- a/docs/reference/google.auth.transport.mtls.rst
+++ b/docs/reference/google.auth.transport.mtls.rst
@@ -1,0 +1,7 @@
+google.auth.transport.mtls module
+=================================
+
+.. automodule:: google.auth.transport.mtls
+   :members:
+   :inherited-members:
+   :show-inheritance:

--- a/google/auth/environment_vars.py
+++ b/google/auth/environment_vars.py
@@ -53,3 +53,9 @@ the system falls back to the old variable.
 GCE_METADATA_IP = "GCE_METADATA_IP"
 """Environment variable providing an alternate ip:port to be used for ip-only
 GCE metadata requests."""
+
+GOOGLE_API_USE_CLIENT_CERTIFICATE = "GOOGLE_API_USE_CLIENT_CERTIFICATE"
+"""Environment variable controlling whether to use client certificate or not.
+
+The default value is false. Users have to explicitly set this value to true
+in order to use client certificate to establish a mutual TLS channel."""

--- a/system_tests/test_mtls_http.py
+++ b/system_tests/test_mtls_http.py
@@ -18,6 +18,7 @@ import time
 
 import google.auth
 import google.auth.credentials
+from google.auth import environment_vars
 from google.auth.transport import mtls
 import google.auth.transport.requests
 import google.auth.transport.urllib3
@@ -33,7 +34,8 @@ def test_requests():
     )
 
     authed_session = google.auth.transport.requests.AuthorizedSession(credentials)
-    authed_session.configure_mtls_channel()
+    with mock.patch.dict(os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "true"}):
+        authed_session.configure_mtls_channel()
 
     # If the devices has default client cert source, then a mutual TLS channel
     # is supposed to be created.
@@ -57,7 +59,8 @@ def test_urllib3():
     )
 
     authed_http = google.auth.transport.urllib3.AuthorizedHttp(credentials)
-    is_mtls = authed_http.configure_mtls_channel()
+    with mock.patch.dict(os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "true"}):
+        is_mtls = authed_http.configure_mtls_channel()
 
     # If the devices has default client cert source, then a mutual TLS channel
     # is supposed to be created.
@@ -83,9 +86,10 @@ def test_requests_with_default_client_cert_source():
     authed_session = google.auth.transport.requests.AuthorizedSession(credentials)
 
     if mtls.has_default_client_cert_source():
-        authed_session.configure_mtls_channel(
-            client_cert_callback=mtls.default_client_cert_source()
-        )
+        with mock.patch.dict(os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "true"}):
+            authed_session.configure_mtls_channel(
+                client_cert_callback=mtls.default_client_cert_source()
+            )
 
         assert authed_session.is_mtls
 
@@ -105,9 +109,10 @@ def test_urllib3_with_default_client_cert_source():
     authed_http = google.auth.transport.urllib3.AuthorizedHttp(credentials)
 
     if mtls.has_default_client_cert_source():
-        assert authed_http.configure_mtls_channel(
-            client_cert_callback=mtls.default_client_cert_source()
-        )
+        with mock.patch.dict(os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "true"}):
+            assert authed_http.configure_mtls_channel(
+                client_cert_callback=mtls.default_client_cert_source()
+            )
 
         # Sleep 1 second to avoid 503 error.
         time.sleep(1)

--- a/tests/transport/test_requests.py
+++ b/tests/transport/test_requests.py
@@ -14,6 +14,7 @@
 
 import datetime
 import functools
+import os
 import sys
 
 import freezegun
@@ -24,6 +25,7 @@ import requests
 import requests.adapters
 from six.moves import http_client
 
+from google.auth import environment_vars
 from google.auth import exceptions
 import google.auth.credentials
 import google.auth.transport._mtls_helper
@@ -380,7 +382,10 @@ class TestAuthorizedSession(object):
         auth_session = google.auth.transport.requests.AuthorizedSession(
             credentials=mock.Mock()
         )
-        auth_session.configure_mtls_channel(mock_callback)
+        with mock.patch.dict(
+            os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "true"}
+        ):
+            auth_session.configure_mtls_channel(mock_callback)
 
         assert auth_session.is_mtls
         assert isinstance(
@@ -401,7 +406,10 @@ class TestAuthorizedSession(object):
         auth_session = google.auth.transport.requests.AuthorizedSession(
             credentials=mock.Mock()
         )
-        auth_session.configure_mtls_channel()
+        with mock.patch.dict(
+            os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "true"}
+        ):
+            auth_session.configure_mtls_channel()
 
         assert auth_session.is_mtls
         assert isinstance(
@@ -421,7 +429,10 @@ class TestAuthorizedSession(object):
         auth_session = google.auth.transport.requests.AuthorizedSession(
             credentials=mock.Mock()
         )
-        auth_session.configure_mtls_channel()
+        with mock.patch.dict(
+            os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "true"}
+        ):
+            auth_session.configure_mtls_channel()
 
         assert not auth_session.is_mtls
 
@@ -438,10 +449,38 @@ class TestAuthorizedSession(object):
             credentials=mock.Mock()
         )
         with pytest.raises(exceptions.MutualTLSChannelError):
-            auth_session.configure_mtls_channel()
+            with mock.patch.dict(
+                os.environ, {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "true"}
+            ):
+                auth_session.configure_mtls_channel()
 
         mock_get_client_cert_and_key.return_value = (False, None, None)
         with mock.patch.dict("sys.modules"):
             sys.modules["OpenSSL"] = None
             with pytest.raises(exceptions.MutualTLSChannelError):
-                auth_session.configure_mtls_channel()
+                with mock.patch.dict(
+                    os.environ,
+                    {environment_vars.GOOGLE_API_USE_CLIENT_CERTIFICATE: "true"},
+                ):
+                    auth_session.configure_mtls_channel()
+
+    @mock.patch(
+        "google.auth.transport._mtls_helper.get_client_cert_and_key", autospec=True
+    )
+    def test_configure_mtls_channel_without_client_cert_env(
+        self, get_client_cert_and_key
+    ):
+        # Test client cert won't be used if GOOGLE_API_USE_CLIENT_CERTIFICATE
+        # environment variable is not set.
+        auth_session = google.auth.transport.requests.AuthorizedSession(
+            credentials=mock.Mock()
+        )
+
+        auth_session.configure_mtls_channel()
+        assert not auth_session.is_mtls
+        get_client_cert_and_key.assert_not_called()
+
+        mock_callback = mock.Mock()
+        auth_session.configure_mtls_channel(mock_callback)
+        assert not auth_session.is_mtls
+        mock_callback.assert_not_called()


### PR DESCRIPTION
Support this new env variable introduced in https://google.aip.dev/auth/4114