### PR TITLE
fix: Rename aws imdsv2 url field and update token lifetime

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -261,7 +261,8 @@ following requirements are needed:
   external subject tokens and exchange them for service account access tokens.
 - If you want to use IDMSv2, then below field needs to be added to credential_source
   section of credential configuration.
-  "aws_session_token_url": "http://169.254.169.254/latest/api/token"
+  "_imdsv2_session_token_url": "http://169.254.169.254/latest/api/token"
+  The gcloud create-cred-config command will be updated to support this soon.
 
 Follow the detailed instructions on how to
 `Configure Workload Identity Federation from AWS`_.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -261,8 +261,7 @@ following requirements are needed:
   external subject tokens and exchange them for service account access tokens.
 - If you want to use IDMSv2, then below field needs to be added to credential_source
   section of credential configuration.
-  "_imdsv2_session_token_url": "http://169.254.169.254/latest/api/token"
-  The gcloud create-cred-config command will be updated to support this soon.
+  "imdsv2_session_token_url": "http://169.254.169.254/latest/api/token"
 
 Follow the detailed instructions on how to
 `Configure Workload Identity Federation from AWS`_.

--- a/google/auth/aws.py
+++ b/google/auth/aws.py
@@ -406,7 +406,9 @@ class Credentials(external_account.Credentials):
         self._cred_verification_url = credential_source.get(
             "regional_cred_verification_url"
         )
-        self._aws_session_token_url = credential_source.get("aws_session_token_url")
+        self._imdsv2_session_token_url = credential_source.get(
+            "imdsv2_session_token_url"
+        )
         self._region = None
         self._request_signer = None
         self._target_resource = audience
@@ -460,32 +462,32 @@ class Credentials(external_account.Credentials):
             str: The retrieved subject token.
         """
         # Fetch the session token required to make meta data endpoint calls to aws
-        if request is not None and self._aws_session_token_url is not None:
-            headers = {"X-aws-ec2-metadata-token-ttl-seconds": "21600"}
+        if request is not None and self._imdsv2_session_token_url is not None:
+            headers = {"X-aws-ec2-metadata-token-ttl-seconds": "300"}
 
-            session_token_response = request(
-                url=self._aws_session_token_url, method="PUT", headers=headers
+            imdsv2_session_token_response = request(
+                url=self._imdsv2_session_token_url, method="PUT", headers=headers
             )
 
-            if session_token_response.status != 200:
+            if imdsv2_session_token_response.status != 200:
                 raise exceptions.RefreshError(
-                    "Unable to retrieve AWS Session Token", session_token_response.data
+                    "Unable to retrieve AWS Session Token", imdsv2_session_token_response.data
                 )
 
-            session_token = session_token_response.data
+            imdsv2_session_token = imdsv2_session_token_response.data
         else:
-            session_token = None
+            imdsv2_session_token = None
 
         # Initialize the request signer if not yet initialized after determining
         # the current AWS region.
         if self._request_signer is None:
-            self._region = self._get_region(request, self._region_url, session_token)
+            self._region = self._get_region(request, self._region_url, imdsv2_session_token)
             self._request_signer = RequestSigner(self._region)
 
         # Retrieve the AWS security credentials needed to generate the signed
         # request.
         aws_security_credentials = self._get_security_credentials(
-            request, session_token
+            request, imdsv2_session_token
         )
         # Generate the signed request to AWS STS GetCallerIdentity API.
         # Use the required regional endpoint. Otherwise, the request will fail.
@@ -531,7 +533,7 @@ class Credentials(external_account.Credentials):
             json.dumps(aws_signed_req, separators=(",", ":"), sort_keys=True)
         )
 
-    def _get_region(self, request, url, session_token):
+    def _get_region(self, request, url, imdsv2_session_token):
         """Retrieves the current AWS region from either the AWS_REGION or
         AWS_DEFAULT_REGION environment variable or from the AWS metadata server.
 
@@ -539,7 +541,7 @@ class Credentials(external_account.Credentials):
             request (google.auth.transport.Request): A callable used to make
                 HTTP requests.
             url (str): The AWS metadata server region URL.
-            session_token (str): The AWS session token to be added as a
+            imdsv2_session_token (str): The AWS IMDSv2 session token to be added as a
                 header in the requests to AWS metadata endpoint.
 
         Returns:
@@ -564,8 +566,8 @@ class Credentials(external_account.Credentials):
             raise exceptions.RefreshError("Unable to determine AWS region")
 
         headers = None
-        if session_token is not None:
-            headers = {"X-aws-ec2-metadata-token": session_token}
+        if imdsv2_session_token is not None:
+            headers = {"X-aws-ec2-metadata-token": imdsv2_session_token}
 
         response = request(url=self._region_url, method="GET", headers=headers)
 
@@ -585,7 +587,7 @@ class Credentials(external_account.Credentials):
         # Only the us-east-2 part should be used.
         return response_body[:-1]
 
-    def _get_security_credentials(self, request, session_token):
+    def _get_security_credentials(self, request, imdsv2_session_token):
         """Retrieves the AWS security credentials required for signing AWS
         requests from either the AWS security credentials environment variables
         or from the AWS metadata server.
@@ -593,7 +595,7 @@ class Credentials(external_account.Credentials):
         Args:
             request (google.auth.transport.Request): A callable used to make
                 HTTP requests.
-            session_token (str): The AWS session token to be added as a
+            imdsv2_session_token (str): The AWS IMDSv2 session token to be added as a
                 header in the requests to AWS metadata endpoint.
 
         Returns:
@@ -620,11 +622,11 @@ class Credentials(external_account.Credentials):
             }
 
         # Get role name.
-        role_name = self._get_metadata_role_name(request, session_token)
+        role_name = self._get_metadata_role_name(request, imdsv2_session_token)
 
         # Get security credentials.
         credentials = self._get_metadata_security_credentials(
-            request, role_name, session_token
+            request, role_name, imdsv2_session_token
         )
 
         return {
@@ -633,7 +635,7 @@ class Credentials(external_account.Credentials):
             "security_token": credentials.get("Token"),
         }
 
-    def _get_metadata_security_credentials(self, request, role_name, session_token):
+    def _get_metadata_security_credentials(self, request, role_name, imdsv2_session_token):
         """Retrieves the AWS security credentials required for signing AWS
         requests from the AWS metadata server.
 
@@ -643,7 +645,7 @@ class Credentials(external_account.Credentials):
             role_name (str): The AWS role name required by the AWS metadata
                 server security_credentials endpoint in order to return the
                 credentials.
-            session_token (str): The AWS session token to be added as a
+            imdsv2_session_token (str): The AWS IMDSv2 session token to be added as a
                 header in the requests to AWS metadata endpoint.
 
         Returns:
@@ -655,8 +657,8 @@ class Credentials(external_account.Credentials):
                 retrieving the AWS security credentials.
         """
         headers = {"Content-Type": "application/json"}
-        if session_token is not None:
-            headers["X-aws-ec2-metadata-token"] = session_token
+        if imdsv2_session_token is not None:
+            headers["X-aws-ec2-metadata-token"] = imdsv2_session_token
 
         response = request(
             url="{}/{}".format(self._security_credentials_url, role_name),
@@ -680,7 +682,7 @@ class Credentials(external_account.Credentials):
 
         return credentials_response
 
-    def _get_metadata_role_name(self, request, session_token):
+    def _get_metadata_role_name(self, request, imdsv2_session_token):
         """Retrieves the AWS role currently attached to the current AWS
         workload by querying the AWS metadata server. This is needed for the
         AWS metadata server security credentials endpoint in order to retrieve
@@ -689,7 +691,7 @@ class Credentials(external_account.Credentials):
         Args:
             request (google.auth.transport.Request): A callable used to make
                 HTTP requests.
-            session_token (str): The AWS session token to be added as a
+            imdsv2_session_token (str): The AWS IMDSv2 session token to be added as a
                 header in the requests to AWS metadata endpoint.
 
         Returns:
@@ -705,8 +707,8 @@ class Credentials(external_account.Credentials):
             )
 
         headers = None
-        if session_token is not None:
-            headers = {"X-aws-ec2-metadata-token": session_token}
+        if imdsv2_session_token is not None:
+            headers = {"X-aws-ec2-metadata-token": imdsv2_session_token}
 
         response = request(
             url=self._security_credentials_url, method="GET", headers=headers

--- a/google/auth/aws.py
+++ b/google/auth/aws.py
@@ -471,7 +471,8 @@ class Credentials(external_account.Credentials):
 
             if imdsv2_session_token_response.status != 200:
                 raise exceptions.RefreshError(
-                    "Unable to retrieve AWS Session Token", imdsv2_session_token_response.data
+                    "Unable to retrieve AWS Session Token",
+                    imdsv2_session_token_response.data,
                 )
 
             imdsv2_session_token = imdsv2_session_token_response.data
@@ -481,7 +482,9 @@ class Credentials(external_account.Credentials):
         # Initialize the request signer if not yet initialized after determining
         # the current AWS region.
         if self._request_signer is None:
-            self._region = self._get_region(request, self._region_url, imdsv2_session_token)
+            self._region = self._get_region(
+                request, self._region_url, imdsv2_session_token
+            )
             self._request_signer = RequestSigner(self._region)
 
         # Retrieve the AWS security credentials needed to generate the signed
@@ -635,7 +638,9 @@ class Credentials(external_account.Credentials):
             "security_token": credentials.get("Token"),
         }
 
-    def _get_metadata_security_credentials(self, request, role_name, imdsv2_session_token):
+    def _get_metadata_security_credentials(
+        self, request, role_name, imdsv2_session_token
+    ):
         """Retrieves the AWS security credentials required for signing AWS
         requests from the AWS metadata server.
 


### PR DESCRIPTION
Rename aws session token url field to "imdsv2_session_token_url" and lower the session token ttl to 5 minutes.