### PR TITLE
feat: add api_key credentials

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -479,6 +479,13 @@ def _get_gdch_service_account_credentials(filename, info):
     return credentials, info.get("project")
 
 
+def get_api_key_credentials(key):
+    """Return credentials with the given API key."""
+    from google.auth import api_key
+
+    return api_key.Credentials(key)
+
+
 def _apply_quota_project_id(credentials, quota_project_id):
     if quota_project_id:
         credentials = credentials.with_quota_project(quota_project_id)

--- a/google/auth/api_key.py
+++ b/google/auth/api_key.py
@@ -1,0 +1,75 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Google API key support.
+This module provides authentication using the `API key`_.
+.. _API key:
+    https://cloud.google.com/docs/authentication/api-keys/
+"""
+
+from google.auth import _helpers
+from google.auth import credentials
+
+
+class Credentials(credentials.Credentials):
+    """API key credentials.
+    These credentials use API key to provide authorization to applications.
+    """
+
+    def __init__(self, token):
+        """
+        Args:
+            token (str): API key string
+        Raises:
+            ValueError: If the provided API key is not a non-empty string.
+        """
+        super(Credentials, self).__init__()
+        if not token:
+            raise ValueError("Token must be a non-empty API key string")
+        self.token = token
+
+    @property
+    def expired(self):
+        return False
+
+    @property
+    def valid(self):
+        return True
+
+    @_helpers.copy_docstring(credentials.Credentials)
+    def refresh(self, request):
+        return
+
+    def apply(self, headers, token=None):
+        """Apply the API key token to the x-goog-api-key header.
+        Args:
+            headers (Mapping): The HTTP request headers.
+            token (Optional[str]): If specified, overrides the current access
+                token.
+        """
+        headers["x-goog-api-key"] = token or self.token
+
+    def before_request(self, request, method, url, headers):
+        """Performs credential-specific before request logic.
+        Refreshes the credentials if necessary, then calls :meth:`apply` to
+        apply the token to the x-goog-api-key header.
+        Args:
+            request (google.auth.transport.Request): The object used to make
+                HTTP requests.
+            method (str): The request's HTTP method or the RPC method being
+                invoked.
+            url (str): The request's URI or the RPC service's URI.
+            headers (Mapping): The request's headers.
+        """
+        self.apply(headers)

--- a/tests/test__default.py
+++ b/tests/test__default.py
@@ -19,6 +19,7 @@ import mock
 import pytest  # type: ignore
 
 from google.auth import _default
+from google.auth import api_key
 from google.auth import app_engine
 from google.auth import aws
 from google.auth import compute_engine
@@ -681,6 +682,12 @@ def test__get_gdch_service_account_credentials_invalid_format_version():
             "file_name", {"format_version": "2"}
         )
     assert excinfo.match("Failed to load GDCH service account credentials")
+
+
+def test_get_api_key_credentials():
+    creds = _default.get_api_key_credentials("api_key")
+    assert isinstance(creds, api_key.Credentials)
+    assert creds.token == "api_key"
 
 
 class _AppIdentityModule(object):

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,0 +1,45 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest  # type: ignore
+
+from google.auth import api_key
+
+
+def test_credentials_constructor():
+    with pytest.raises(ValueError) as excinfo:
+        api_key.Credentials("")
+
+    assert excinfo.match(r"Token must be a non-empty API key string")
+
+
+def test_expired_and_valid():
+    credentials = api_key.Credentials("api-key")
+
+    assert credentials.valid
+    assert credentials.token == "api-key"
+    assert not credentials.expired
+
+    credentials.refresh(None)
+    assert credentials.valid
+    assert credentials.token == "api-key"
+    assert not credentials.expired
+
+
+def test_before_request():
+    credentials = api_key.Credentials("api-key")
+    headers = {}
+
+    credentials.before_request(None, "http://example.com", "GET", headers)
+    assert headers["x-goog-api-key"] == "api-key"


### PR DESCRIPTION
This PR adds a new credential type for API key, and the `get_api_key_credentials` method needed by GAPIC clients (see [here](https://github.com/googleapis/gapic-generator-python/blob/main/gapic/templates/%25namespace/%25name_%25version/%25sub/services/%25service/client.py.j2#L353)) to enable API key support. Once this PR is released in auth lib, GAPIC clients will be able to use API key with the latest auth lib. This feature has been tested with the following sample.

```
import google.cloud.language_v1
import google.api_core.client_options

# provide api key value via client options
client = google.cloud.language_v1.LanguageServiceClient(client_options={"api_key":"FILL IN"})

request = {'document': { 'type_': 'PLAIN_TEXT', 'content': "hello" }, 'encoding_type': 'UTF8'}
response = client.analyze_sentiment(request)

print(response)
```