### PR TITLE
Update example in oauth2.id_token docs

### DIFF
--- a/google/oauth2/id_token.py
+++ b/google/oauth2/id_token.py
@@ -33,9 +33,6 @@ Example::
     id_info = id_token.verify_oauth2_token(
         token, request, 'my-client-id.example.com')
 
-    if id_info['iss'] != 'https://accounts.google.com':
-        raise ValueError('Wrong issuer.')
-
     userid = id_info['sub']
 
 By default, this will re-fetch certificates for each verification. Because


### PR DESCRIPTION
Since c05b8b5 oauth2.id_token.verify_oauth2_token handles the issuer
check itself, so remove this redundant check from the docs.