### PR TITLE
feat: ADC can load a json of impersonated service account credentials generated by gcloud

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -27,16 +27,10 @@ import six
 
 from google.auth import environment_vars
 from google.auth import exceptions
+from google.auth.credentials import CredentialsType
 import google.auth.transport._http_client
 
 _LOGGER = logging.getLogger(__name__)
-
-# Valid types accepted for file-based credentials.
-_AUTHORIZED_USER_TYPE = "authorized_user"
-_SERVICE_ACCOUNT_TYPE = "service_account"
-_EXTERNAL_ACCOUNT_TYPE = "external_account"
-_IMPERSONATED_SERVICE_ACCOUNT_TYPE = "impersonated_service_account"
-_VALID_TYPES = (_AUTHORIZED_USER_TYPE, _SERVICE_ACCOUNT_TYPE, _EXTERNAL_ACCOUNT_TYPE, _IMPERSONATED_SERVICE_ACCOUNT_TYPE)
 
 # Help message when no credentials can be found.
 _HELP_MESSAGE = """\
@@ -125,7 +119,7 @@ def load_credentials_from_file(
     # credentials file or an authorized user credentials file.
     credential_type = info.get("type")
 
-    if credential_type == _AUTHORIZED_USER_TYPE:
+    if credential_type == CredentialsType.AUTHORIZED_USER_TYPE:
         from google.oauth2 import credentials
 
         try:
@@ -142,7 +136,7 @@ def load_credentials_from_file(
             _warn_about_problematic_credentials(credentials)
         return credentials, None
 
-    elif credential_type == _SERVICE_ACCOUNT_TYPE:
+    elif credential_type == CredentialsType.SERVICE_ACCOUNT_TYPE:
         from google.oauth2 import service_account
 
         try:
@@ -157,7 +151,7 @@ def load_credentials_from_file(
             credentials = credentials.with_quota_project(quota_project_id)
         return credentials, info.get("project_id")
 
-    elif credential_type == _IMPERSONATED_SERVICE_ACCOUNT_TYPE:
+    elif credential_type == CredentialsType.IMPERSONATED_SERVICE_ACCOUNT_TYPE:
         from google.auth import impersonated_credentials
 
         try:
@@ -165,11 +159,13 @@ def load_credentials_from_file(
                 info, scopes=scopes, default_scopes=default_scopes
             )
         except ValueError as caught_exc:
-            msg = "Failed to load authorized impersonated credentials from {}".format(filename)
+            msg = "Failed to load authorized impersonated credentials from {}".format(
+                filename
+            )
             new_exc = exceptions.DefaultCredentialsError(msg, caught_exc)
             six.raise_from(new_exc, caught_exc)
 
-    elif credential_type == _EXTERNAL_ACCOUNT_TYPE:
+    elif credential_type == CredentialsType.EXTERNAL_ACCOUNT_TYPE:
         credentials, project_id = _get_external_account_credentials(
             info,
             filename,
@@ -185,7 +181,9 @@ def load_credentials_from_file(
         raise exceptions.DefaultCredentialsError(
             "The file {file} does not have a valid type. "
             "Type is {type}, expected one of {valid_types}.".format(
-                file=filename, type=credential_type, valid_types=_VALID_TYPES
+                file=filename,
+                type=credential_type,
+                valid_types=CredentialsType.valid_types(),
             )
         )
 

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -159,17 +159,11 @@ def load_credentials_from_file(
 
     elif credential_type == _IMPERSONATED_SERVICE_ACCOUNT_TYPE:
         from google.auth import impersonated_credentials
-        from google.oauth2 import credentials
 
         try:
-            source_credentials = credentials.Credentials.from_authorized_user_info(
-                info.get("source_credentials"), scopes=scopes
+            return impersonated_credentials.Credentials.from_impersonated_credentials_info(
+                info, scopes=scopes, default_scopes=default_scopes
             )
-            credentials, project_id = impersonated_credentials.Credentials.from_authorized_user_info(
-                source_credentials, info, scopes=scopes
-            )
-            return credentials, project_id
-
         except ValueError as caught_exc:
             msg = "Failed to load authorized impersonated credentials from {}".format(filename)
             new_exc = exceptions.DefaultCredentialsError(msg, caught_exc)

--- a/google/auth/_default_async.py
+++ b/google/auth/_default_async.py
@@ -26,6 +26,7 @@ import six
 from google.auth import _default
 from google.auth import environment_vars
 from google.auth import exceptions
+from google.auth.credentials import CredentialsType
 
 
 def load_credentials_from_file(filename, scopes=None, quota_project_id=None):
@@ -69,7 +70,7 @@ def load_credentials_from_file(filename, scopes=None, quota_project_id=None):
     # credentials file or an authorized user credentials file.
     credential_type = info.get("type")
 
-    if credential_type == _default._AUTHORIZED_USER_TYPE:
+    if credential_type == CredentialsType.AUTHORIZED_USER_TYPE:
         from google.oauth2 import _credentials_async as credentials
 
         try:
@@ -86,7 +87,7 @@ def load_credentials_from_file(filename, scopes=None, quota_project_id=None):
             _default._warn_about_problematic_credentials(credentials)
         return credentials, None
 
-    elif credential_type == _default._SERVICE_ACCOUNT_TYPE:
+    elif credential_type == CredentialsType.SERVICE_ACCOUNT_TYPE:
         from google.oauth2 import _service_account_async as service_account
 
         try:
@@ -103,7 +104,9 @@ def load_credentials_from_file(filename, scopes=None, quota_project_id=None):
         raise exceptions.DefaultCredentialsError(
             "The file {file} does not have a valid type. "
             "Type is {type}, expected one of {valid_types}.".format(
-                file=filename, type=credential_type, valid_types=_default._VALID_TYPES
+                file=filename,
+                type=credential_type,
+                valid_types=CredentialsType.valid_types(),
             )
         )
 

--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -16,10 +16,25 @@
 """Interfaces for credentials."""
 
 import abc
+from enum import Enum
+from typing import Set
 
 import six
 
 from google.auth import _helpers
+
+
+class CredentialsType(str, Enum):
+    """Valid types accepted for file-based credentials."""
+
+    AUTHORIZED_USER_TYPE = "authorized_user"
+    SERVICE_ACCOUNT_TYPE = "service_account"
+    EXTERNAL_ACCOUNT_TYPE = "external_account"
+    IMPERSONATED_SERVICE_ACCOUNT_TYPE = "impersonated_service_account"
+
+    @classmethod
+    def valid_types(cls) -> Set[str]:
+        return set(cls._member_names_)
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -27,8 +27,8 @@ service account.
 
 import base64
 import copy
-import json
 from datetime import datetime
+import json
 
 import six
 from six.moves import http_client
@@ -44,18 +44,18 @@ _DEFAULT_TOKEN_LIFETIME_SECS = 3600  # 1 hour in seconds
 _IAM_SCOPE = ["https://www.googleapis.com/auth/iam"]
 
 _IAM_ENDPOINT = (
-        "https://iamcredentials.googleapis.com/v1/projects/-"
-        + "/serviceAccounts/{}:generateAccessToken"
+    "https://iamcredentials.googleapis.com/v1/projects/-"
+    + "/serviceAccounts/{}:generateAccessToken"
 )
 
 _IAM_SIGN_ENDPOINT = (
-        "https://iamcredentials.googleapis.com/v1/projects/-"
-        + "/serviceAccounts/{}:signBlob"
+    "https://iamcredentials.googleapis.com/v1/projects/-"
+    + "/serviceAccounts/{}:signBlob"
 )
 
 _IAM_IDTOKEN_ENDPOINT = (
-        "https://iamcredentials.googleapis.com/v1/"
-        + "projects/-/serviceAccounts/{}:generateIdToken"
+    "https://iamcredentials.googleapis.com/v1/"
+    + "projects/-/serviceAccounts/{}:generateIdToken"
 )
 
 _REFRESH_ERROR = "Unable to acquire impersonated credentials"
@@ -66,7 +66,7 @@ _DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token"
 
 
 def _make_iam_token_request(
-        request, principal, headers, body, iam_endpoint_override=None
+    request, principal, headers, body, iam_endpoint_override=None
 ):
     """Makes a request to the Google Cloud IAM service for an access token.
     Args:
@@ -183,14 +183,14 @@ class Credentials(credentials.CredentialsWithQuotaProject, credentials.Signing):
     """
 
     def __init__(
-            self,
-            source_credentials,
-            target_principal,
-            target_scopes,
-            delegates=None,
-            lifetime=_DEFAULT_TOKEN_LIFETIME_SECS,
-            quota_project_id=None,
-            iam_endpoint_override=None,
+        self,
+        source_credentials,
+        target_principal,
+        target_scopes,
+        delegates=None,
+        lifetime=_DEFAULT_TOKEN_LIFETIME_SECS,
+        quota_project_id=None,
+        iam_endpoint_override=None,
     ):
         """
         Args:
@@ -391,11 +391,11 @@ class IDTokenCredentials(credentials.CredentialsWithQuotaProject):
     """
 
     def __init__(
-            self,
-            target_credentials,
-            target_audience=None,
-            include_email=False,
-            quota_project_id=None,
+        self,
+        target_credentials,
+        target_audience=None,
+        include_email=False,
+        quota_project_id=None,
     ):
         """
         Args:
@@ -452,6 +452,7 @@ class IDTokenCredentials(credentials.CredentialsWithQuotaProject):
 
     @_helpers.copy_docstring(credentials.Credentials)
     def refresh(self, request):
+
         iam_sign_endpoint = _IAM_IDTOKEN_ENDPOINT.format(
             self._target_credentials.signer_email
         )


### PR DESCRIPTION
Proposition for #762 

It's in a "work in progress" state but I wanted to know if I was going in the right direction. I tried it out with `google-cloud-storage = "1.42.3"` and a simple script like:

```python
from google.cloud.storage import client

conn = client.Client()
print(next(conn.list_buckets()))
```

and it works.

If the `service-account` do not have the permission `storage.buckets.list`, the client returns a `403 Forbidden` as expected.

@liuchaoren what do you think?

edit: I've just signed the cla