### PR TITLE
fix: fix aiohttp issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ DEPENDENCIES = (
 )
 
 extras = {
-    "aiohttp": "aiohttp >= 3.6.2, < 4.0.0dev; python_version>='3.6'",
+    "aiohttp": "aiohttp >= 3.6.2, < 3.7.4; python_version>='3.6'",
     "pyopenssl": "pyopenssl>=20.0.0",
 }
 


### PR DESCRIPTION
It seems the lastest `aiohttp` '3.7.4.post0' release is causing problem. 

```
_______ ERROR collecting tests_async/transport/test_aiohttp_requests.py ________
tests_async/transport/test_aiohttp_requests.py:16: in <module>
    from aioresponses import aioresponses, core
.nox/unit-3-6/lib/python3.6/site-packages/aioresponses/__init__.py:2: in <module>
    from .core import CallbackResult, aioresponses
.nox/unit-3-6/lib/python3.6/site-packages/aioresponses/core.py:23: in <module>
    from .compat import (
.nox/unit-3-6/lib/python3.6/site-packages/aioresponses/compat.py:17: in <module>
    AIOHTTP_VERSION = StrictVersion(aiohttp_version)
/usr/local/lib/python3.6/distutils/version.py:40: in __init__
    self.parse(vstring)
/usr/local/lib/python3.6/distutils/version.py:137: in parse
    raise ValueError("invalid version number '%s'" % vstring)
E   ValueError: invalid version number '3.7.4.post0'
```