### PR TITLE
Fix "AttributeError: 'str' object has no attribute 'get'"

### DIFF
--- a/google/oauth2/reauth.py
+++ b/google/oauth2/reauth.py
@@ -324,6 +324,10 @@ def refresh_grant(
     response_status_ok, response_data, retryable_error = _client._token_endpoint_request_no_throw(
         request, token_uri, body
     )
+   
+    if type(response_data) != dict:
+        response_data = {"data": response_data}
+   
     if (
         not response_status_ok
         and response_data.get("error") == _REAUTH_NEEDED_ERROR


### PR DESCRIPTION
* This is a bug fix.
* The current code assumes that `response_data` will always be a `dict` or a mapping of some kind, but it is possible for `response_data` to be a `str`.
* When `response_data` is a `str`, then the function fails on `response_data.get("error")` but the error response is swallowed so the user doesn't know why it failed. The user just sees: `AttributeError: 'str' object has no attribute 'get'` and a stacktrace
* This is a quick and dirty fix that guarantees the `.get` call will succeed, and the result is that the error response bubbles up to the user.
* Feel free to make this fix more robust/clean.

**Steps to reproduce the bug**
* Set credentials like this:
```
credentials = google.oauth2.credentials.Credentials(
        token=None,
        refresh_token=os.getenv('GCP_REFRESH_TOKEN'),
        token_uri=os.getenv('GCP_TOKEN_URI'),
        client_id=os.getenv('GCP_CLIENT_ID'),
        client_secret=os.getenv('GCP_CLIENT_SECRET'))
```
But ensure that there is a typo in GCP_TOKEN_URI. Example: "https://oauth2.googleapis.com/token1"
* Use the credentials to authenticate. Example:
```
df.to_gbq(destination_table=tablename, project_id=project_id, if_exists=if_exists, table_schema=schema, credentials=credentials)
```
**Expected**: Authentication should fail with a useful error response
**Actual**: Authentication fails with an AttributeError: "AttributeError: 'str' object has no attribute 'get'"