### PR TITLE
fix: enforce constraints during unit tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,7 @@ DEPENDENCIES = (
 extras = {
     "aiohttp": [
         "aiohttp >= 3.6.2, < 4.0.0dev; python_version>='3.6'",
-        "requests >= 2.18.0, < 3.0.0dev",
-        "urllib3 >= 1.0.0, <2.0.0dev",
+        "requests >= 2.20.0, < 3.0.0dev",
     ],
     "pyopenssl": "pyopenssl>=20.0.0",
     "reauth": "pyu2f>=0.1.5",

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -9,8 +9,6 @@ cachetools==2.0.0
 pyasn1-modules==0.2.1
 setuptools==40.3.0
 six==1.9.0
-rsa==4.6
 rsa==3.1.4
 aiohttp==3.6.2
-requests==2.18.0
-urllib3==1.0.0
+requests==2.20.0


### PR DESCRIPTION
Drop explicit pin / constraint on `urllib3`:  specific `requests` versions have very narrow pins, and ours is only likely to create conflicts.

Bump the `requests` lower bound to `2.20.0`, the lowest version for which our tests pass once constraints are being checked.

Closes #759