### PR TITLE
Raise HTTP error if encountered

### DIFF
--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -433,6 +433,7 @@ class IDTokenCredentials(credentials.CredentialsWithQuotaProject):
             headers=headers,
             data=json.dumps(body).encode("utf-8"),
         )
+        response.raise_for_status()
 
         id_token = response.json()["token"]
         self.token = id_token


### PR DESCRIPTION
Currently, if the user is not authorized to make a request, there is no token in the response so the user receives a KeyError, which is less informative than the HTTPError returned from the API.

Raising the HTTP error solves this.