### PR TITLE
feat: add metrics (part 3)

### DIFF
--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -378,7 +378,12 @@ class IDTokenCredentials(
         try:
             path = "instance/service-accounts/default/identity"
             params = {"audience": self._target_audience, "format": "full"}
-            id_token = _metadata.get(request, path, params=params)
+            metrics_header = {
+                metrics.API_CLIENT_HEADER: metrics.token_request_id_token_mds()
+            }
+            id_token = _metadata.get(
+                request, path, params=params, headers=metrics_header
+            )
         except exceptions.TransportError as caught_exc:
             new_exc = exceptions.RefreshError(caught_exc)
             six.raise_from(new_exc, caught_exc)

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -265,7 +265,10 @@ class Credentials(
             "lifetime": str(self._lifetime) + "s",
         }
 
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            metrics.API_CLIENT_HEADER: metrics.token_request_access_token_impersonate(),
+        }
 
         # Apply the source credentials authentication info.
         self._source_credentials.apply(headers)
@@ -426,7 +429,10 @@ class IDTokenCredentials(credentials.CredentialsWithQuotaProject):
             "includeEmail": self._include_email,
         }
 
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            metrics.API_CLIENT_HEADER: metrics.token_request_id_token_impersonate(),
+        }
 
         authed_session = AuthorizedSession(
             self._target_credentials._source_credentials, auth_request=request

--- a/google/oauth2/reauth.py
+++ b/google/oauth2/reauth.py
@@ -37,6 +37,7 @@ import sys
 from six.moves import range
 
 from google.auth import exceptions
+from google.auth import metrics
 from google.oauth2 import _client
 from google.oauth2 import challenges
 
@@ -94,9 +95,15 @@ def _get_challenges(
     body = {"supportedChallengeTypes": supported_challenge_types}
     if requested_scopes:
         body["oauthScopesForDomainPolicyLookup"] = requested_scopes
+    metrics_header = {metrics.API_CLIENT_HEADER: metrics.reauth_start()}
 
     return _client._token_endpoint_request(
-        request, _REAUTH_API + ":start", body, access_token=access_token, use_json=True
+        request,
+        _REAUTH_API + ":start",
+        body,
+        access_token=access_token,
+        use_json=True,
+        headers=metrics_header,
     )
 
 
@@ -123,6 +130,7 @@ def _send_challenge_result(
         "action": "RESPOND",
         "proposalResponse": client_input,
     }
+    metrics_header = {metrics.API_CLIENT_HEADER: metrics.reauth_continue()}
 
     return _client._token_endpoint_request(
         request,
@@ -130,6 +138,7 @@ def _send_challenge_result(
         body,
         access_token=access_token,
         use_json=True,
+        headers=metrics_header,
     )
 
 
@@ -320,9 +329,10 @@ def refresh_grant(
         body["scope"] = " ".join(scopes)
     if rapt_token:
         body["rapt"] = rapt_token
+    metrics_header = {metrics.API_CLIENT_HEADER: metrics.token_request_user()}
 
     response_status_ok, response_data, retryable_error = _client._token_endpoint_request_no_throw(
-        request, token_uri, body
+        request, token_uri, body, headers=metrics_header
     )
     if (
         not response_status_ok
@@ -345,7 +355,9 @@ def refresh_grant(
             response_status_ok,
             response_data,
             retryable_error,
-        ) = _client._token_endpoint_request_no_throw(request, token_uri, body)
+        ) = _client._token_endpoint_request_no_throw(
+            request, token_uri, body, headers=metrics_header
+        )
 
     if not response_status_ok:
         _client._handle_error_response(response_data, retryable_error)

--- a/tests/compute_engine/test_credentials.py
+++ b/tests/compute_engine/test_credentials.py
@@ -43,6 +43,13 @@ SAMPLE_ID_TOKEN = (
     b"bsxbLa6Fp0SYeYwO8ifEnkRvasVpc1WTQqfRB2JCj5pTBDzJpIpFCMmnQ"
 )
 
+ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE = (
+    "gl-python/3.7 auth/1.1 auth-request-type/at cred-type/mds"
+)
+ID_TOKEN_REQUEST_METRICS_HEADER_VALUE = (
+    "gl-python/3.7 auth/1.1 auth-request-type/it cred-type/mds"
+)
+
 
 class TestCredentials(object):
     credentials = None
@@ -97,11 +104,15 @@ class TestCredentials(object):
         assert self.credentials.valid
 
     @mock.patch(
+        "google.auth.metrics.token_request_access_token_mds",
+        return_value=ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
+    )
+    @mock.patch(
         "google.auth._helpers.utcnow",
         return_value=datetime.datetime.min + _helpers.REFRESH_THRESHOLD,
     )
     @mock.patch("google.auth.compute_engine._metadata.get", autospec=True)
-    def test_refresh_success_with_scopes(self, get, utcnow):
+    def test_refresh_success_with_scopes(self, get, utcnow, mock_metrics_header_value):
         get.side_effect = [
             {
                 # First request is for sevice account info.
@@ -133,7 +144,10 @@ class TestCredentials(object):
         assert self.credentials.valid
 
         kwargs = get.call_args[1]
-        assert kwargs == {"params": {"scopes": "three,four"}}
+        assert kwargs["params"] == {"scopes": "three,four"}
+        assert kwargs["headers"] == {
+            "x-goog-api-client": ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE
+        }
 
     @mock.patch("google.auth.compute_engine._metadata.get", autospec=True)
     def test_refresh_error(self, get):
@@ -733,10 +747,16 @@ class TestIDTokenCredentials(object):
         assert signature == b"signature"
 
     @mock.patch(
+        "google.auth.metrics.token_request_id_token_mds",
+        return_value=ID_TOKEN_REQUEST_METRICS_HEADER_VALUE,
+    )
+    @mock.patch(
         "google.auth.compute_engine._metadata.get_service_account_info", autospec=True
     )
     @mock.patch("google.auth.compute_engine._metadata.get", autospec=True)
-    def test_get_id_token_from_metadata(self, get, get_service_account_info):
+    def test_get_id_token_from_metadata(
+        self, get, get_service_account_info, mock_metrics_header_value
+    ):
         get.return_value = SAMPLE_ID_TOKEN
         get_service_account_info.return_value = {"email": "foo@example.com"}
 
@@ -744,6 +764,10 @@ class TestIDTokenCredentials(object):
             mock.Mock(), "audience", use_metadata_identity_endpoint=True
         )
         cred.refresh(request=mock.Mock())
+
+        assert get.call_args.kwargs["headers"] == {
+            "x-goog-api-client": ID_TOKEN_REQUEST_METRICS_HEADER_VALUE
+        }
 
         assert cred.token == SAMPLE_ID_TOKEN
         assert cred.expiry == datetime.datetime.fromtimestamp(SAMPLE_ID_TOKEN_EXP)

--- a/tests/oauth2/test__client.py
+++ b/tests/oauth2/test__client.py
@@ -46,6 +46,13 @@ SCOPES_AS_STRING = (
     " https://www.googleapis.com/auth/logging.write"
 )
 
+ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE = (
+    "gl-python/3.7 auth/1.1 auth-request-type/at cred-type/sa"
+)
+ID_TOKEN_REQUEST_METRICS_HEADER_VALUE = (
+    "gl-python/3.7 auth/1.1 auth-request-type/it cred-type/sa"
+)
+
 
 @pytest.mark.parametrize("retryable", [True, False])
 def test__handle_error_response(retryable):
@@ -483,47 +490,83 @@ def test_refresh_grant_no_access_token():
     assert not excinfo.value.retryable
 
 
+@mock.patch(
+    "google.auth.metrics.token_request_access_token_sa_assertion",
+    return_value=ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
+)
 @mock.patch("google.oauth2._client._parse_expiry", return_value=None)
 @mock.patch.object(_client, "_token_endpoint_request", autospec=True)
-def test_jwt_grant_retry_default(mock_token_endpoint_request, mock_expiry):
+def test_jwt_grant_retry_default(
+    mock_token_endpoint_request, mock_expiry, mock_metrics_header_value
+):
     _client.jwt_grant(mock.Mock(), mock.Mock(), mock.Mock())
     mock_token_endpoint_request.assert_called_with(
-        mock.ANY, mock.ANY, mock.ANY, can_retry=True
+        mock.ANY,
+        mock.ANY,
+        mock.ANY,
+        can_retry=True,
+        headers={"x-goog-api-client": ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE},
     )
 
 
 @pytest.mark.parametrize("can_retry", [True, False])
+@mock.patch(
+    "google.auth.metrics.token_request_access_token_sa_assertion",
+    return_value=ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
+)
 @mock.patch("google.oauth2._client._parse_expiry", return_value=None)
 @mock.patch.object(_client, "_token_endpoint_request", autospec=True)
 def test_jwt_grant_retry_with_retry(
-    mock_token_endpoint_request, mock_expiry, can_retry
+    mock_token_endpoint_request, mock_expiry, mock_metrics_header_value, can_retry
 ):
     _client.jwt_grant(mock.Mock(), mock.Mock(), mock.Mock(), can_retry=can_retry)
     mock_token_endpoint_request.assert_called_with(
-        mock.ANY, mock.ANY, mock.ANY, can_retry=can_retry
+        mock.ANY,
+        mock.ANY,
+        mock.ANY,
+        can_retry=can_retry,
+        headers={"x-goog-api-client": ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE},
     )
 
 
+@mock.patch(
+    "google.auth.metrics.token_request_id_token_sa_assertion",
+    return_value=ID_TOKEN_REQUEST_METRICS_HEADER_VALUE,
+)
 @mock.patch("google.auth.jwt.decode", return_value={"exp": 0})
 @mock.patch.object(_client, "_token_endpoint_request", autospec=True)
-def test_id_token_jwt_grant_retry_default(mock_token_endpoint_request, mock_jwt_decode):
+def test_id_token_jwt_grant_retry_default(
+    mock_token_endpoint_request, mock_jwt_decode, mock_metrics_header_value
+):
     _client.id_token_jwt_grant(mock.Mock(), mock.Mock(), mock.Mock())
     mock_token_endpoint_request.assert_called_with(
-        mock.ANY, mock.ANY, mock.ANY, can_retry=True
+        mock.ANY,
+        mock.ANY,
+        mock.ANY,
+        can_retry=True,
+        headers={"x-goog-api-client": ID_TOKEN_REQUEST_METRICS_HEADER_VALUE},
     )
 
 
 @pytest.mark.parametrize("can_retry", [True, False])
+@mock.patch(
+    "google.auth.metrics.token_request_id_token_sa_assertion",
+    return_value=ID_TOKEN_REQUEST_METRICS_HEADER_VALUE,
+)
 @mock.patch("google.auth.jwt.decode", return_value={"exp": 0})
 @mock.patch.object(_client, "_token_endpoint_request", autospec=True)
 def test_id_token_jwt_grant_retry_with_retry(
-    mock_token_endpoint_request, mock_jwt_decode, can_retry
+    mock_token_endpoint_request, mock_jwt_decode, mock_metrics_header_value, can_retry
 ):
     _client.id_token_jwt_grant(
         mock.Mock(), mock.Mock(), mock.Mock(), can_retry=can_retry
     )
     mock_token_endpoint_request.assert_called_with(
-        mock.ANY, mock.ANY, mock.ANY, can_retry=can_retry
+        mock.ANY,
+        mock.ANY,
+        mock.ANY,
+        can_retry=can_retry,
+        headers={"x-goog-api-client": ID_TOKEN_REQUEST_METRICS_HEADER_VALUE},
     )
 
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -28,6 +28,10 @@ from google.auth import exceptions
 from google.auth import transport
 
 
+IMPERSONATE_ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE = (
+    "gl-python/3.7 auth/1.1 auth-request-type/at cred-type/imp"
+)
+
 CLIENT_ID = "username"
 CLIENT_SECRET = "password"
 # Base64 encoding of "username:password".
@@ -1901,8 +1905,14 @@ class TestCredentials(object):
         assert credentials.scopes is None
         assert credentials.default_scopes == SCOPES
 
+    @mock.patch(
+        "google.auth.metrics.token_request_access_token_impersonate",
+        return_value=IMPERSONATE_ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
+    )
     @mock.patch("google.auth._helpers.utcnow")
-    def test_refresh_success_with_impersonation_ignore_default_scopes(self, utcnow):
+    def test_refresh_success_with_impersonation_ignore_default_scopes(
+        self, utcnow, mock_metrics_header_value
+    ):
         utcnow.return_value = datetime.datetime.strptime(
             self.AWS_SIGNATURE_TIME, "%Y-%m-%dT%H:%M:%SZ"
         )
@@ -1937,6 +1947,7 @@ class TestCredentials(object):
             "Content-Type": "application/json",
             "authorization": "Bearer {}".format(self.SUCCESS_RESPONSE["access_token"]),
             "x-goog-user-project": QUOTA_PROJECT_ID,
+            "x-goog-api-client": IMPERSONATE_ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
         }
         impersonation_request_data = {
             "delegates": None,
@@ -1985,8 +1996,14 @@ class TestCredentials(object):
         assert credentials.scopes == SCOPES
         assert credentials.default_scopes == ["ignored"]
 
+    @mock.patch(
+        "google.auth.metrics.token_request_access_token_impersonate",
+        return_value=IMPERSONATE_ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
+    )
     @mock.patch("google.auth._helpers.utcnow")
-    def test_refresh_success_with_impersonation_use_default_scopes(self, utcnow):
+    def test_refresh_success_with_impersonation_use_default_scopes(
+        self, utcnow, mock_metrics_header_value
+    ):
         utcnow.return_value = datetime.datetime.strptime(
             self.AWS_SIGNATURE_TIME, "%Y-%m-%dT%H:%M:%SZ"
         )
@@ -2021,6 +2038,7 @@ class TestCredentials(object):
             "Content-Type": "application/json",
             "authorization": "Bearer {}".format(self.SUCCESS_RESPONSE["access_token"]),
             "x-goog-user-project": QUOTA_PROJECT_ID,
+            "x-goog-api-client": IMPERSONATE_ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
         }
         impersonation_request_data = {
             "delegates": None,

--- a/tests/test_external_account.py
+++ b/tests/test_external_account.py
@@ -26,6 +26,8 @@ from google.auth import external_account
 from google.auth import transport
 
 
+METRICS_HEADER_VALUE = "gl-python/3.7 auth/1.1 auth-request-type/at cred-type/imp"
+
 CLIENT_ID = "username"
 CLIENT_SECRET = "password"
 # Base64 encoding of "username:password"
@@ -751,7 +753,13 @@ class TestCredentials(object):
         assert not credentials.expired
         assert credentials.token == response["access_token"]
 
-    def test_refresh_impersonation_without_client_auth_success(self):
+    @mock.patch(
+        "google.auth.metrics.token_request_access_token_impersonate",
+        return_value=METRICS_HEADER_VALUE,
+    )
+    def test_refresh_impersonation_without_client_auth_success(
+        self, mock_metrics_header_value
+    ):
         # Simulate service account access token expires in 2800 seconds.
         expire_time = (
             _helpers.utcnow().replace(microsecond=0) + datetime.timedelta(seconds=2800)
@@ -776,6 +784,7 @@ class TestCredentials(object):
         impersonation_headers = {
             "Content-Type": "application/json",
             "authorization": "Bearer {}".format(token_response["access_token"]),
+            "x-goog-api-client": METRICS_HEADER_VALUE,
         }
         impersonation_request_data = {
             "delegates": None,
@@ -815,7 +824,13 @@ class TestCredentials(object):
         assert not credentials.expired
         assert credentials.token == impersonation_response["accessToken"]
 
-    def test_refresh_workforce_impersonation_without_client_auth_success(self):
+    @mock.patch(
+        "google.auth.metrics.token_request_access_token_impersonate",
+        return_value=METRICS_HEADER_VALUE,
+    )
+    def test_refresh_workforce_impersonation_without_client_auth_success(
+        self, mock_metrics_header_value
+    ):
         # Simulate service account access token expires in 2800 seconds.
         expire_time = (
             _helpers.utcnow().replace(microsecond=0) + datetime.timedelta(seconds=2800)
@@ -843,6 +858,7 @@ class TestCredentials(object):
         impersonation_headers = {
             "Content-Type": "application/json",
             "authorization": "Bearer {}".format(token_response["access_token"]),
+            "x-goog-api-client": METRICS_HEADER_VALUE,
         }
         impersonation_request_data = {
             "delegates": None,
@@ -1000,7 +1016,13 @@ class TestCredentials(object):
         assert not credentials.expired
         assert credentials.token == self.SUCCESS_RESPONSE["access_token"]
 
-    def test_refresh_impersonation_with_client_auth_success_ignore_default_scopes(self):
+    @mock.patch(
+        "google.auth.metrics.token_request_access_token_impersonate",
+        return_value=METRICS_HEADER_VALUE,
+    )
+    def test_refresh_impersonation_with_client_auth_success_ignore_default_scopes(
+        self, mock_metrics_header_value
+    ):
         # Simulate service account access token expires in 2800 seconds.
         expire_time = (
             _helpers.utcnow().replace(microsecond=0) + datetime.timedelta(seconds=2800)
@@ -1028,6 +1050,7 @@ class TestCredentials(object):
         impersonation_headers = {
             "Content-Type": "application/json",
             "authorization": "Bearer {}".format(token_response["access_token"]),
+            "x-goog-api-client": METRICS_HEADER_VALUE,
         }
         impersonation_request_data = {
             "delegates": None,
@@ -1071,7 +1094,13 @@ class TestCredentials(object):
         assert not credentials.expired
         assert credentials.token == impersonation_response["accessToken"]
 
-    def test_refresh_impersonation_with_client_auth_success_use_default_scopes(self):
+    @mock.patch(
+        "google.auth.metrics.token_request_access_token_impersonate",
+        return_value=METRICS_HEADER_VALUE,
+    )
+    def test_refresh_impersonation_with_client_auth_success_use_default_scopes(
+        self, mock_metrics_header_value
+    ):
         # Simulate service account access token expires in 2800 seconds.
         expire_time = (
             _helpers.utcnow().replace(microsecond=0) + datetime.timedelta(seconds=2800)
@@ -1099,6 +1128,7 @@ class TestCredentials(object):
         impersonation_headers = {
             "Content-Type": "application/json",
             "authorization": "Bearer {}".format(token_response["access_token"]),
+            "x-goog-api-client": METRICS_HEADER_VALUE,
         }
         impersonation_request_data = {
             "delegates": None,
@@ -1488,7 +1518,13 @@ class TestCredentials(object):
 
         assert credentials.get_project_id(None) is None
 
-    def test_get_project_id_cloud_resource_manager_success(self):
+    @mock.patch(
+        "google.auth.metrics.token_request_access_token_impersonate",
+        return_value=METRICS_HEADER_VALUE,
+    )
+    def test_get_project_id_cloud_resource_manager_success(
+        self, mock_metrics_header_value
+    ):
         # STS token exchange request/response.
         token_response = self.SUCCESS_RESPONSE.copy()
         token_headers = {"Content-Type": "application/x-www-form-urlencoded"}
@@ -1513,6 +1549,7 @@ class TestCredentials(object):
             "Content-Type": "application/json",
             "x-goog-user-project": self.QUOTA_PROJECT_ID,
             "authorization": "Bearer {}".format(token_response["access_token"]),
+            "x-goog-api-client": METRICS_HEADER_VALUE,
         }
         impersonation_request_data = {
             "delegates": None,
@@ -1638,7 +1675,11 @@ class TestCredentials(object):
         # No additional requests.
         assert len(request.call_args_list) == 2
 
-    def test_refresh_impersonation_with_lifetime(self):
+    @mock.patch(
+        "google.auth.metrics.token_request_access_token_impersonate",
+        return_value=METRICS_HEADER_VALUE,
+    )
+    def test_refresh_impersonation_with_lifetime(self, mock_metrics_header_value):
         # Simulate service account access token expires in 2800 seconds.
         expire_time = (
             _helpers.utcnow().replace(microsecond=0) + datetime.timedelta(seconds=2800)
@@ -1663,6 +1704,7 @@ class TestCredentials(object):
         impersonation_headers = {
             "Content-Type": "application/json",
             "authorization": "Bearer {}".format(token_response["access_token"]),
+            "x-goog-api-client": METRICS_HEADER_VALUE,
         }
         impersonation_request_data = {
             "delegates": None,

--- a/tests/test_impersonated_credentials.py
+++ b/tests/test_impersonated_credentials.py
@@ -55,6 +55,13 @@ with open(SERVICE_ACCOUNT_JSON_FILE, "rb") as fh:
 SIGNER = crypt.RSASigner.from_string(PRIVATE_KEY_BYTES, "1")
 TOKEN_URI = "https://example.com/oauth2/token"
 
+ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE = (
+    "gl-python/3.7 auth/1.1 auth-request-type/at cred-type/imp"
+)
+ID_TOKEN_REQUEST_METRICS_HEADER_VALUE = (
+    "gl-python/3.7 auth/1.1 auth-request-type/it cred-type/imp"
+)
+
 
 @pytest.fixture
 def mock_donor_credentials():
@@ -188,10 +195,18 @@ class TestImpersonatedCredentials(object):
             use_data_bytes=use_data_bytes,
         )
 
-        credentials.refresh(request)
+        with mock.patch(
+            "google.auth.metrics.token_request_access_token_impersonate",
+            return_value=ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
+        ):
+            credentials.refresh(request)
 
         assert credentials.valid
         assert not credentials.expired
+        assert (
+            request.call_args.kwargs["headers"]["x-goog-api-client"]
+            == ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE
+        )
 
     @pytest.mark.parametrize("use_data_bytes", [True, False])
     def test_refresh_success_iam_endpoint_override(
@@ -453,6 +468,36 @@ class TestImpersonatedCredentials(object):
 
         assert id_creds.token == ID_TOKEN_DATA
         assert id_creds.expiry == datetime.datetime.fromtimestamp(ID_TOKEN_EXPIRY)
+
+    def test_id_token_metrics(self, mock_donor_credentials):
+        credentials = self.make_credentials(lifetime=None)
+        credentials.token = "token"
+        credentials.expiry = None
+        target_audience = "https://foo.bar"
+
+        id_creds = impersonated_credentials.IDTokenCredentials(
+            credentials, target_audience=target_audience
+        )
+
+        with mock.patch(
+            "google.auth.metrics.token_request_id_token_impersonate",
+            return_value=ID_TOKEN_REQUEST_METRICS_HEADER_VALUE,
+        ):
+            with mock.patch(
+                "google.auth.transport.requests.AuthorizedSession.post", autospec=True
+            ) as mock_post:
+                data = {"token": ID_TOKEN_DATA}
+                mock_post.return_value = MockResponse(data, http_client.OK)
+                id_creds.refresh(None)
+
+                assert id_creds.token == ID_TOKEN_DATA
+                assert id_creds.expiry == datetime.datetime.fromtimestamp(
+                    ID_TOKEN_EXPIRY
+                )
+                assert (
+                    mock_post.call_args.kwargs["headers"]["x-goog-api-client"]
+                    == ID_TOKEN_REQUEST_METRICS_HEADER_VALUE
+                )
 
     def test_id_token_from_credential(
         self, mock_donor_credentials, mock_authorizedsession_idtoken


### PR DESCRIPTION
This PR adds `x-goog-api-client` header to
- access token and id token refresh requests, for compute engine credentials / user credentials / service account credentials / impersonated credentials
- reauth start and continue requests
- metadata server ping requests

Previous PRs:
Part 1: #1298 
Part 2: #1303 