### PR TITLE
fix: ADC with impersonated workforce pools

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -54,6 +54,9 @@ or "API not enabled" error. We recommend you rerun \
 added. Or you can use service accounts instead. For more information \
 about service accounts, see https://cloud.google.com/docs/authentication/"""
 
+# The subject token type used for AWS external_account credentials.
+_AWS_SUBJECT_TOKEN_TYPE = "urn:ietf:params:aws:token-type:aws4_request"
+
 
 def _warn_about_problematic_credentials(credentials):
     """Determines if the credentials are problematic.
@@ -321,14 +324,14 @@ def _get_external_account_credentials(
             is in the wrong format or is missing required information.
     """
     # There are currently 2 types of external_account credentials.
-    try:
+    if info.get("subject_token_type") == _AWS_SUBJECT_TOKEN_TYPE:
         # Check if configuration corresponds to an AWS credentials.
         from google.auth import aws
 
         credentials = aws.Credentials.from_info(
             info, scopes=scopes, default_scopes=default_scopes
         )
-    except ValueError:
+    else:
         try:
             # Check if configuration corresponds to an Identity Pool credentials.
             from google.auth import identity_pool


### PR DESCRIPTION
While service account impersonation is uncommonly used with workforce
pool external credentials, there is a bug where the following commands
raise exceptions when impersonated workforce pools are used:

- `google.auth.default()`
- `google.auth.load_credentials_from_file()`

The issue is due to `google.auth.aws.Credentials` not supporting the
`workforce_pool_user_project` argument in the constructor, unlike
`google.auth.identity_pool.Credentials`.

This was indirectly passed here:
https://github.com/googleapis/google-auth-library-python/blob/a37ff00d7afd6c7aac2d0fab29e05708bbc068be/google/auth/external_account.py#L395
Causing a TypeError to be raised (we only catch ValueError).

Updated the credential determination logic to explicitly check the
subject token type. This is a more reliable indicator instead of a
try/catch.

Increased unit test coverage in tests/test__default.py to cover these
credentials.