### PR TITLE
fix: avoid losing the original _include_email parameter in impersonated credentials

### DIFF
--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -341,6 +341,7 @@ class IDTokenCredentials(credentials.CredentialsWithQuotaProject):
         return self.__class__(
             target_credentials=self._target_credentials,
             target_audience=target_audience,
+            include_email=self._include_email,
             quota_project_id=self._quota_project_id,
         )
 
@@ -348,6 +349,7 @@ class IDTokenCredentials(credentials.CredentialsWithQuotaProject):
         return self.__class__(
             target_credentials=self._target_credentials,
             target_audience=target_audience,
+            include_email=self._include_email,
             quota_project_id=self._quota_project_id,
         )
 

--- a/tests/test_impersonated_credentials.py
+++ b/tests/test_impersonated_credentials.py
@@ -368,12 +368,13 @@ class TestImpersonatedCredentials(object):
         assert not credentials.expired
 
         id_creds = impersonated_credentials.IDTokenCredentials(
-            credentials, target_audience=target_audience
+            credentials, target_audience=target_audience, include_email=True
         )
         id_creds = id_creds.from_credentials(target_credentials=credentials)
         id_creds.refresh(request)
 
         assert id_creds.token == ID_TOKEN_DATA
+        assert id_creds._include_email is True
 
     def test_id_token_with_target_audience(
         self, mock_donor_credentials, mock_authorizedsession_idtoken
@@ -396,12 +397,15 @@ class TestImpersonatedCredentials(object):
         assert credentials.valid
         assert not credentials.expired
 
-        id_creds = impersonated_credentials.IDTokenCredentials(credentials)
+        id_creds = impersonated_credentials.IDTokenCredentials(
+            credentials, include_email=True
+        )
         id_creds = id_creds.with_target_audience(target_audience=target_audience)
         id_creds.refresh(request)
 
         assert id_creds.token == ID_TOKEN_DATA
         assert id_creds.expiry == datetime.datetime.fromtimestamp(ID_TOKEN_EXPIRY)
+        assert id_creds._include_email is True
 
     def test_id_token_invalid_cred(
         self, mock_donor_credentials, mock_authorizedsession_idtoken


### PR DESCRIPTION
In `IDTokenCredentials.with_target_audience()`, `IDTokenCredentials.from_credentials()`, don't discard the original `self._include_email` parameter of the original credentials instance.