### PR TITLE
fix: misc fixes

### DIFF
--- a/google/oauth2/reauth.py
+++ b/google/oauth2/reauth.py
@@ -34,7 +34,6 @@ Those steps are:
 
 import sys
 
-import six
 from six.moves import range
 
 from google.auth import exceptions
@@ -336,7 +335,7 @@ def refresh_grant(
         request, token_uri, body, headers=metrics_header
     )
 
-    if not response_status_ok and isinstance(response_data, six.string_types):
+    if not response_status_ok and isinstance(response_data, str):
         raise exceptions.RefreshError(response_data, retryable=False)
 
     if (

--- a/google/oauth2/reauth.py
+++ b/google/oauth2/reauth.py
@@ -34,6 +34,7 @@ Those steps are:
 
 import sys
 
+import six
 from six.moves import range
 
 from google.auth import exceptions
@@ -334,6 +335,10 @@ def refresh_grant(
     response_status_ok, response_data, retryable_error = _client._token_endpoint_request_no_throw(
         request, token_uri, body, headers=metrics_header
     )
+
+    if not response_status_ok and isinstance(response_data, six.string_types):
+        raise exceptions.RefreshError(response_data, retryable=False)
+
     if (
         not response_status_ok
         and response_data.get("error") == _REAUTH_NEEDED_ERROR

--- a/samples/cloud-client/snippets/idtoken_from_metadata_server.py
+++ b/samples/cloud-client/snippets/idtoken_from_metadata_server.py
@@ -28,7 +28,7 @@ def idtoken_from_metadata_server(url: str):
 
     Args:
         url: The url or target audience to obtain the ID token for.
-            Examples: http://www.abc.com
+            Examples: http://www.example.com
     """
 
     request = google.auth.transport.requests.Request()

--- a/tests/compute_engine/test_credentials.py
+++ b/tests/compute_engine/test_credentials.py
@@ -525,8 +525,8 @@ class TestIDTokenCredentials(object):
             token_uri="http://xyz.com",
         )
         assert self.credentials._token_uri == "http://xyz.com"
-        creds_with_token_uri = self.credentials.with_token_uri("http://abc.com")
-        assert creds_with_token_uri._token_uri == "http://abc.com"
+        creds_with_token_uri = self.credentials.with_token_uri("http://example.com")
+        assert creds_with_token_uri._token_uri == "http://example.com"
 
     @mock.patch(
         "google.auth._helpers.utcnow",
@@ -548,7 +548,7 @@ class TestIDTokenCredentials(object):
         )
         assert self.credentials._token_uri is None
         with pytest.raises(ValueError):
-            self.credentials.with_token_uri("http://abc.com")
+            self.credentials.with_token_uri("http://example.com")
 
     @responses.activate
     def test_with_quota_project_integration(self):

--- a/tests/oauth2/test_reauth.py
+++ b/tests/oauth2/test_reauth.py
@@ -326,6 +326,26 @@ def test_refresh_grant_failed(mock_metrics_header_value):
         )
 
 
+def test_refresh_grant_failed_with_string_type_response():
+    with mock.patch(
+        "google.oauth2._client._token_endpoint_request_no_throw"
+    ) as mock_token_request:
+        mock_token_request.return_value = (False, "string type error", False)
+        with pytest.raises(exceptions.RefreshError) as excinfo:
+            reauth.refresh_grant(
+                MOCK_REQUEST,
+                "token_uri",
+                "refresh_token",
+                "client_id",
+                "client_secret",
+                scopes=["foo", "bar"],
+                rapt_token="rapt_token",
+                enable_reauth_refresh=True,
+            )
+        assert excinfo.match(r"string type error")
+        assert not excinfo.value.retryable
+
+
 def test_refresh_grant_success():
     with mock.patch(
         "google.oauth2._client._token_endpoint_request_no_throw"


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: fix "AttributeError: 'str' object has no attribute 'get'" 
docs: replacing abc.com with example.com
END_COMMIT_OVERRIDE

Fix reauth logic so it can handle token response where error response is a string instead of dict.  Similar issue see #857 