### PR TITLE
feat: support self-signed jwt in requests and urllib3 transports

### DIFF
--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -44,6 +44,7 @@ import six  # pylint: disable=ungrouped-imports
 from google.auth import environment_vars
 from google.auth import exceptions
 from google.auth import transport
+from google.oauth2 import service_account
 import google.auth.transport._mtls_helper
 
 _LOGGER = logging.getLogger(__name__)
@@ -313,6 +314,9 @@ class AuthorizedSession(requests.Session):
             refreshing credentials. If not passed,
             an instance of :class:`~google.auth.transport.requests.Request`
             is created.
+        default_host (Optional[str]): A host like "pubsub.googleapis.com".
+            This is used when a self-signed JWT is created from service
+            account credentials.
     """
 
     def __init__(
@@ -322,6 +326,7 @@ class AuthorizedSession(requests.Session):
         max_refresh_attempts=transport.DEFAULT_MAX_REFRESH_ATTEMPTS,
         refresh_timeout=None,
         auth_request=None,
+        default_host=None,
     ):
         super(AuthorizedSession, self).__init__()
         self.credentials = credentials
@@ -329,6 +334,7 @@ class AuthorizedSession(requests.Session):
         self._max_refresh_attempts = max_refresh_attempts
         self._refresh_timeout = refresh_timeout
         self._is_mtls = False
+        self._default_host = default_host
 
         if auth_request is None:
             auth_request_session = requests.Session()
@@ -346,6 +352,18 @@ class AuthorizedSession(requests.Session):
         # Request instance used by internal methods (for example,
         # credentials.refresh).
         self._auth_request = auth_request
+
+        # https://google.aip.dev/auth/4111
+        # Attempt to use self-signed JWTs when a service account is used.
+        # A default host must be explicitly provided.
+        if (
+            isinstance(self.credentials, service_account.Credentials)
+            and self._default_host
+        ):
+            self.credentials._create_self_signed_jwt(
+                "https://{}/".format(self._default_host)
+            )
+
 
     def configure_mtls_channel(self, client_cert_callback=None):
         """Configure the client certificate and key for SSL connection.

--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -44,8 +44,8 @@ import six  # pylint: disable=ungrouped-imports
 from google.auth import environment_vars
 from google.auth import exceptions
 from google.auth import transport
-from google.oauth2 import service_account
 import google.auth.transport._mtls_helper
+from google.oauth2 import service_account
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -363,7 +363,6 @@ class AuthorizedSession(requests.Session):
             self.credentials._create_self_signed_jwt(
                 "https://{}/".format(self._default_host)
             )
-
 
     def configure_mtls_channel(self, client_cert_callback=None):
         """Configure the client certificate and key for SSL connection.

--- a/google/auth/transport/urllib3.py
+++ b/google/auth/transport/urllib3.py
@@ -49,6 +49,7 @@ import urllib3.exceptions  # pylint: disable=ungrouped-imports
 from google.auth import environment_vars
 from google.auth import exceptions
 from google.auth import transport
+from google.oauth2 import service_account
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -262,6 +263,9 @@ class AuthorizedHttp(urllib3.request.RequestMethods):
             retried.
         max_refresh_attempts (int): The maximum number of times to attempt to
             refresh the credentials and retry the request.
+        default_host (Optional[str]): A host like "pubsub.googleapis.com".
+            This is used when a self-signed JWT is created from service
+            account credentials.
     """
 
     def __init__(
@@ -270,6 +274,7 @@ class AuthorizedHttp(urllib3.request.RequestMethods):
         http=None,
         refresh_status_codes=transport.DEFAULT_REFRESH_STATUS_CODES,
         max_refresh_attempts=transport.DEFAULT_MAX_REFRESH_ATTEMPTS,
+        default_host=None,
     ):
         if http is None:
             self.http = _make_default_http()
@@ -281,9 +286,22 @@ class AuthorizedHttp(urllib3.request.RequestMethods):
         self.credentials = credentials
         self._refresh_status_codes = refresh_status_codes
         self._max_refresh_attempts = max_refresh_attempts
+        self._default_host = default_host
         # Request instance used by internal methods (for example,
         # credentials.refresh).
         self._request = Request(self.http)
+
+        # https://google.aip.dev/auth/4111
+        # Attempt to use self-signed JWTs when a service account is used.
+        # A default host must be explicitly provided.
+        if (
+            isinstance(self.credentials, service_account.Credentials)
+            and self._default_host
+        ):
+            self.credentials._create_self_signed_jwt(
+                "https://{}/".format(self._default_host)
+            )
+
 
         super(AuthorizedHttp, self).__init__()
 

--- a/google/auth/transport/urllib3.py
+++ b/google/auth/transport/urllib3.py
@@ -302,7 +302,6 @@ class AuthorizedHttp(urllib3.request.RequestMethods):
                 "https://{}/".format(self._default_host)
             )
 
-
         super(AuthorizedHttp, self).__init__()
 
     def configure_mtls_channel(self, client_cert_callback=None):

--- a/system_tests/noxfile.py
+++ b/system_tests/noxfile.py
@@ -294,11 +294,28 @@ def grpc(session):
 
 
 @nox.session(python=PYTHON_VERSIONS_SYNC)
+def requests(session):
+    session.install(LIBRARY_DIR)
+    session.install(*TEST_DEPENDENCIES_SYNC)
+    session.env[EXPLICIT_CREDENTIALS_ENV] = SERVICE_ACCOUNT_FILE
+    session.run("pytest", "system_tests_sync/test_requests.py")
+
+
+@nox.session(python=PYTHON_VERSIONS_SYNC)
+def urllib3(session):
+    session.install(LIBRARY_DIR)
+    session.install(*TEST_DEPENDENCIES_SYNC)
+    session.env[EXPLICIT_CREDENTIALS_ENV] = SERVICE_ACCOUNT_FILE
+    session.run("pytest", "system_tests_sync/test_requests.py")
+
+
+@nox.session(python=PYTHON_VERSIONS_SYNC)
 def mtls_http(session):
     session.install(LIBRARY_DIR)
     session.install(*TEST_DEPENDENCIES_SYNC, "pyopenssl")
     session.env[EXPLICIT_CREDENTIALS_ENV] = SERVICE_ACCOUNT_FILE
     session.run("pytest", "system_tests_sync/test_mtls_http.py")
+
 
 #ASYNC SYSTEM TESTS
 

--- a/system_tests/noxfile.py
+++ b/system_tests/noxfile.py
@@ -306,7 +306,7 @@ def urllib3(session):
     session.install(LIBRARY_DIR)
     session.install(*TEST_DEPENDENCIES_SYNC)
     session.env[EXPLICIT_CREDENTIALS_ENV] = SERVICE_ACCOUNT_FILE
-    session.run("pytest", "system_tests_sync/test_requests.py")
+    session.run("pytest", "system_tests_sync/test_urllib3.py")
 
 
 @nox.session(python=PYTHON_VERSIONS_SYNC)

--- a/system_tests/system_tests_sync/test_grpc.py
+++ b/system_tests/system_tests_sync/test_grpc.py
@@ -57,8 +57,9 @@ def test_grpc_request_with_regular_credentials_and_self_signed_jwt(http_request)
     list_topics_iter = client.list_topics(project="projects/{}".format(project_id))
     list(list_topics_iter)
     
-    # Check that self-signed JWT was created
+    # Check that self-signed JWT was created and is being used
     assert credentials._jwt_credentials is not None
+    assert credentials._jwt_credentials.token == credentials.token
 
 
 def test_grpc_request_with_jwt_credentials():

--- a/system_tests/system_tests_sync/test_requests.py
+++ b/system_tests/system_tests_sync/test_requests.py
@@ -1,0 +1,40 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import google.auth
+import google.auth.credentials
+import google.auth.transport.requests
+from google.oauth2 import service_account
+
+
+def test_authorized_session_with_service_account_and_self_signed_jwt():
+    credentials, project_id = google.auth.default()
+
+    credentials = credentials.with_scopes(
+        scopes=[],
+        default_scopes=["https://www.googleapis.com/auth/pubsub"],
+    )
+
+    session = google.auth.transport.requests.AuthorizedSession(
+        credentials=credentials, default_host="pubsub.googleapis.com"
+    )
+
+    # List Pub/Sub Topics through the REST API
+    # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/list
+    response = session.get("https://pubsub.googleapis.com/v1/projects/{}/topics".format(project_id))
+    response.raise_for_status()
+
+    # Check that self-signed JWT was created and is being used
+    assert credentials._jwt_credentials is not None
+    assert credentials._jwt_credentials.token == credentials.token

--- a/system_tests/system_tests_sync/test_urllib3.py
+++ b/system_tests/system_tests_sync/test_urllib3.py
@@ -1,0 +1,44 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import google.auth
+import google.auth.credentials
+import google.auth.transport.requests
+from google.oauth2 import service_account
+
+
+def test_authorized_session_with_service_account_and_self_signed_jwt():
+    credentials, project_id = google.auth.default()
+
+    credentials = credentials.with_scopes(
+        scopes=[],
+        default_scopes=["https://www.googleapis.com/auth/pubsub"],
+    )
+
+    http = google.auth.transport.urllib3.AuthorizedHttp(
+        credentials=credentials, default_host="pubsub.googleapis.com"
+    )
+
+    # List Pub/Sub Topics through the REST API
+    # https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/list
+    response = http.urlopen(
+        method="GET",
+        url="https://pubsub.googleapis.com/v1/projects/{}/topics".format(project_id)
+    )
+
+    assert response.status == 200
+
+    # Check that self-signed JWT was created and is being used
+    assert credentials._jwt_credentials is not None
+    assert credentials._jwt_credentials.token == credentials.token

--- a/tests/transport/test_requests.py
+++ b/tests/transport/test_requests.py
@@ -27,6 +27,7 @@ from six.moves import http_client
 
 from google.auth import environment_vars
 from google.auth import exceptions
+from google.oauth2 import service_account
 import google.auth.credentials
 import google.auth.transport._mtls_helper
 import google.auth.transport.requests
@@ -371,6 +372,28 @@ class TestAuthorizedSession(object):
             authed_session.request(
                 "GET", self.TEST_URL, timeout=60, max_allowed_time=2.9
             )
+
+    def test_authorized_session_without_default_host(self):
+        credentials = mock.create_autospec(service_account.Credentials)
+
+        authed_session = google.auth.transport.requests.AuthorizedSession(
+            credentials,
+        )
+
+        authed_session.credentials._create_self_signed_jwt.assert_not_called()
+
+    def test_authorized_session_with_default_host(self):
+        default_host = "pubsub.googleapis.com"
+        credentials = mock.create_autospec(service_account.Credentials)
+
+        authed_session = google.auth.transport.requests.AuthorizedSession(
+            credentials,
+            default_host=default_host
+        )
+
+        authed_session.credentials._create_self_signed_jwt.assert_called_once_with(
+            "https://{}/".format(default_host)
+        )
 
     def test_configure_mtls_channel_with_callback(self):
         mock_callback = mock.Mock()

--- a/tests/transport/test_requests.py
+++ b/tests/transport/test_requests.py
@@ -27,10 +27,10 @@ from six.moves import http_client
 
 from google.auth import environment_vars
 from google.auth import exceptions
-from google.oauth2 import service_account
 import google.auth.credentials
 import google.auth.transport._mtls_helper
 import google.auth.transport.requests
+from google.oauth2 import service_account
 from tests.transport import compliance
 
 
@@ -376,9 +376,7 @@ class TestAuthorizedSession(object):
     def test_authorized_session_without_default_host(self):
         credentials = mock.create_autospec(service_account.Credentials)
 
-        authed_session = google.auth.transport.requests.AuthorizedSession(
-            credentials,
-        )
+        authed_session = google.auth.transport.requests.AuthorizedSession(credentials)
 
         authed_session.credentials._create_self_signed_jwt.assert_not_called()
 
@@ -387,8 +385,7 @@ class TestAuthorizedSession(object):
         credentials = mock.create_autospec(service_account.Credentials)
 
         authed_session = google.auth.transport.requests.AuthorizedSession(
-            credentials,
-            default_host=default_host
+            credentials, default_host=default_host
         )
 
         authed_session.credentials._create_self_signed_jwt.assert_called_once_with(

--- a/tests/transport/test_urllib3.py
+++ b/tests/transport/test_urllib3.py
@@ -23,6 +23,7 @@ import urllib3
 
 from google.auth import environment_vars
 from google.auth import exceptions
+from google.oauth2 import service_account
 import google.auth.credentials
 import google.auth.transport._mtls_helper
 import google.auth.transport.urllib3
@@ -157,6 +158,27 @@ class TestAuthorizedHttp(object):
             ("GET", self.TEST_URL, None, {"authorization": "token"}, {}),
             ("GET", self.TEST_URL, None, {"authorization": "token1"}, {}),
         ]
+    
+    def test_urlopen_no_default_host(self):
+        credentials = mock.create_autospec(service_account.Credentials)
+
+        authed_http = google.auth.transport.urllib3.AuthorizedHttp(
+            credentials
+        )
+
+        authed_http.credentials._create_self_signed_jwt.assert_not_called()
+
+    def test_urlopen_with_default_host(self):
+        default_host = "pubsub.googleapis.com"
+        credentials = mock.create_autospec(service_account.Credentials)
+
+        authed_http = google.auth.transport.urllib3.AuthorizedHttp(
+            credentials, default_host=default_host
+        )
+
+        authed_http.credentials._create_self_signed_jwt.assert_called_once_with(
+            "https://{}/".format(default_host)
+        )
 
     def test_proxies(self):
         http = mock.create_autospec(urllib3.PoolManager)

--- a/tests/transport/test_urllib3.py
+++ b/tests/transport/test_urllib3.py
@@ -23,10 +23,10 @@ import urllib3
 
 from google.auth import environment_vars
 from google.auth import exceptions
-from google.oauth2 import service_account
 import google.auth.credentials
 import google.auth.transport._mtls_helper
 import google.auth.transport.urllib3
+from google.oauth2 import service_account
 from tests.transport import compliance
 
 
@@ -158,13 +158,11 @@ class TestAuthorizedHttp(object):
             ("GET", self.TEST_URL, None, {"authorization": "token"}, {}),
             ("GET", self.TEST_URL, None, {"authorization": "token1"}, {}),
         ]
-    
+
     def test_urlopen_no_default_host(self):
         credentials = mock.create_autospec(service_account.Credentials)
 
-        authed_http = google.auth.transport.urllib3.AuthorizedHttp(
-            credentials
-        )
+        authed_http = google.auth.transport.urllib3.AuthorizedHttp(credentials)
 
         authed_http.credentials._create_self_signed_jwt.assert_not_called()
 


### PR DESCRIPTION
Follow up to #665.

Allow self-signed JWT flow to be used in the `requests` and `urllib3` transports if a `default_host` is provided. I don't think any of our clients wrap the `urllib3` transport, but a good number of handwritten libraries (Storage for example) uses `AuthorizedSession` from `requests`.