### PR TITLE
feat: allow scopes for self signed jwt

### DIFF
--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -525,8 +525,9 @@ class Credentials(
             "sub": self._subject,
             "iat": _helpers.datetime_to_secs(now),
             "exp": _helpers.datetime_to_secs(expiry),
-            "aud": self._audience,
         }
+        if self._audience:
+            payload.update({"aud": self._audience})
 
         payload.update(self._additional_claims)
 

--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -527,7 +527,7 @@ class Credentials(
             "exp": _helpers.datetime_to_secs(expiry),
         }
         if self._audience:
-            payload.update({"aud": self._audience})
+            payload["aud"] = self._audience
 
         payload.update(self._additional_claims)
 

--- a/google/auth/transport/grpc.py
+++ b/google/auth/transport/grpc.py
@@ -79,12 +79,9 @@ class AuthMetadataPlugin(grpc.AuthMetadataPlugin):
         # Attempt to use self-signed JWTs when a service account is used.
         # A default host must be explicitly provided since it cannot always
         # be determined from the context.service_url.
-        if (
-            isinstance(self._credentials, service_account.Credentials)
-            and self._default_host
-        ):
+        if isinstance(self._credentials, service_account.Credentials):
             self._credentials._create_self_signed_jwt(
-                "https://{}/".format(self._default_host)
+                "https://{}/".format(self._default_host) if self._default_host else None
             )
 
         self._credentials.before_request(

--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -358,13 +358,9 @@ class AuthorizedSession(requests.Session):
 
         # https://google.aip.dev/auth/4111
         # Attempt to use self-signed JWTs when a service account is used.
-        # A default host must be explicitly provided.
-        if (
-            isinstance(self.credentials, service_account.Credentials)
-            and self._default_host
-        ):
+        if isinstance(self.credentials, service_account.Credentials):
             self.credentials._create_self_signed_jwt(
-                "https://{}/".format(self._default_host)
+                "https://{}/".format(self._default_host) if self._default_host else None
             )
 
     def configure_mtls_channel(self, client_cert_callback=None):

--- a/google/auth/transport/urllib3.py
+++ b/google/auth/transport/urllib3.py
@@ -293,13 +293,9 @@ class AuthorizedHttp(urllib3.request.RequestMethods):
 
         # https://google.aip.dev/auth/4111
         # Attempt to use self-signed JWTs when a service account is used.
-        # A default host must be explicitly provided.
-        if (
-            isinstance(self.credentials, service_account.Credentials)
-            and self._default_host
-        ):
+        if isinstance(self.credentials, service_account.Credentials):
             self.credentials._create_self_signed_jwt(
-                "https://{}/".format(self._default_host)
+                "https://{}/".format(self._default_host) if self._default_host else None
             )
 
         super(AuthorizedHttp, self).__init__()

--- a/google/oauth2/service_account.py
+++ b/google/oauth2/service_account.py
@@ -432,7 +432,7 @@ class Credentials(
                     None,
                     additional_claims={"scope": " ".join(self._default_scopes)},
                 )
-        elif not self._scopes and not self._default_scopes and audience:
+        elif not self._scopes and audience:
             self._jwt_credentials = jwt.Credentials.from_signing_credentials(
                 self, audience
             )

--- a/google/oauth2/service_account.py
+++ b/google/oauth2/service_account.py
@@ -131,6 +131,7 @@ class Credentials(
         project_id=None,
         quota_project_id=None,
         additional_claims=None,
+        always_use_jwt_access=False,
     ):
         """
         Args:
@@ -149,6 +150,8 @@ class Credentials(
                 billing.
             additional_claims (Mapping[str, str]): Any additional claims for
                 the JWT assertion used in the authorization grant.
+            always_use_jwt_access (Optional[bool]): Whether self signed JWT should
+                be always used.
 
         .. note:: Typically one of the helper constructors
             :meth:`from_service_account_file` or
@@ -165,6 +168,7 @@ class Credentials(
         self._project_id = project_id
         self._quota_project_id = quota_project_id
         self._token_uri = token_uri
+        self._always_use_jwt_access = always_use_jwt_access
 
         self._jwt_credentials = None
 
@@ -266,6 +270,30 @@ class Credentials(
             project_id=self._project_id,
             quota_project_id=self._quota_project_id,
             additional_claims=self._additional_claims.copy(),
+            always_use_jwt_access=self._always_use_jwt_access,
+        )
+
+    def with_always_use_jwt_access(self, always_use_jwt_access):
+        """Create a copy of these credentials with the specified always_use_jwt_access value.
+
+        Args:
+            always_use_jwt_access (bool): Whether always use self signed JWT or not.
+
+        Returns:
+            google.auth.service_account.Credentials: A new credentials
+                instance.
+        """
+        return self.__class__(
+            self._signer,
+            service_account_email=self._service_account_email,
+            scopes=self._scopes,
+            default_scopes=self._default_scopes,
+            token_uri=self._token_uri,
+            subject=self._subject,
+            project_id=self._project_id,
+            quota_project_id=self._quota_project_id,
+            additional_claims=self._additional_claims.copy(),
+            always_use_jwt_access=always_use_jwt_access,
         )
 
     def with_subject(self, subject):
@@ -288,6 +316,7 @@ class Credentials(
             project_id=self._project_id,
             quota_project_id=self._quota_project_id,
             additional_claims=self._additional_claims.copy(),
+            always_use_jwt_access=self._always_use_jwt_access,
         )
 
     def with_claims(self, additional_claims):
@@ -315,6 +344,7 @@ class Credentials(
             project_id=self._project_id,
             quota_project_id=self._quota_project_id,
             additional_claims=new_additional_claims,
+            always_use_jwt_access=self._always_use_jwt_access,
         )
 
     @_helpers.copy_docstring(credentials.CredentialsWithQuotaProject)
@@ -330,6 +360,7 @@ class Credentials(
             project_id=self._project_id,
             quota_project_id=quota_project_id,
             additional_claims=self._additional_claims.copy(),
+            always_use_jwt_access=self._always_use_jwt_access,
         )
 
     def _make_authorization_grant_assertion(self):
@@ -386,8 +417,22 @@ class Credentials(
             audience (str): The service URL. ``https://[API_ENDPOINT]/``
         """
         # https://google.aip.dev/auth/4111
-        # If the user has not defined scopes, create a self-signed jwt
-        if not self.scopes:
+        if self._always_use_jwt_access:
+            if self._scopes:
+                self._jwt_credentials = jwt.Credentials.from_signing_credentials(
+                    self, None, additional_claims={"scope": " ".join(self._scopes)}
+                )
+            elif audience:
+                self._jwt_credentials = jwt.Credentials.from_signing_credentials(
+                    self, audience
+                )
+            elif self._default_scopes:
+                self._jwt_credentials = jwt.Credentials.from_signing_credentials(
+                    self,
+                    None,
+                    additional_claims={"scope": " ".join(self._default_scopes)},
+                )
+        elif not self._scopes and not self._default_scopes and audience:
             self._jwt_credentials = jwt.Credentials.from_signing_credentials(
                 self, audience
             )

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -390,6 +390,18 @@ class TestCredentials(object):
         assert new_credentials._additional_claims == self.credentials._additional_claims
         assert new_credentials._quota_project_id == self.credentials._quota_project_id
 
+    def test__make_jwt_without_audience(self):
+        cred = jwt.Credentials.from_service_account_info(
+            SERVICE_ACCOUNT_INFO.copy(),
+            subject=self.SUBJECT,
+            audience=None,
+            additional_claims={"scope": "foo bar"},
+        )
+        token, _ = cred._make_jwt()
+        payload = jwt.decode(token, PUBLIC_CERT_BYTES)
+        assert payload["scope"] == "foo bar"
+        assert "aud" not in payload
+
     def test_with_quota_project(self):
         quota_project_id = "project-foo"
 

--- a/tests/transport/test_grpc.py
+++ b/tests/transport/test_grpc.py
@@ -111,8 +111,7 @@ class TestAuthMetadataPlugin(object):
 
         plugin._get_authorization_headers(context)
 
-        # self-signed JWT should not be created when default_host is not set
-        credentials._create_self_signed_jwt.assert_not_called()
+        credentials._create_self_signed_jwt.assert_called_once_with(None)
 
     def test__get_authorization_headers_with_service_account_and_default_host(self):
         credentials = mock.create_autospec(service_account.Credentials)

--- a/tests/transport/test_requests.py
+++ b/tests/transport/test_requests.py
@@ -378,7 +378,7 @@ class TestAuthorizedSession(object):
 
         authed_session = google.auth.transport.requests.AuthorizedSession(credentials)
 
-        authed_session.credentials._create_self_signed_jwt.assert_not_called()
+        authed_session.credentials._create_self_signed_jwt.assert_called_once_with(None)
 
     def test_authorized_session_with_default_host(self):
         default_host = "pubsub.googleapis.com"

--- a/tests/transport/test_urllib3.py
+++ b/tests/transport/test_urllib3.py
@@ -164,7 +164,7 @@ class TestAuthorizedHttp(object):
 
         authed_http = google.auth.transport.urllib3.AuthorizedHttp(credentials)
 
-        authed_http.credentials._create_self_signed_jwt.assert_not_called()
+        authed_http.credentials._create_self_signed_jwt.assert_called_once_with(None)
 
     def test_urlopen_with_default_host(self):
         default_host = "pubsub.googleapis.com"


### PR DESCRIPTION
This doc implements https://google.aip.dev/auth/4111. Internal doc: go/yoshi-self-signed-jwt-phase-2.

The main feature here is now we can use `scope` claim in self signed JWT.

This PR does the following 2 things:
(1) Add `always_use_jwt_access` property to service account credentials to allow opt-in for the feature.
(2) If `always_use_jwt_access` is True, then apply the following logic. If `alwaysUseJwtAccess` is False, the logic is the same as before; if True, then we can always use self signed jwt with scopes or audience.
```
if (alwaysUseJwtAccess):
    if (scope):
        // create a self signed JWT with "scope" set to the scope
    else if (audience):
        // create a self signed JWT with "aud" set to the audience
    else if (defaultScope):
        // create a self signed JWT with "scope" set to the defaultScope
else:
    if (scope):
        // call OAuth token endpoint
    else if (audience):
        // create a self signed JWT with audience
    else if (defaultScope):
        // call OAuth token endpoint
```

This PR has been tested with python-kms, https://github.com/googleapis/python-kms/pull/122

The follow up PR in python microgenerator is: https://github.com/googleapis/gapic-generator-python/pull/920