### PR TITLE
feat: add experimental GDCH support

### DIFF
--- a/google/oauth2/_client.py
+++ b/google/oauth2/_client.py
@@ -156,7 +156,7 @@ def _token_endpoint_request_no_throw(
                 ):
                     retry += 1
                     continue
-            except json.decoder.JSONDecodeError:
+            except ValueError:
                 response_data = response_body
             return response.status == expected_status_code, response_data
 

--- a/google/oauth2/_client.py
+++ b/google/oauth2/_client.py
@@ -44,11 +44,13 @@ def _handle_error_response(response_data):
     """Translates an error response into an exception.
 
     Args:
-        response_data (Mapping): The decoded response data.
+        response_data (Mapping | str): The decoded response data.
 
     Raises:
         google.auth.exceptions.RefreshError: The errors contained in response_data.
     """
+    if isinstance(response_data, str):
+        raise exceptions.RefreshError(response_data)
     try:
         error_details = "{}: {}".format(
             response_data["error"], response_data.get("error_description")
@@ -79,7 +81,14 @@ def _parse_expiry(response_data):
 
 
 def _token_endpoint_request_no_throw(
-    request, token_uri, body, access_token=None, use_json=False
+    request,
+    token_uri,
+    body,
+    access_token=None,
+    use_json=False,
+    cert=None,
+    verify=None,
+    expected_status_code=http_client.OK,
 ):
     """Makes a request to the OAuth 2.0 authorization server's token endpoint.
     This function doesn't throw on response errors.
@@ -93,6 +102,11 @@ def _token_endpoint_request_no_throw(
         access_token (Optional(str)): The access token needed to make the request.
         use_json (Optional(bool)): Use urlencoded format or json format for the
             content type. The default value is False.
+        cert (Optional(Tuple[str, str])): The (cert_path, key_path) tuple for mTLS.
+        verify (Optional(str)): The CA cert path for server side TLS cert verification.
+        expected_status_code (Optional(int)): The expected the status code of
+            the token response. The default value is 200. We may expect other
+            status code like 201 for GDCH credentials.
 
     Returns:
         Tuple(bool, Mapping[str, str]): A boolean indicating if the request is
@@ -112,32 +126,52 @@ def _token_endpoint_request_no_throw(
     # retry to fetch token for maximum of two times if any internal failure
     # occurs.
     while True:
-        response = request(method="POST", url=token_uri, headers=headers, body=body)
+        response = request(
+            method="POST",
+            url=token_uri,
+            headers=headers,
+            body=body,
+            cert=cert,
+            verify=verify,
+        )
         response_body = (
             response.data.decode("utf-8")
             if hasattr(response.data, "decode")
             else response.data
         )
-        response_data = json.loads(response_body)
 
-        if response.status == http_client.OK:
+        if response.status == expected_status_code:
+            # response_body should be a JSON
+            response_data = json.loads(response_body)
             break
         else:
-            error_desc = response_data.get("error_description") or ""
-            error_code = response_data.get("error") or ""
-            if (
-                any(e == "internal_failure" for e in (error_code, error_desc))
-                and retry < 1
-            ):
-                retry += 1
-                continue
-            return response.status == http_client.OK, response_data
+            # For a failed response, response_body could be a string
+            try:
+                response_data = json.loads(response_body)
+                error_desc = response_data.get("error_description") or ""
+                error_code = response_data.get("error") or ""
+                if (
+                    any(e == "internal_failure" for e in (error_code, error_desc))
+                    and retry < 1
+                ):
+                    retry += 1
+                    continue
+            except json.decoder.JSONDecodeError:
+                response_data = response_body
+            return response.status == expected_status_code, response_data
 
-    return response.status == http_client.OK, response_data
+    return response.status == expected_status_code, response_data
 
 
 def _token_endpoint_request(
-    request, token_uri, body, access_token=None, use_json=False
+    request,
+    token_uri,
+    body,
+    access_token=None,
+    use_json=False,
+    cert=None,
+    verify=None,
+    expected_status_code=http_client.OK,
 ):
     """Makes a request to the OAuth 2.0 authorization server's token endpoint.
 
@@ -150,6 +184,11 @@ def _token_endpoint_request(
         access_token (Optional(str)): The access token needed to make the request.
         use_json (Optional(bool)): Use urlencoded format or json format for the
             content type. The default value is False.
+        cert (Optional(Tuple[str, str])): The (cert_path, key_path) tuple for mTLS.
+        verify (Optional(str)): The CA cert path for server side TLS cert verification.
+        expected_status_code (Optional(int)): The expected the status code of
+            the token response. The default value is 200. We may expect other
+            status code like 201 for GDCH credentials.
 
     Returns:
         Mapping[str, str]: The JSON-decoded response data.
@@ -159,7 +198,14 @@ def _token_endpoint_request(
             an error.
     """
     response_status_ok, response_data = _token_endpoint_request_no_throw(
-        request, token_uri, body, access_token=access_token, use_json=use_json
+        request,
+        token_uri,
+        body,
+        access_token=access_token,
+        use_json=use_json,
+        cert=cert,
+        verify=verify,
+        expected_status_code=expected_status_code,
     )
     if not response_status_ok:
         _handle_error_response(response_data)

--- a/google/oauth2/gdch_credentials.py
+++ b/google/oauth2/gdch_credentials.py
@@ -1,0 +1,202 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Experimental GDCH credentials support.
+"""
+
+import base64
+
+import six
+from six.moves import http_client
+
+from google.auth import _helpers
+from google.auth import credentials
+from google.auth import exceptions
+from google.oauth2 import _client
+
+
+TOKEN_EXCHANGE_TYPE = "urn:ietf:params:oauth:token-type:token-exchange"
+ACCESS_TOKEN_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+JWT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt"
+SERVICE_ACCOUNT_TOKEN_TYPE = "urn:k8s:params:oauth:token-type:serviceaccount"
+
+
+class Credentials(credentials.CredentialsWithQuotaProject):
+    """Credentials for GDCH (`Google Distributed Cloud Hosted`_).
+
+    .. _Google Distributed Cloud Hosted:
+        https://cloud.google.com/blog/topics/hybrid-cloud/\
+            announcing-google-distributed-cloud-edge-and-hosted
+
+    Besides the constructor, a GDCH credential can be created via application
+    default credentials.
+
+    To do so, user first creates a JSON file of the
+    following format::
+
+        {
+            "type":"gdch",
+            "k8s_ca_cert_path":"<k8s ca cert pem file path>",
+            "k8s_cert_path":"<k8s cert pem file path>",
+            "k8s_key_path":"<k8s key pem file path>",
+            "k8s_token_endpoint":"<k8s token endpoint>",
+            "ais_ca_cert_path":"<AIS ca cert pem file path>",
+            "ais_token_endpoint":"<AIS token endpoint>"
+        }
+
+    Here "k8s_*" files are used to request a k8s token from k8s token endpoint
+    using mutual TLS connection. The k8s token is then sent to AIS token endpoint
+    to exchange for an AIS token. The AIS token will be used to talk to Google
+    API services.
+
+    "k8s_ca_cert_path" field is not needed if the k8s server uses well known CA.
+    "ais_ca_cert_path" field is not needed if the AIS server uses well known CA.
+    These two fields can be used for testing environments.
+
+    After the JSON file is created, set `GOOGLE_APPLICATION_CREDENTIALS` environment
+    variable to the JSON file path, then use the following code to create the
+    credential::
+
+        import google.auth
+
+        credential, _ = google.auth.default()
+        credential = credential.with_audience("<the audience>")
+
+    The audience denotes the scope the AIS token is requested, for example, it
+    could be either a k8s cluster or API service.
+    """
+
+    def __init__(
+        self,
+        k8s_ca_cert_path,
+        k8s_cert_path,
+        k8s_key_path,
+        k8s_token_endpoint,
+        ais_ca_cert_path,
+        ais_token_endpoint,
+        audience,
+        quota_project_id=None,
+    ):
+        """
+        Args:
+            k8s_ca_cert_path (str): CA cert path for k8s calls. This field is
+                useful if the specific k8s server doesn't use well known CA,
+                for instance, a testing k8s server. If the CA is well known,
+                you can pass `None` for this parameter.
+            k8s_cert_path (str): Certificate path for k8s calls
+            k8s_key_path (str): Key path for k8s calls
+            k8s_token_endpoint (str): k8s token endpoint url
+            ais_ca_cert_path (str): CA cert path for AIS token endpoint calls.
+                This field is useful if the specific AIS token server doesn't
+                uses well known CA, for instance, a testing AIS server. If the
+                CA is well known, you can pass `None` for this parameter.
+            ais_token_endpoint (str): AIS token endpoint url
+            audience (str): The audience for the requested AIS token. For
+                example, it could be a k8s cluster or API service.
+            quota_project_id (Optional[str]): The project ID used for quota
+                and billing. This project may be different from the project
+                used to create the credentials.
+        """
+        super(Credentials, self).__init__()
+        self._k8s_ca_cert_path = k8s_ca_cert_path
+        self._k8s_cert_path = k8s_cert_path
+        self._k8s_key_path = k8s_key_path
+        self._k8s_token_endpoint = k8s_token_endpoint
+        self._ais_ca_cert_path = ais_ca_cert_path
+        self._ais_token_endpoint = ais_token_endpoint
+        self._audience = audience
+        self._quota_project_id = quota_project_id
+
+    def _make_k8s_token_request(self, request):
+        # mTLS connection to k8s token endpoint to get a k8s token.
+        k8s_response_data = _client._token_endpoint_request(
+            request,
+            self._k8s_token_endpoint,
+            {},
+            None,
+            True,
+            (self._k8s_cert_path, self._k8s_key_path),
+            self._k8s_ca_cert_path,
+            http_client.CREATED,
+        )
+
+        try:
+            k8s_token = k8s_response_data["status"]["token"]
+            return k8s_token
+        except KeyError as caught_exc:
+            new_exc = exceptions.RefreshError(
+                "No access token in k8s token response.", k8s_response_data
+            )
+            six.raise_from(new_exc, caught_exc)
+
+    def _make_ais_token_request(self, k8s_token, request):
+        # base64 encode the k8s token
+        k8s_token = base64.b64encode(k8s_token.encode()).decode()
+
+        # send a request to AIS token point with the k8s token
+        ais_request_body = {
+            "grant_type": TOKEN_EXCHANGE_TYPE,
+            "audience": self._audience,
+            "requested_token_type": ACCESS_TOKEN_TOKEN_TYPE,
+            "subject_token": k8s_token,
+            "subject_token_type": SERVICE_ACCOUNT_TOKEN_TYPE,
+        }
+        ais_response_data = _client._token_endpoint_request(
+            request,
+            self._ais_token_endpoint,
+            ais_request_body,
+            None,
+            True,
+            None,
+            self._ais_ca_cert_path,
+        )
+        ais_token, _, ais_expiry, _ = _client._handle_refresh_grant_response(
+            ais_response_data, None
+        )
+        return ais_token, ais_expiry
+
+    @_helpers.copy_docstring(credentials.Credentials)
+    def refresh(self, request):
+        k8s_token = self._make_k8s_token_request(request)
+        self.token, self.expiry = self._make_ais_token_request(k8s_token, request)
+
+    def with_audience(self, audience):
+        """Create a copy of GDCH credentials with the specified audience.
+
+        Args:
+            audience (str): The intended audience for GDCH credentials.
+        """
+        return self.__class__(
+            self._k8s_ca_cert_path,
+            self._k8s_cert_path,
+            self._k8s_key_path,
+            self._k8s_token_endpoint,
+            self._ais_ca_cert_path,
+            self._ais_token_endpoint,
+            audience,
+            self._quota_project_id,
+        )
+
+    @_helpers.copy_docstring(credentials.CredentialsWithQuotaProject)
+    def with_quota_project(self, quota_project_id):
+        return self.__class__(
+            self._k8s_ca_cert_path,
+            self._k8s_cert_path,
+            self._k8s_key_path,
+            self._k8s_token_endpoint,
+            self._ais_ca_cert_path,
+            self._ais_token_endpoint,
+            self._audience,
+            quota_project_id,
+        )

--- a/tests/data/gdch.json
+++ b/tests/data/gdch.json
@@ -1,0 +1,9 @@
+{
+    "type":"gdch",
+    "k8s_ca_cert_path":"./k8s_ca_cert.pem",
+    "k8s_cert_path":"./k8s_cert.pem",
+    "k8s_key_path":"./k8s_key.pem",
+    "k8s_token_endpoint":"https://k8s_endpoint/api/v1/namespaces/sa-token-test/serviceaccounts/sa-token-user/token",
+    "ais_ca_cert_path":"./ais_ca_cert.pem",
+    "ais_token_endpoint":"https://ais_endpoint/sts/v1beta/token"
+}

--- a/tests/oauth2/test_gdch_credentials.py
+++ b/tests/oauth2/test_gdch_credentials.py
@@ -15,7 +15,7 @@
 import datetime
 
 import mock
-import pytest
+import pytest  # type: ignore
 from six.moves import http_client
 
 from google.auth import exceptions

--- a/tests/oauth2/test_gdch_credentials.py
+++ b/tests/oauth2/test_gdch_credentials.py
@@ -1,0 +1,173 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+
+import mock
+import pytest
+from six.moves import http_client
+
+from google.auth import exceptions
+from google.oauth2 import gdch_credentials
+
+
+class TestCredentials(object):
+    K8S_CA_CERT_PATH = "./k8s_ca_cert.pem"
+    K8S_CERT_PATH = "./k8s_cert.pem"
+    K8S_KEY_PATH = "./k8s_key.pem"
+    K8S_TOKEN_ENDPOINT = "https://k8s_endpoint/v1/token"
+    AIS_CA_CERT_PATH = "./ais_ca_cert.pem"
+    AIS_TOKEN_ENDPOINT = "https://k8s_endpoint/v1/token"
+    AUDIENCE = "audience_foo"
+    QUOTA_PROJECT = "project_foo"
+
+    @classmethod
+    def make_credentials(cls):
+        return gdch_credentials.Credentials(
+            cls.K8S_CA_CERT_PATH,
+            cls.K8S_CERT_PATH,
+            cls.K8S_KEY_PATH,
+            cls.K8S_TOKEN_ENDPOINT,
+            cls.AIS_CA_CERT_PATH,
+            cls.AIS_TOKEN_ENDPOINT,
+            cls.AUDIENCE,
+            cls.QUOTA_PROJECT,
+        )
+
+    def test_with_audience(self):
+        creds = self.make_credentials()
+        assert creds._audience == self.AUDIENCE
+
+        new_creds = creds.with_audience("bar")
+        assert new_creds._audience == "bar"
+
+    def test_with_quota_project(self):
+        creds = self.make_credentials()
+        assert creds.quota_project_id == self.QUOTA_PROJECT
+
+        new_creds = creds.with_quota_project("project_bar")
+        assert new_creds._quota_project_id == "project_bar"
+
+    @mock.patch("google.oauth2._client._token_endpoint_request", autospec=True)
+    def test__make_k8s_token_request(self, token_endpoint_request):
+        creds = self.make_credentials()
+        req = mock.Mock()
+
+        token_endpoint_request.return_value = {
+            "status": {
+                "token": "k8s_token",
+                "expirationTimestamp": "2022-02-22T06:51:46Z",
+            }
+        }
+        assert creds._make_k8s_token_request(req) == "k8s_token"
+        token_endpoint_request.assert_called_with(
+            req,
+            creds._k8s_token_endpoint,
+            {},
+            None,
+            True,
+            (creds._k8s_cert_path, creds._k8s_key_path),
+            creds._k8s_ca_cert_path,
+            http_client.CREATED,
+        )
+
+    @mock.patch("google.oauth2._client._token_endpoint_request", autospec=True)
+    def test__make_k8s_token_request_no_token(self, token_endpoint_request):
+        creds = self.make_credentials()
+        req = mock.Mock()
+
+        token_endpoint_request.return_value = {
+            "status": {"expirationTimestamp": "2022-02-22T06:51:46Z"}
+        }
+
+        with pytest.raises(exceptions.RefreshError) as excinfo:
+            creds._make_k8s_token_request(req)
+        assert excinfo.match("No access token in k8s token response")
+
+    @mock.patch("google.oauth2._client._token_endpoint_request", autospec=True)
+    @mock.patch("google.auth._helpers.utcnow", autospec=True)
+    def test__make_ais_token_request(self, utcnow, token_endpoint_request):
+        creds = self.make_credentials()
+        req = mock.Mock()
+
+        token_endpoint_request.return_value = {
+            "access_token": "ais_token",
+            "expires_in": 3599,
+            "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+            "token_type": "Bearer",
+        }
+        utcnow.return_value = datetime.datetime(2022, 1, 1, 0, 0, 0)
+
+        k8s_token = "k8s_token"
+        base64_k8s_token = "azhzX3Rva2Vu"
+        ais_token, ais_expiry = creds._make_ais_token_request(k8s_token, req)
+        assert ais_token == "ais_token"
+        assert ais_expiry == datetime.datetime(2022, 1, 1, 0, 59, 59)
+        token_endpoint_request.assert_called_with(
+            req,
+            creds._ais_token_endpoint,
+            {
+                "grant_type": gdch_credentials.TOKEN_EXCHANGE_TYPE,
+                "audience": creds._audience,
+                "requested_token_type": gdch_credentials.ACCESS_TOKEN_TOKEN_TYPE,
+                "subject_token": base64_k8s_token,
+                "subject_token_type": gdch_credentials.SERVICE_ACCOUNT_TOKEN_TYPE,
+            },
+            None,
+            True,
+            None,
+            creds._ais_ca_cert_path,
+        )
+
+    @mock.patch(
+        "google.oauth2.gdch_credentials.Credentials._make_k8s_token_request",
+        autospec=True,
+    )
+    @mock.patch(
+        "google.oauth2.gdch_credentials.Credentials._make_ais_token_request",
+        autospec=True,
+    )
+    def test_refresh(self, ais_token_request, k8s_token_request):
+        k8s_token_request.return_value = "k8s_token"
+        mock_expiry = mock.Mock()
+        ais_token_request.return_value = ("ais_token", mock_expiry)
+
+        creds = self.make_credentials()
+        req = mock.Mock()
+        creds.refresh(req)
+
+        k8s_token_request.assert_called_with(creds, req)
+        ais_token_request.assert_called_with(creds, "k8s_token", req)
+        assert creds.token == "ais_token"
+        assert creds.expiry == mock_expiry
+
+    @mock.patch(
+        "google.oauth2.gdch_credentials.Credentials._make_k8s_token_request",
+        autospec=True,
+    )
+    @mock.patch(
+        "google.oauth2.gdch_credentials.Credentials._make_ais_token_request",
+        autospec=True,
+    )
+    def test_before_request(self, ais_token_request, k8s_token_request):
+        ais_token_request.return_value = ("ais_token", mock.Mock())
+
+        cred = self.make_credentials()
+        headers = {}
+
+        cred.before_request(mock.Mock(), "GET", "https://example.com", headers)
+        k8s_token_request.assert_called()
+        ais_token_request.assert_called()
+        assert headers["authorization"] == "Bearer ais_token"
+        assert headers["x-goog-user-project"] == "project_foo"


### PR DESCRIPTION
internal doc: go/gdch-python-auth-lib

experimental support for GDCH (Google Distributed Cloud Hosted) credentials.

Besides the constructor, a GDCH credential can be created via application default credentials.

To do so, user first creates a JSON file of the following format::

        {
            "type":"gdch",
            "k8s_ca_cert_path":"<k8s ca cert pem file path>",
            "k8s_cert_path":"<k8s cert pem file path>",
            "k8s_key_path":"<k8s key pem file path>",
            "k8s_token_endpoint":"<k8s token endpoint>",
            "ais_ca_cert_path":"<AIS ca cert pem file path>",
            "ais_token_endpoint":"<AIS token endpoint>"
        }

Here "k8s_*" files are used to request a k8s token from k8s token endpoint using mutual TLS connection. The k8s token is then sent to AIS token endpoint to exchange for an AIS token. The AIS token will be used to talk to Google API services.

"k8s_ca_cert_path" field is not needed if the k8s server uses well known CA. "ais_ca_cert_path" field is not needed if the AIS server uses well known CA. These two fields can be used for testing environments.

After the JSON file is created, set `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the JSON file path, then use the following code to create the credential::

        import google.auth

        credential, _ = google.auth.default()
        credential = credential.with_audience("<the audience>")

The audience denotes the scope the AIS token is requested, for example, it could be either a k8s cluster or API service.