### PR TITLE
feat: setup.py: remove rsa requirement

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -372,4 +372,4 @@ intersphinx_mapping = {
 # Autodoc config
 autoclass_content = "both"
 autodoc_member_order = "bysource"
-autodoc_mock_imports = ["grpc"]
+autodoc_mock_imports = ["grpc", "rsa"]

--- a/google/auth/crypt/_cryptography_rsa.py
+++ b/google/auth/crypt/_cryptography_rsa.py
@@ -14,7 +14,7 @@
 
 """RSA verifier and signer that use the ``cryptography`` library.
 
-This is a much faster implementation than the default (in
+This is a much faster implementation than the alternative (in
 ``google.auth.crypt._python_rsa``), which depends on the pure-Python
 ``rsa`` library.
 """

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,6 @@ from setuptools import setup
 DEPENDENCIES = (
     "cachetools>=2.0.0,<7.0",
     "pyasn1-modules>=0.2.1",
-    # rsa==4.5 is the last version to support 2.7
-    # https://github.com/sybrenstuvel/python-rsa/issues/152#issuecomment-643470233
-    "rsa>=3.1.4,<5",
 )
 
 # TODO(https://github.com/googleapis/google-auth-library-python/issues/1737): Unit test fails with


### PR DESCRIPTION
The `rsa` library is slower and not as well-maintained as the `cryptography` library. Now that we require the `cryptography` library, drop the hard requirement on the `rsa` library.


Fixes: #941