### PR TITLE
fix: Add AWS session token to metadata requests

### DIFF
--- a/google/auth/aws.py
+++ b/google/auth/aws.py
@@ -406,6 +406,7 @@ class Credentials(external_account.Credentials):
         self._cred_verification_url = credential_source.get(
             "regional_cred_verification_url"
         )
+        self._aws_token_url = credential_source.get("aws_token_url")
         self._region = None
         self._request_signer = None
         self._target_resource = audience
@@ -458,15 +459,24 @@ class Credentials(external_account.Credentials):
         Returns:
             str: The retrieved subject token.
         """
+        # Fetch the session token required to make meta data endpoint calls to aws
+        headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"}
+        if request is not None:
+            session_token = request(
+                url=self._aws_token_url,
+                method="PUT",
+                headers=headers,
+            )
+
         # Initialize the request signer if not yet initialized after determining
         # the current AWS region.
         if self._request_signer is None:
-            self._region = self._get_region(request, self._region_url)
+            self._region = self._get_region(request, self._region_url, session_token)
             self._request_signer = RequestSigner(self._region)
 
         # Retrieve the AWS security credentials needed to generate the signed
         # request.
-        aws_security_credentials = self._get_security_credentials(request)
+        aws_security_credentials = self._get_security_credentials(request, session_token)
         # Generate the signed request to AWS STS GetCallerIdentity API.
         # Use the required regional endpoint. Otherwise, the request will fail.
         request_options = self._request_signer.get_request_options(
@@ -511,7 +521,7 @@ class Credentials(external_account.Credentials):
             json.dumps(aws_signed_req, separators=(",", ":"), sort_keys=True)
         )
 
-    def _get_region(self, request, url):
+    def _get_region(self, request, url, session_token):
         """Retrieves the current AWS region from either the AWS_REGION or
         AWS_DEFAULT_REGION environment variable or from the AWS metadata server.
 
@@ -519,6 +529,8 @@ class Credentials(external_account.Credentials):
             request (google.auth.transport.Request): A callable used to make
                 HTTP requests.
             url (str): The AWS metadata server region URL.
+            session_token (str): The AWS session token to be added as a
+                header in the requests to AWS metadata endpoint.
 
         Returns:
             str: The current AWS region.
@@ -540,7 +552,13 @@ class Credentials(external_account.Credentials):
 
         if not self._region_url:
             raise exceptions.RefreshError("Unable to determine AWS region")
-        response = request(url=self._region_url, method="GET")
+
+        headers = {"X-aws-ec2-metadata-token": session_token}
+        response = request(
+            url=self._region_url,
+            method="GET",
+            headers=headers,
+        )
 
         # Support both string and bytes type response.data.
         response_body = (
@@ -558,7 +576,7 @@ class Credentials(external_account.Credentials):
         # Only the us-east-2 part should be used.
         return response_body[:-1]
 
-    def _get_security_credentials(self, request):
+    def _get_security_credentials(self, request, session_token):
         """Retrieves the AWS security credentials required for signing AWS
         requests from either the AWS security credentials environment variables
         or from the AWS metadata server.
@@ -566,6 +584,8 @@ class Credentials(external_account.Credentials):
         Args:
             request (google.auth.transport.Request): A callable used to make
                 HTTP requests.
+            session_token (str): The AWS session token to be added as a
+                header in the requests to AWS metadata endpoint.
 
         Returns:
             Mapping[str, str]: The AWS security credentials dictionary object.
@@ -591,10 +611,10 @@ class Credentials(external_account.Credentials):
             }
 
         # Get role name.
-        role_name = self._get_metadata_role_name(request)
+        role_name = self._get_metadata_role_name(request, session_token)
 
         # Get security credentials.
-        credentials = self._get_metadata_security_credentials(request, role_name)
+        credentials = self._get_metadata_security_credentials(request, role_name, session_token)
 
         return {
             "access_key_id": credentials.get("AccessKeyId"),
@@ -602,7 +622,7 @@ class Credentials(external_account.Credentials):
             "security_token": credentials.get("Token"),
         }
 
-    def _get_metadata_security_credentials(self, request, role_name):
+    def _get_metadata_security_credentials(self, request, role_name, session_token):
         """Retrieves the AWS security credentials required for signing AWS
         requests from the AWS metadata server.
 
@@ -612,6 +632,8 @@ class Credentials(external_account.Credentials):
             role_name (str): The AWS role name required by the AWS metadata
                 server security_credentials endpoint in order to return the
                 credentials.
+            session_token (str): The AWS session token to be added as a
+                header in the requests to AWS metadata endpoint.
 
         Returns:
             Mapping[str, str]: The AWS metadata server security credentials
@@ -621,7 +643,9 @@ class Credentials(external_account.Credentials):
             google.auth.exceptions.RefreshError: If an error occurs while
                 retrieving the AWS security credentials.
         """
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            "X-aws-ec2-metadata-token": session_token}
         response = request(
             url="{}/{}".format(self._security_credentials_url, role_name),
             method="GET",
@@ -644,7 +668,7 @@ class Credentials(external_account.Credentials):
 
         return credentials_response
 
-    def _get_metadata_role_name(self, request):
+    def _get_metadata_role_name(self, request, session_token):
         """Retrieves the AWS role currently attached to the current AWS
         workload by querying the AWS metadata server. This is needed for the
         AWS metadata server security credentials endpoint in order to retrieve
@@ -653,6 +677,8 @@ class Credentials(external_account.Credentials):
         Args:
             request (google.auth.transport.Request): A callable used to make
                 HTTP requests.
+            session_token (str): The AWS session token to be added as a
+                header in the requests to AWS metadata endpoint.
 
         Returns:
             str: The AWS role name.
@@ -665,7 +691,13 @@ class Credentials(external_account.Credentials):
             raise exceptions.RefreshError(
                 "Unable to determine the AWS metadata server security credentials endpoint"
             )
-        response = request(url=self._security_credentials_url, method="GET")
+
+        headers = {"X-aws-ec2-metadata-token": session_token}
+        response = request(
+            url=self._security_credentials_url,
+            method="GET",
+            headers=headers,
+        )
 
         # support both string and bytes type response.data
         response_body = (

--- a/google/auth/aws.py
+++ b/google/auth/aws.py
@@ -460,13 +460,15 @@ class Credentials(external_account.Credentials):
             str: The retrieved subject token.
         """
         # Fetch the session token required to make meta data endpoint calls to aws
-        headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"}
         if request is not None:
+            headers = {"X-aws-ec2-metadata-token-ttl-seconds": "21600"}
             session_token = request(
                 url=self._aws_token_url,
                 method="PUT",
                 headers=headers,
             )
+        else:
+            session_token = None
 
         # Initialize the request signer if not yet initialized after determining
         # the current AWS region.

--- a/google/auth/aws.py
+++ b/google/auth/aws.py
@@ -464,15 +464,13 @@ class Credentials(external_account.Credentials):
             headers = {"X-aws-ec2-metadata-token-ttl-seconds": "21600"}
 
             session_token_response = request(
-                url=self._aws_session_token_url,
-                method="PUT",
-                headers=headers,
+                url=self._aws_session_token_url, method="PUT", headers=headers
             )
 
             if session_token_response.status != 200:
                 raise exceptions.RefreshError(
-                    "Unable to retrieve AWS Session Token",
-                    session_token_response.data)
+                    "Unable to retrieve AWS Session Token", session_token_response.data
+                )
 
             session_token = session_token_response.data
         else:
@@ -486,7 +484,9 @@ class Credentials(external_account.Credentials):
 
         # Retrieve the AWS security credentials needed to generate the signed
         # request.
-        aws_security_credentials = self._get_security_credentials(request, session_token)
+        aws_security_credentials = self._get_security_credentials(
+            request, session_token
+        )
         # Generate the signed request to AWS STS GetCallerIdentity API.
         # Use the required regional endpoint. Otherwise, the request will fail.
         request_options = self._request_signer.get_request_options(
@@ -567,11 +567,7 @@ class Credentials(external_account.Credentials):
         if session_token is not None:
             headers = {"X-aws-ec2-metadata-token": session_token}
 
-        response = request(
-            url=self._region_url,
-            method="GET",
-            headers=headers,
-        )
+        response = request(url=self._region_url, method="GET", headers=headers)
 
         # Support both string and bytes type response.data.
         response_body = (
@@ -627,7 +623,9 @@ class Credentials(external_account.Credentials):
         role_name = self._get_metadata_role_name(request, session_token)
 
         # Get security credentials.
-        credentials = self._get_metadata_security_credentials(request, role_name, session_token)
+        credentials = self._get_metadata_security_credentials(
+            request, role_name, session_token
+        )
 
         return {
             "access_key_id": credentials.get("AccessKeyId"),
@@ -711,9 +709,7 @@ class Credentials(external_account.Credentials):
             headers = {"X-aws-ec2-metadata-token": session_token}
 
         response = request(
-            url=self._security_credentials_url,
-            method="GET",
-            headers=headers,
+            url=self._security_credentials_url, method="GET", headers=headers
         )
 
         # support both string and bytes type response.data

--- a/google/auth/aws.py
+++ b/google/auth/aws.py
@@ -570,7 +570,7 @@ class Credentials(external_account.Credentials):
         response = request(
             url=self._region_url,
             method="GET",
-            #headers=headers,
+            headers=headers,
         )
 
         # Support both string and bytes type response.data.

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -669,8 +669,7 @@ class TestCredentials(object):
             #AWS session token request
             session_response = mock.create_autospec(transport.Response, instance=True)
             session_response.status = session_token_status
-            if session_token_data:
-                session_response.data = session_token_data
+            session_response.data = session_token_data
             responses.append(session_response)
 
         if region_status:

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1114,6 +1114,34 @@ class TestCredentials(object):
         )
 
     @mock.patch("google.auth._helpers.utcnow")
+    def test_retrieve_subject_token_session_error_idmsv2(
+        self, utcnow
+    ):
+        utcnow.return_value = datetime.datetime.strptime(
+            self.AWS_SIGNATURE_TIME, "%Y-%m-%dT%H:%M:%SZ"
+        )
+        request = self.make_mock_request(
+            session_token_status=http_client.UNAUTHORIZED,
+            session_token_data="unauthorized",
+        )
+        credential_source_token_url = self.CREDENTIAL_SOURCE.copy()
+        credential_source_token_url["aws_session_token_url"] = AWS_SESSION_TOKEN_URL
+        credentials = self.make_credentials(credential_source=credential_source_token_url)
+
+        with pytest.raises(exceptions.RefreshError) as excinfo:
+            credentials.retrieve_subject_token(request)
+
+        assert excinfo.match(r"Unable to retrieve AWS Session Token")
+
+        # Assert session token request
+        self.assert_aws_metadata_request_kwargs(
+            request.call_args_list[0][1],
+            AWS_SESSION_TOKEN_URL,
+            {"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
+            "PUT"
+        )
+
+    @mock.patch("google.auth._helpers.utcnow")
     def test_retrieve_subject_token_success_permanent_creds_no_environment_vars(
         self, utcnow
     ):

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -666,7 +666,7 @@ class TestCredentials(object):
         """
         responses = []
         if session_token_status:
-            #AWS session token request
+            # AWS session token request
             session_response = mock.create_autospec(transport.Response, instance=True)
             session_response.status = session_token_status
             session_response.data = session_token_data
@@ -746,14 +746,16 @@ class TestCredentials(object):
         )
 
     @classmethod
-    def assert_aws_metadata_request_kwargs(cls, request_kwargs, url, headers=None, method="GET"):
+    def assert_aws_metadata_request_kwargs(
+        cls, request_kwargs, url, headers=None, method="GET"
+    ):
         assert request_kwargs["url"] == url
         # All used AWS metadata server endpoints use GET HTTP method.
         assert request_kwargs["method"] == method
         if headers:
             assert request_kwargs["headers"] == headers
         else:
-            assert "headers" not in request_kwargs or request_kwargs["headers"] == None
+            assert "headers" not in request_kwargs or request_kwargs["headers"] is None
         # None of the endpoints used require any data in request.
         assert "body" not in request_kwargs
 
@@ -983,13 +985,11 @@ class TestCredentials(object):
         )
         # Assert region request.
         self.assert_aws_metadata_request_kwargs(
-            request.call_args_list[0][1],
-            REGION_URL
+            request.call_args_list[0][1], REGION_URL
         )
         # Assert role request.
         self.assert_aws_metadata_request_kwargs(
-            request.call_args_list[1][1],
-            SECURITY_CREDS_URL
+            request.call_args_list[1][1], SECURITY_CREDS_URL
         )
         # Assert security credentials request.
         self.assert_aws_metadata_request_kwargs(
@@ -1012,8 +1012,7 @@ class TestCredentials(object):
         assert len(new_request.call_args_list) == 2
         # Assert role request.
         self.assert_aws_metadata_request_kwargs(
-            new_request.call_args_list[0][1],
-            SECURITY_CREDS_URL
+            new_request.call_args_list[0][1], SECURITY_CREDS_URL
         )
         # Assert security credentials request.
         self.assert_aws_metadata_request_kwargs(
@@ -1041,7 +1040,9 @@ class TestCredentials(object):
         )
         credential_source_token_url = self.CREDENTIAL_SOURCE.copy()
         credential_source_token_url["aws_session_token_url"] = AWS_SESSION_TOKEN_URL
-        credentials = self.make_credentials(credential_source=credential_source_token_url)
+        credentials = self.make_credentials(
+            credential_source=credential_source_token_url
+        )
 
         subject_token = credentials.retrieve_subject_token(request)
 
@@ -1057,25 +1058,28 @@ class TestCredentials(object):
             request.call_args_list[0][1],
             AWS_SESSION_TOKEN_URL,
             {"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
-            "PUT"
+            "PUT",
         )
         # Assert region request.
         self.assert_aws_metadata_request_kwargs(
             request.call_args_list[1][1],
             REGION_URL,
-            {"X-aws-ec2-metadata-token": self.AWS_SESSION_TOKEN}
+            {"X-aws-ec2-metadata-token": self.AWS_SESSION_TOKEN},
         )
         # Assert role request.
         self.assert_aws_metadata_request_kwargs(
             request.call_args_list[2][1],
             SECURITY_CREDS_URL,
-            {"X-aws-ec2-metadata-token": self.AWS_SESSION_TOKEN}
+            {"X-aws-ec2-metadata-token": self.AWS_SESSION_TOKEN},
         )
         # Assert security credentials request.
         self.assert_aws_metadata_request_kwargs(
             request.call_args_list[3][1],
             "{}/{}".format(SECURITY_CREDS_URL, self.AWS_ROLE),
-            {"Content-Type": "application/json", "X-aws-ec2-metadata-token": self.AWS_SESSION_TOKEN},
+            {
+                "Content-Type": "application/json",
+                "X-aws-ec2-metadata-token": self.AWS_SESSION_TOKEN,
+            },
         )
 
         # Retrieve subject_token again. Region should not be queried again.
@@ -1097,25 +1101,26 @@ class TestCredentials(object):
             request.call_args_list[0][1],
             AWS_SESSION_TOKEN_URL,
             {"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
-            "PUT"
+            "PUT",
         )
         # Assert role request.
         self.assert_aws_metadata_request_kwargs(
             new_request.call_args_list[1][1],
             SECURITY_CREDS_URL,
-            {"X-aws-ec2-metadata-token": self.AWS_SESSION_TOKEN}
+            {"X-aws-ec2-metadata-token": self.AWS_SESSION_TOKEN},
         )
         # Assert security credentials request.
         self.assert_aws_metadata_request_kwargs(
             new_request.call_args_list[2][1],
             "{}/{}".format(SECURITY_CREDS_URL, self.AWS_ROLE),
-            {"Content-Type": "application/json", "X-aws-ec2-metadata-token": self.AWS_SESSION_TOKEN},
+            {
+                "Content-Type": "application/json",
+                "X-aws-ec2-metadata-token": self.AWS_SESSION_TOKEN,
+            },
         )
 
     @mock.patch("google.auth._helpers.utcnow")
-    def test_retrieve_subject_token_session_error_idmsv2(
-        self, utcnow
-    ):
+    def test_retrieve_subject_token_session_error_idmsv2(self, utcnow):
         utcnow.return_value = datetime.datetime.strptime(
             self.AWS_SIGNATURE_TIME, "%Y-%m-%dT%H:%M:%SZ"
         )
@@ -1125,7 +1130,9 @@ class TestCredentials(object):
         )
         credential_source_token_url = self.CREDENTIAL_SOURCE.copy()
         credential_source_token_url["aws_session_token_url"] = AWS_SESSION_TOKEN_URL
-        credentials = self.make_credentials(credential_source=credential_source_token_url)
+        credentials = self.make_credentials(
+            credential_source=credential_source_token_url
+        )
 
         with pytest.raises(exceptions.RefreshError) as excinfo:
             credentials.retrieve_subject_token(request)
@@ -1137,7 +1144,7 @@ class TestCredentials(object):
             request.call_args_list[0][1],
             AWS_SESSION_TOKEN_URL,
             {"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
-            "PUT"
+            "PUT",
         )
 
     @mock.patch("google.auth._helpers.utcnow")
@@ -1268,8 +1275,7 @@ class TestCredentials(object):
         )
         # Region will be queried since it is not found in envvars.
         request = self.make_mock_request(
-            region_status=http_client.OK,
-            region_name=self.AWS_REGION,
+            region_status=http_client.OK, region_name=self.AWS_REGION
         )
         credentials = self.make_credentials(credential_source=self.CREDENTIAL_SOURCE)
 
@@ -1285,8 +1291,7 @@ class TestCredentials(object):
 
     def test_retrieve_subject_token_error_determining_aws_region(self):
         # Simulate error in retrieving the AWS region.
-        request = self.make_mock_request(
-            region_status=http_client.BAD_REQUEST,)
+        request = self.make_mock_request(region_status=http_client.BAD_REQUEST)
         credentials = self.make_credentials(credential_source=self.CREDENTIAL_SOURCE)
 
         with pytest.raises(exceptions.RefreshError) as excinfo:
@@ -1314,8 +1319,7 @@ class TestCredentials(object):
         credential_source = self.CREDENTIAL_SOURCE.copy()
         credential_source.pop("url")
         request = self.make_mock_request(
-            region_status=http_client.OK,
-            region_name=self.AWS_REGION,
+            region_status=http_client.OK, region_name=self.AWS_REGION
         )
         credentials = self.make_credentials(credential_source=credential_source)
 
@@ -1623,8 +1627,7 @@ class TestCredentials(object):
         assert credentials.default_scopes == SCOPES
 
     def test_refresh_with_retrieve_subject_token_error(self):
-        request = self.make_mock_request(
-            region_status=http_client.BAD_REQUEST,)
+        request = self.make_mock_request(region_status=http_client.BAD_REQUEST)
         credentials = self.make_credentials(credential_source=self.CREDENTIAL_SOURCE)
 
         with pytest.raises(exceptions.RefreshError) as excinfo:


### PR DESCRIPTION
AWS instance metadata service v2 introduced a need for session token when making call to the meta data endpoints. This change add the code to fetch the session token and add to our requests to metadata urls.