### PR TITLE
Fix: response content is empty when using cache

### DIFF
--- a/google/auth/transport/_aiohttp_requests.py
+++ b/google/auth/transport/_aiohttp_requests.py
@@ -74,7 +74,7 @@ class _CombinedResponse(transport.Response):
 
     async def raw_content(self):
         if self._raw_content is None:
-            self._raw_content = await self._response.content.read()
+            self._raw_content = await self._response.read()
         return self._raw_content
 
     async def content(self):


### PR DESCRIPTION
I am using this library in a project and found there is an issue when combined with cache.

Check the example below:
```py
import asyncio
import aiohttp
from aiohttp_client_cache import CachedSession, CacheBackend


async def main():
    request_cache = CacheBackend(expire_after=60*60)
    async with CachedSession(cache=request_cache, auto_decompress=False) as s:
    # async with aiohttp.ClientSession() as s:
        while True:
            resp = await s.request('GET', 'https://www.googleapis.com/oauth2/v1/certs')
            content = await resp.content.read()
            body = await resp.read()
            import pdb
            pdb.set_trace()

# call main() in a loop
loop = asyncio.get_event_loop()
loop.run_until_complete(main())

```

In the 3rd iteration of the loop above, `content` will be an empty string while `body` is expected. This is probably because the content stream was GCed.  Use `.read()` instead of `.content.read()` can fix the problem.