### PR TITLE
fix: replacing abc.com with example.com

### DIFF
--- a/samples/cloud-client/snippets/idtoken_from_metadata_server.py
+++ b/samples/cloud-client/snippets/idtoken_from_metadata_server.py
@@ -28,7 +28,7 @@ def idtoken_from_metadata_server(url: str):
 
     Args:
         url: The url or target audience to obtain the ID token for.
-            Examples: http://www.abc.com
+            Examples: http://www.example.com
     """
 
     request = google.auth.transport.requests.Request()


### PR DESCRIPTION
abc.com is a domain owned by someone else and is not an example domain