### PR TITLE
fix: move aiohttp to extra as it is currently internal surface

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,11 @@ DEPENDENCIES = (
     'rsa>=3.1.4,<5; python_version >= "3.5"',
     "setuptools>=40.3.0",
     "six>=1.9.0",
-    'aiohttp >= 3.6.2, < 4.0.0dev; python_version>="3.6"',
 )
 
+extras = {
+    "aiohttp": "aiohttp >= 3.6.2, < 4.0.0dev; python_version>='3.6'",
+}
 
 with io.open("README.rst", "r") as fh:
     long_description = fh.read()

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     packages=find_packages(exclude=("tests*", "system_tests*")),
     namespace_packages=("google",),
     install_requires=DEPENDENCIES,
+    extras_require=extras,
     python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
     license="Apache 2.0",
     keywords="google auth oauth client",

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,7 @@ DEPENDENCIES = (
     "six>=1.9.0",
 )
 
-extras = {
-    "aiohttp": "aiohttp >= 3.6.2, < 4.0.0dev; python_version>='3.6'",
-}
+extras = {"aiohttp": "aiohttp >= 3.6.2, < 4.0.0dev; python_version>='3.6'"}
 
 with io.open("README.rst", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
Fix #618. Removes aiohttp from required dependencies to lessen dependency tree for google-auth.

This will need to be looked at again as more folks use aiohttp and once the surfaces goes to public visibility.