### PR TITLE
fix: Check if user access token is valid before refresh

### DIFF
--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -534,5 +534,6 @@ class UserAccessTokenCredentials(credentials.CredentialsWithQuotaProject):
 
     @_helpers.copy_docstring(credentials.Credentials)
     def before_request(self, request, method, url, headers):
-        self.refresh(request)
+        if not self.valid:
+            self.refresh(request)
         self.apply(headers)

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -979,6 +979,7 @@ class TestUserAccessTokenCredentials(object):
     )
     def test_before_request(self, refresh, apply):
         cred = credentials.UserAccessTokenCredentials()
-        cred.before_request(mock.Mock(), "GET", "https://example.com", {})
+        with mock.patch("google.auth.credentials.Credentials.valid", False):
+            cred.before_request(mock.Mock(), "GET", "https://example.com", {})
         refresh.assert_called()
         apply.assert_called()

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -983,3 +983,16 @@ class TestUserAccessTokenCredentials(object):
             cred.before_request(mock.Mock(), "GET", "https://example.com", {})
         refresh.assert_called()
         apply.assert_called()
+
+    @mock.patch(
+        "google.oauth2.credentials.UserAccessTokenCredentials.apply", autospec=True
+    )
+    @mock.patch(
+        "google.oauth2.credentials.UserAccessTokenCredentials.refresh", autospec=True
+    )
+    def test_before_request_no_refresh(self, refresh, apply):
+        cred = credentials.UserAccessTokenCredentials()
+        with mock.patch("google.auth.credentials.Credentials.valid", True):
+            cred.before_request(mock.Mock(), "GET", "https://example.com", {})
+        refresh.assert_not_called()
+        apply.assert_called()


### PR DESCRIPTION
- fix: Check if user access token credential is valid before refreshing.
