### PR TITLE
chore: prevent normalization of semver versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ version = version["__version__"]
 
 setup(
     name="google-auth",
-    version=version,
+    version=setuptools.sic(version),
     author="Google Cloud Platform",
     author_email="googleapis-packages@google.com",
     description="Google Authentication Library",

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,22 @@ import os
 
 import setuptools
 
+# Disable version normalization performed by setuptools.setup()
+# Adding this in even though it works for Python3.x, but does not
+# work for Python 2.7
+try:
+    # Try the approach of using sic(), added in setuptools 46.1.0
+    from setuptools import sic
+except ImportError:
+    # Try the approach of replacing packaging.version.Version
+    sic = lambda v: v
+    try:
+        # setuptools >=39.0.0 uses packaging from setuptools.extern
+        from setuptools.extern import packaging
+    except ImportError:
+        # setuptools <39.0.0 uses packaging from pkg_resources.extern
+        from pkg_resources.extern import packaging
+    packaging.version.Version = packaging.version.LegacyVersion
 
 DEPENDENCIES = (
     "cachetools>=2.0.0,<5.0",
@@ -47,7 +63,7 @@ version = version["__version__"]
 
 setuptools.setup(
     name="google-auth",
-    version=setuptools.sic(version),
+    version=sic(version),
     author="Google Cloud Platform",
     author_email="googleapis-packages@google.com",
     description="Google Authentication Library",

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@
 import io
 import os
 
-from setuptools import find_packages
-from setuptools import setup
+import setuptools
 
 
 DEPENDENCIES = (
@@ -26,7 +25,7 @@ DEPENDENCIES = (
     # https://github.com/sybrenstuvel/python-rsa/issues/152#issuecomment-643470233
     'rsa<4.6; python_version < "3.6"',
     'rsa>=3.1.4,<5; python_version >= "3.6"',
-    "setuptools>=40.3.0",
+    "setuptools>=46.1.0",
     "six>=1.9.0",
 )
 
@@ -46,7 +45,7 @@ with open(os.path.join(package_root, "google/auth/version.py")) as fp:
     exec(fp.read(), version)
 version = version["__version__"]
 
-setup(
+setuptools.setup(
     name="google-auth",
     version=setuptools.sic(version),
     author="Google Cloud Platform",
@@ -54,7 +53,7 @@ setup(
     description="Google Authentication Library",
     long_description=long_description,
     url="https://github.com/googleapis/google-auth-library-python",
-    packages=find_packages(exclude=("tests*", "system_tests*")),
+    packages=setuptools.find_packages(exclude=("tests*", "system_tests*")),
     namespace_packages=("google",),
     install_requires=DEPENDENCIES,
     extras_require=extras,

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ DEPENDENCIES = (
     # https://github.com/sybrenstuvel/python-rsa/issues/152#issuecomment-643470233
     'rsa<4.6; python_version < "3.6"',
     'rsa>=3.1.4,<5; python_version >= "3.6"',
-    "setuptools>=46.1.0",
+    "setuptools>=40.3.0",
     "six>=1.9.0",
 )
 


### PR DESCRIPTION
When there is a patch version added to semver versioning, setuptools.setup(version) will normalize the versioning from `-patch` to `.patch` which is not correct SEMVER versioning. The added feature with setuptools.sic(version) will prevent this from happening.