### PR TITLE
feat: add custom scopes for access tokens from the metadata service

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -274,10 +274,11 @@ def default(scopes=None, request=None, quota_project_id=None):
             gcloud config set project
 
     3. If the application is running in the `App Engine standard environment`_
-       then the credentials and project ID from the `App Identity Service`_
-       are used.
-    4. If the application is running in `Compute Engine`_ or the
-       `App Engine flexible environment`_ then the credentials and project ID
+       (first generation) then the credentials and project ID from the
+       `App Identity Service`_ are used.
+    4. If the application is running in `Compute Engine`_ or `Cloud Run`_ or
+       the `App Engine flexible environment`_ or the `App Engine standard
+       environment`_ (second generation) then the credentials and project ID
        are obtained from the `Metadata Service`_.
     5. If no credentials are found,
        :class:`~google.auth.exceptions.DefaultCredentialsError` will be raised.
@@ -293,6 +294,7 @@ def default(scopes=None, request=None, quota_project_id=None):
             /appengine/flexible
     .. _Metadata Service: https://cloud.google.com/compute/docs\
             /storing-retrieving-metadata
+    .. _Cloud Run: https://cloud.google.com/run
 
     Example::
 

--- a/google/auth/_default_async.py
+++ b/google/auth/_default_async.py
@@ -187,10 +187,11 @@ def default_async(scopes=None, request=None, quota_project_id=None):
             gcloud config set project
 
     3. If the application is running in the `App Engine standard environment`_
-       then the credentials and project ID from the `App Identity Service`_
-       are used.
-    4. If the application is running in `Compute Engine`_ or the
-       `App Engine flexible environment`_ then the credentials and project ID
+       (first generation) then the credentials and project ID from the
+       `App Identity Service`_ are used.
+    4. If the application is running in `Compute Engine`_ or `Cloud Run`_ or
+       the `App Engine flexible environment`_ or the `App Engine standard
+       environment`_ (second generation) then the credentials and project ID
        are obtained from the `Metadata Service`_.
     5. If no credentials are found,
        :class:`~google.auth.exceptions.DefaultCredentialsError` will be raised.
@@ -206,6 +207,7 @@ def default_async(scopes=None, request=None, quota_project_id=None):
             /appengine/flexible
     .. _Metadata Service: https://cloud.google.com/compute/docs\
             /storing-retrieving-metadata
+    .. _Cloud Run: https://cloud.google.com/run
 
     Example::
 

--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -234,7 +234,7 @@ def get_service_account_info(request, service_account="default"):
     return get(request, path, params={"recursive": "true"})
 
 
-def get_service_account_token(request, service_account="default"):
+def get_service_account_token(request, service_account="default", scopes=None):
     """Get the OAuth 2.0 access token for a service account.
 
     Args:
@@ -243,7 +243,8 @@ def get_service_account_token(request, service_account="default"):
         service_account (str): The string 'default' or a service account email
             address. The determines which service account for which to acquire
             an access token.
-
+        scopes (Optional[Union[str, List[str]]]): Optional string or list of
+            strings with auth scopes.
     Returns:
         Union[str, datetime]: The access token and its expiration.
 
@@ -251,9 +252,15 @@ def get_service_account_token(request, service_account="default"):
         google.auth.exceptions.TransportError: if an error occurred while
             retrieving metadata.
     """
-    token_json = get(
-        request, "instance/service-accounts/{0}/token".format(service_account)
-    )
+    if scopes:
+        if not isinstance(scopes, str):
+            scopes = ",".join(scopes)
+        params = {"scopes": scopes}
+    else:
+        params = None
+
+    path = "instance/service-accounts/{0}/token".format(service_account)
+    token_json = get(request, path, params=params)
     token_expiry = _helpers.utcnow() + datetime.timedelta(
         seconds=token_json["expires_in"]
     )

--- a/system_tests/noxfile.py
+++ b/system_tests/noxfile.py
@@ -315,7 +315,7 @@ def default_explicit_service_account_async(session):
     session.env[EXPECT_PROJECT_ENV] = "1"
     session.install(*(TEST_DEPENDENCIES_SYNC + TEST_DEPENDENCIES_ASYNC))
     session.install(LIBRARY_DIR)
-    session.run("pytest", "system_tests_async/test_default.py", 
+    session.run("pytest", "system_tests_async/test_default.py",
     "system_tests_async/test_id_token.py")
 
 


### PR DESCRIPTION
This works for App Engine, Cloud Run and Flex. On Compute Engine you
can request custom scopes, but they are ignored.

Part of #579 

I will create a separate PR to update the user guide, which has been out-of-date for a while.

https://google-auth.readthedocs.io/en/latest/user-guide.html#compute-engine-container-engine-and-the-app-engine-flexible-environment

I've tested this on App Engine standard and Cloud Run, and using `google.auth.default(scopes=..)` works now. I tested on Compute Engine and requesting scopes has no effect, but does not raise an exception (which is expected).