### PR TITLE
feat: expose library version at `google.auth.__version`

### DIFF
--- a/google/auth/__init__.py
+++ b/google/auth/__init__.py
@@ -16,8 +16,8 @@
 
 import logging
 
-from google.auth._default import default, load_credentials_from_file
 from google.auth import version as google_auth_version
+from google.auth._default import default, load_credentials_from_file
 
 
 __version__ = google_auth_version.__version__

--- a/google/auth/version.py
+++ b/google/auth/version.py
@@ -1,10 +1,10 @@
-# Copyright 2016 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,18 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Google Auth Library for Python."""
-
-import logging
-
-from google.auth._default import default, load_credentials_from_file
-from google.auth import version as google_auth_version
-
-
-__version__ = google_auth_version.__version__
-
-
-__all__ = ["default", "load_credentials_from_file"]
-
-# Set default logging handler to avoid "No handler found" warnings.
-logging.getLogger(__name__).addHandler(logging.NullHandler())
+__version__ = "1.27.1"

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import io
+import os
 
 from setuptools import find_packages
 from setuptools import setup
@@ -37,7 +38,12 @@ extras = {
 with io.open("README.rst", "r") as fh:
     long_description = fh.read()
 
-version = "1.27.1"
+package_root = os.path.abspath(os.path.dirname(__file__))
+
+version = {}
+with open(os.path.join(package_root, "google/auth/version.py")) as fp:
+    exec(fp.read(), version)
+version = version["__version__"]
 
 setup(
     name="google-auth",


### PR DESCRIPTION
Move the version from `setup.py` to `google/auth/version.py`.  Same as https://github.com/googleapis/python-api-core/pull/80.  (see https://github.com/googleapis/python-api-core/issues/27 for motivation). This is option 3 in https://packaging.python.org/guides/single-sourcing-package-version/.

This unblocks a version check I'd like to add in https://github.com/googleapis/python-api-core/pull/134.

Usage:

```py
>>> import google.auth
>>> google.auth.__version__
'1.25.0'
```

