### PR TITLE
test: install package before tests deps in unit_prev_versions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -93,7 +93,7 @@ def unit(session):
 @nox.session(python=["2.7"])
 def unit_prev_versions(session):
     session.install(".")
-    session.install(*TEST_DEPENDENCIES) 
+    session.install(*TEST_DEPENDENCIES)
     session.run(
         "pytest", "--cov=google.auth", "--cov=google.oauth2", "--cov=tests", "tests"
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -92,8 +92,8 @@ def unit(session):
 
 @nox.session(python=["2.7"])
 def unit_prev_versions(session):
-    session.install(*TEST_DEPENDENCIES)
     session.install(".")
+    session.install(*TEST_DEPENDENCIES) 
     session.run(
         "pytest", "--cov=google.auth", "--cov=google.oauth2", "--cov=tests", "tests"
     )


### PR DESCRIPTION
One of the test dependencies appears to require `rsa`, which resulted in a `rsa` version incompatible with 2.7 being installed.

Switching the order resolves the issue (`rsa` is installed according to the requirements in `setup.py`)

https://github.com/googleapis/google-auth-library-python/blob/aeab5d07c5538f3d8cce817df24199534572b97d/setup.py#L24-L27