### PR TITLE
fix: pin 'aoihttp < 3.7.0dev'

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,12 @@ TEST_DEPENDENCIES = [
     "grpcio",
 ]
 
-ASYNC_DEPENDENCIES = ["pytest-asyncio", "aiohttp < 3.7.0dev", "aioresponses", "asynctest"]
+ASYNC_DEPENDENCIES = [
+    "pytest-asyncio",
+    "aiohttp < 3.7.0dev",
+    "aioresponses",
+    "asynctest",
+]
 
 BLACK_VERSION = "black==19.3b0"
 BLACK_PATHS = [

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ TEST_DEPENDENCIES = [
     "grpcio",
 ]
 
-ASYNC_DEPENDENCIES = ["pytest-asyncio", "aioresponses", "asynctest"]
+ASYNC_DEPENDENCIES = ["pytest-asyncio", "aiohttp < 3.7.0dev", "aioresponses", "asynctest"]
 
 BLACK_VERSION = "black==19.3b0"
 BLACK_PATHS = [

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ DEPENDENCIES = (
     "six>=1.9.0",
 )
 
-extras = {"aiohttp": "aiohttp >= 3.6.2, < 4.0.0dev; python_version>='3.6'"}
+extras = {"aiohttp": "aiohttp >= 3.6.2, < 3.7.0dev; python_version>='3.6'"}
 
 with io.open("README.rst", "r") as fh:
     long_description = fh.read()

--- a/system_tests/noxfile.py
+++ b/system_tests/noxfile.py
@@ -168,7 +168,7 @@ def configure_cloud_sdk(session, application_default_credentials, project=False)
 
 # Test sesssions
 
-TEST_DEPENDENCIES_ASYNC = ["aiohttp", "pytest-asyncio", "nest-asyncio"]
+TEST_DEPENDENCIES_ASYNC = ["aiohttp < 3.7.0dev", "pytest-asyncio", "nest-asyncio"]
 TEST_DEPENDENCIES_SYNC = ["pytest", "requests"]
 PYTHON_VERSIONS_ASYNC = ["3.7"]
 PYTHON_VERSIONS_SYNC = ["2.7", "3.7"]


### PR DESCRIPTION
Working around breaking change in 3.7.0.  See:

https://github.com/pnuckowski/aioresponses/issues/173