### PR TITLE
feat: service account is able to use a private token endpoint

### DIFF
--- a/google/oauth2/service_account.py
+++ b/google/oauth2/service_account.py
@@ -80,6 +80,7 @@ from google.auth import jwt
 from google.oauth2 import _client
 
 _DEFAULT_TOKEN_LIFETIME_SECS = 3600  # 1 hour in seconds
+_GOOGLE_OAUTH2_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
 
 
 class Credentials(
@@ -382,7 +383,7 @@ class Credentials(
             # The issuer must be the service account email.
             "iss": self._service_account_email,
             # The audience must be the auth token endpoint's URI
-            "aud": self._token_uri,
+            "aud": _GOOGLE_OAUTH2_TOKEN_ENDPOINT,
             "scope": _helpers.scopes_to_string(self._scopes or ()),
         }
 
@@ -643,7 +644,7 @@ class IDTokenCredentials(credentials.Signing, credentials.CredentialsWithQuotaPr
             # The issuer must be the service account email.
             "iss": self.service_account_email,
             # The audience must be the auth token endpoint's URI
-            "aud": self._token_uri,
+            "aud": _GOOGLE_OAUTH2_TOKEN_ENDPOINT,
             # The target audience specifies which service the ID token is
             # intended for.
             "target_audience": self._target_audience,

--- a/tests/oauth2/test_service_account.py
+++ b/tests/oauth2/test_service_account.py
@@ -167,7 +167,7 @@ class TestCredentials(object):
         token = credentials._make_authorization_grant_assertion()
         payload = jwt.decode(token, PUBLIC_CERT_BYTES)
         assert payload["iss"] == self.SERVICE_ACCOUNT_EMAIL
-        assert payload["aud"] == self.TOKEN_URI
+        assert payload["aud"] == service_account._GOOGLE_OAUTH2_TOKEN_ENDPOINT
 
     def test__make_authorization_grant_assertion_scoped(self):
         credentials = self.make_credentials()
@@ -440,7 +440,7 @@ class TestIDTokenCredentials(object):
         token = credentials._make_authorization_grant_assertion()
         payload = jwt.decode(token, PUBLIC_CERT_BYTES)
         assert payload["iss"] == self.SERVICE_ACCOUNT_EMAIL
-        assert payload["aud"] == self.TOKEN_URI
+        assert payload["aud"] == service_account._GOOGLE_OAUTH2_TOKEN_ENDPOINT
         assert payload["target_audience"] == self.TARGET_AUDIENCE
 
     @mock.patch("google.oauth2._client.id_token_jwt_grant", autospec=True)

--- a/tests_async/oauth2/test_service_account_async.py
+++ b/tests_async/oauth2/test_service_account_async.py
@@ -152,7 +152,10 @@ class TestCredentials(object):
         token = credentials._make_authorization_grant_assertion()
         payload = jwt.decode(token, test_service_account.PUBLIC_CERT_BYTES)
         assert payload["iss"] == self.SERVICE_ACCOUNT_EMAIL
-        assert payload["aud"] == self.TOKEN_URI
+        assert (
+            payload["aud"]
+            == service_account.service_account._GOOGLE_OAUTH2_TOKEN_ENDPOINT
+        )
 
     def test__make_authorization_grant_assertion_scoped(self):
         credentials = self.make_credentials()
@@ -311,7 +314,10 @@ class TestIDTokenCredentials(object):
         token = credentials._make_authorization_grant_assertion()
         payload = jwt.decode(token, test_service_account.PUBLIC_CERT_BYTES)
         assert payload["iss"] == self.SERVICE_ACCOUNT_EMAIL
-        assert payload["aud"] == self.TOKEN_URI
+        assert (
+            payload["aud"]
+            == service_account.service_account._GOOGLE_OAUTH2_TOKEN_ENDPOINT
+        )
         assert payload["target_audience"] == self.TARGET_AUDIENCE
 
     @mock.patch("google.oauth2._client_async.id_token_jwt_grant", autospec=True)


### PR DESCRIPTION
roll forward #784 since the backend issue is fixed