### PR TITLE
test: skip aiohttp version that breaks aioresponses

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,12 @@ TEST_DEPENDENCIES = [
     "grpcio",
 ]
 
-ASYNC_DEPENDENCIES = ["pytest-asyncio", "aioresponses", "asynctest"]
+ASYNC_DEPENDENCIES = [
+    "pytest-asyncio",
+    "aioresponses",
+    "asynctest",
+    "aiohttp!=3.7.4.post0",
+]
 
 BLACK_VERSION = "black==19.3b0"
 BLACK_PATHS = [


### PR DESCRIPTION
Looks like `aioresponses` (test only dependency) is being too strict about how it parses the version: https://github.com/pnuckowski/aioresponses/issues/183