### PR TITLE
fix: "Revert "fix: migrate signBlob to iamcredentials.googleapis.com""

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ pylintrc.test
 pytype_output/
 
 .python-version
+.DS_Store
+cert_path
+key_path

--- a/google/auth/iam.py
+++ b/google/auth/iam.py
@@ -28,7 +28,7 @@ from google.auth import _helpers
 from google.auth import crypt
 from google.auth import exceptions
 
-_IAM_API_ROOT_URI = "https://iam.googleapis.com/v1"
+_IAM_API_ROOT_URI = "https://iamcredentials.googleapis.com/v1"
 _SIGN_BLOB_URI = _IAM_API_ROOT_URI + "/projects/-/serviceAccounts/{}:signBlob?alt=json"
 
 
@@ -71,7 +71,7 @@ class Signer(crypt.Signer):
         url = _SIGN_BLOB_URI.format(self._service_account_email)
         headers = {"Content-Type": "application/json"}
         body = json.dumps(
-            {"bytesToSign": base64.b64encode(message).decode("utf-8")}
+            {"payload": base64.b64encode(message).decode("utf-8")}
         ).encode("utf-8")
 
         self._credentials.before_request(self._request, method, url, headers)
@@ -97,4 +97,4 @@ class Signer(crypt.Signer):
     @_helpers.copy_docstring(crypt.Signer)
     def sign(self, message):
         response = self._make_signing_request(message)
-        return base64.b64decode(response["signature"])
+        return base64.b64decode(response["signedBlob"])

--- a/system_tests/test_service_account.py
+++ b/system_tests/test_service_account.py
@@ -16,6 +16,7 @@ import pytest
 
 from google.auth import _helpers
 from google.auth import exceptions
+from google.auth import iam
 from google.oauth2 import service_account
 
 
@@ -46,3 +47,19 @@ def test_refresh_success(http_request, credentials, token_info):
             "https://www.googleapis.com/auth/userinfo.profile",
         ]
     )
+
+def test_iam_signer(http_request, credentials):
+    credentials = credentials.with_scopes(
+        ["https://www.googleapis.com/auth/iam"]
+    )
+
+    # Verify iamcredentials signer.
+    signer = iam.Signer(
+        http_request,
+        credentials,
+        credentials.service_account_email
+    )
+    
+    signed_blob = signer.sign("message")
+
+    assert isinstance(signed_blob, bytes)

--- a/tests/compute_engine/test_credentials.py
+++ b/tests/compute_engine/test_credentials.py
@@ -363,11 +363,11 @@ class TestIDTokenCredentials(object):
         signature = base64.b64encode(b"some-signature").decode("utf-8")
         responses.add(
             responses.POST,
-            "https://iam.googleapis.com/v1/projects/-/serviceAccounts/"
-            "service-account@example.com:signBlob?alt=json",
+            "https://iamcredentials.googleapis.com/v1/projects/-/"
+            "serviceAccounts/service-account@example.com:signBlob?alt=json",
             status=200,
             content_type="application/json",
-            json={"keyId": "some-key-id", "signature": signature},
+            json={"keyId": "some-key-id", "signedBlob": signature},
         )
 
         id_token = "{}.{}.{}".format(
@@ -477,11 +477,11 @@ class TestIDTokenCredentials(object):
         signature = base64.b64encode(b"some-signature").decode("utf-8")
         responses.add(
             responses.POST,
-            "https://iam.googleapis.com/v1/projects/-/serviceAccounts/"
-            "service-account@example.com:signBlob?alt=json",
+            "https://iamcredentials.googleapis.com/v1/projects/-/"
+            "serviceAccounts/service-account@example.com:signBlob?alt=json",
             status=200,
             content_type="application/json",
-            json={"keyId": "some-key-id", "signature": signature},
+            json={"keyId": "some-key-id", "signedBlob": signature},
         )
 
         id_token = "{}.{}.{}".format(

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -81,7 +81,7 @@ class TestSigner(object):
     def test_sign_bytes(self):
         signature = b"DEADBEEF"
         encoded_signature = base64.b64encode(signature).decode("utf-8")
-        request = make_request(http_client.OK, data={"signature": encoded_signature})
+        request = make_request(http_client.OK, data={"signedBlob": encoded_signature})
         credentials = make_credentials()
 
         signer = iam.Signer(request, credentials, mock.sentinel.service_account_email)


### PR DESCRIPTION
Reverts the revert in googleapis/google-auth-library-python#563.  (original PR is #553) This change is safe to take now that changes have been made internally.

(Copied from #553)

> Migrate signBlob from iam.googleapis.com to iamcredentials.googleapis.com.
> 
> This API is deprecated and will be shutdown in one year.
> 
> This is used google.auth.iam.Signer.
> Added a system_test to sanity check the implementation.