### PR TITLE
bugfix: fix async certificate decoding

### DIFF
--- a/google/oauth2/_id_token_async.py
+++ b/google/oauth2/_id_token_async.py
@@ -95,7 +95,7 @@ async def _fetch_certs(request, certs_url):
 
     data = await response.data.read()
 
-    return json.loads(json.dumps(data))
+    return json.loads(data.decode("utf-8"))
 
 
 async def verify_token(

--- a/tests_async/oauth2/test_id_token.py
+++ b/tests_async/oauth2/test_id_token.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 
 import mock
@@ -32,7 +33,9 @@ def make_request(status, data=None):
 
     if data is not None:
         response.data = mock.AsyncMock(spec=["__call__", "read"])
-        response.data.read = mock.AsyncMock(spec=["__call__"], return_value=data)
+        response.data.read = mock.AsyncMock(
+            spec=["__call__"], return_value=json.dumps(data).encode("utf-8")
+        )
 
     request = mock.AsyncMock(spec=["transport.Request"])
     request.return_value = response


### PR DESCRIPTION
The async _cert_fetch implementation was not properly decoding
certificates into a utf-8 string. This updates the code and tests to
decode the certificates into strings. 

Without this fix, the code will raise a `ValueError` exception, because the data type passed to `json.dumps` is not expected.

This resolves https://github.com/googleapis/google-auth-library-python/issues/1050.