### PR TITLE
feat: add metrics (part 2)

### DIFF
--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -28,6 +28,7 @@ from google.auth import credentials
 from google.auth import exceptions
 from google.auth import iam
 from google.auth import jwt
+from google.auth import metrics
 from google.auth.compute_engine import _metadata
 from google.oauth2 import _client
 
@@ -93,6 +94,9 @@ class Credentials(credentials.Scoped, credentials.CredentialsWithQuotaProject):
         # Don't override scopes requested by the user.
         if self._scopes is None:
             self._scopes = info["scopes"]
+
+    def _metric_header_for_usage(self):
+        return metrics.CRED_TYPE_SA_MDS
 
     def refresh(self, request):
         """Refresh the access token and scopes.

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -37,6 +37,7 @@ from google.auth import _helpers
 from google.auth import credentials
 from google.auth import exceptions
 from google.auth import jwt
+from google.auth import metrics
 
 _DEFAULT_TOKEN_LIFETIME_SECS = 3600  # 1 hour in seconds
 
@@ -237,6 +238,9 @@ class Credentials(
         self.expiry = _helpers.utcnow()
         self._quota_project_id = quota_project_id
         self._iam_endpoint_override = iam_endpoint_override
+
+    def _metric_header_for_usage(self):
+        return metrics.CRED_TYPE_SA_IMPERSONATE
 
     @_helpers.copy_docstring(credentials.Credentials)
     def refresh(self, request):

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -42,6 +42,7 @@ from google.auth import _cloud_sdk
 from google.auth import _helpers
 from google.auth import credentials
 from google.auth import exceptions
+from google.auth import metrics
 from google.oauth2 import reauth
 
 _LOGGER = logging.getLogger(__name__)
@@ -286,6 +287,9 @@ class Credentials(credentials.ReadOnlyScoped, credentials.CredentialsWithQuotaPr
             rapt_token=self.rapt_token,
             enable_reauth_refresh=self._enable_reauth_refresh,
         )
+
+    def _metric_header_for_usage(self):
+        return metrics.CRED_TYPE_USER
 
     @_helpers.copy_docstring(credentials.Credentials)
     def refresh(self, request):

--- a/tests/compute_engine/test_credentials.py
+++ b/tests/compute_engine/test_credentials.py
@@ -185,6 +185,15 @@ class TestCredentials(object):
 
         assert self.credentials._scopes == scopes
 
+    def test_token_usage_metrics(self):
+        self.credentials.token = "token"
+        self.credentials.expiry = None
+
+        headers = {}
+        self.credentials.before_request(mock.Mock(), None, None, headers)
+        assert headers["authorization"] == "Bearer token"
+        assert headers["x-goog-api-client"] == "cred-type/mds"
+
 
 class TestIDTokenCredentials(object):
     credentials = None

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -69,6 +69,16 @@ class TestCredentials(object):
         assert credentials.rapt_token == self.RAPT_TOKEN
         assert credentials.refresh_handler is None
 
+    def test_token_usage_metrics(self):
+        credentials = self.make_credentials()
+        credentials.token = "token"
+        credentials.expiry = None
+
+        headers = {}
+        credentials.before_request(mock.Mock(), None, None, headers)
+        assert headers["authorization"] == "Bearer token"
+        assert headers["x-goog-api-client"] == "cred-type/u"
+
     def test_refresh_handler_setter_and_getter(self):
         scopes = ["email", "profile"]
         original_refresh_handler = mock.Mock(return_value=("ACCESS_TOKEN_1", None))

--- a/tests/test_impersonated_credentials.py
+++ b/tests/test_impersonated_credentials.py
@@ -162,6 +162,16 @@ class TestImpersonatedCredentials(object):
 
         return request
 
+    def test_token_usage_metrics(self):
+        credentials = self.make_credentials()
+        credentials.token = "token"
+        credentials.expiry = None
+
+        headers = {}
+        credentials.before_request(mock.Mock(), None, None, headers)
+        assert headers["authorization"] == "Bearer token"
+        assert headers["x-goog-api-client"] == "cred-type/imp"
+
     @pytest.mark.parametrize("use_data_bytes", [True, False])
     def test_refresh_success(self, use_data_bytes, mock_donor_credentials):
         credentials = self.make_credentials(lifetime=None)


### PR DESCRIPTION
This PR adds `_metric_header_for_usage()` method to compute engine/service account/user/impersonated access token credentials. This method returns `cred-type/<the credential type>` string, and this string will be added to API service request's `x-goog-api-client` headers.

previous PR: #1298 