### PR TITLE
fix: fix error in sign_bytes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ branch = True
 omit =
     */samples/*
     */conftest.py
+    */google-cloud-sdk/lib/*
 exclude_lines =
     # Re-enable the standard pragma
     pragma: NO COVER

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -290,6 +290,11 @@ class Credentials(credentials.CredentialsWithQuotaProject, credentials.Signing):
             url=iam_sign_endpoint, headers=headers, json=body
         )
 
+        if response.status_code != http_client.OK:
+            raise exceptions.TransportError(
+                "Error calling sign_bytes: {}".format(response.json())
+            )
+
         return base64.b64decode(response.json()["signedBlob"])
 
     @property

--- a/tests/test_impersonated_credentials.py
+++ b/tests/test_impersonated_credentials.py
@@ -356,7 +356,7 @@ class TestImpersonatedCredentials(object):
 
             with pytest.raises(exceptions.TransportError) as excinfo:
                 credentials.sign_bytes(b"foo")
-            assert excinfo.match("{'error': {'code': 403, 'message': 'unauthorized'}")
+            assert excinfo.match("'code': 403")
 
     def test_with_quota_project(self):
         credentials = self.make_credentials()

--- a/tests/test_impersonated_credentials.py
+++ b/tests/test_impersonated_credentials.py
@@ -345,6 +345,19 @@ class TestImpersonatedCredentials(object):
         signature = credentials.sign_bytes(b"signed bytes")
         assert signature == b"signature"
 
+    def test_sign_bytes_failure(self):
+        credentials = self.make_credentials(lifetime=None)
+
+        with mock.patch(
+            "google.auth.transport.requests.AuthorizedSession.request", autospec=True
+        ) as auth_session:
+            data = {"error": {"code": 403, "message": "unauthorized"}}
+            auth_session.return_value = MockResponse(data, http_client.FORBIDDEN)
+
+            with pytest.raises(exceptions.TransportError) as excinfo:
+                credentials.sign_bytes(b"foo")
+            assert excinfo.match("{'error': {'code': 403, 'message': 'unauthorized'}")
+
     def test_with_quota_project(self):
         credentials = self.make_credentials()
 


### PR DESCRIPTION
fix #851 

If `AuthorizedSession.post` failed, we should throw an exception instead of calling the `return base64.b64decode(response.json()["signedBlob"])` line.