### PR TITLE
fix: Make OAUTH2.0 client resistant to string type 'expires_in' responses from non-compliant services

### DIFF
--- a/google/oauth2/_client.py
+++ b/google/oauth2/_client.py
@@ -120,6 +120,11 @@ def _parse_expiry(response_data):
     expires_in = response_data.get("expires_in", None)
 
     if expires_in is not None:
+        # Some services do not respect the OAUTH2.0 RFC and send expires_in as a
+        # JSON String.
+        if isinstance(expires_in, str):
+            expires_in = int(expires_in)
+
         return _helpers.utcnow() + datetime.timedelta(seconds=expires_in)
     else:
         return None

--- a/tests/oauth2/test__client.py
+++ b/tests/oauth2/test__client.py
@@ -99,9 +99,10 @@ def test__can_retry_no_retry_message(response_data):
     assert not _client._can_retry(http_client.OK, response_data)
 
 
+@pytest.mark.parametrize("mock_expires_in", [500, "500"])
 @mock.patch("google.auth._helpers.utcnow", return_value=datetime.datetime.min)
-def test__parse_expiry(unused_utcnow):
-    result = _client._parse_expiry({"expires_in": 500})
+def test__parse_expiry(unused_utcnow, mock_expires_in):
+    result = _client._parse_expiry({"expires_in": mock_expires_in})
     assert result == datetime.datetime.min + datetime.timedelta(seconds=500)
 
 


### PR DESCRIPTION
This fixes https://github.com/googleapis/google-auth-library-python/issues/1207.
