### PR TITLE
fix: Raise exception on error from iam_sign_endpoint

### DIFF
--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -288,7 +288,12 @@ class Credentials(credentials.CredentialsWithQuotaProject, credentials.Signing):
             url=iam_sign_endpoint, headers=headers, json=body
         )
 
-        return base64.b64decode(response.json()["signedBlob"])
+        response_data = response.json()
+
+        if "error" in response:
+          raise Exception(response_data["error"])
+
+        return base64.b64decode(response_data["signedBlob"])
 
     @property
     def signer_email(self):


### PR DESCRIPTION
Raise an exception when the sign_bytes function of an impersonated credential gets an error from the iam_sign_endpoint.

(currently, it fails with a KeyError exception)