### PR TITLE
feat: Provide a way to read project from environment instead of checking credential

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -106,6 +106,8 @@ def load_credentials_from_file(
             for a workload identity pool resource (external account credentials).
             If not specified, then it will use a
             google.auth.transport.requests.Request client to make requests.
+        use_project_from_env (bool): If True, use the project ID from the
+            environment variables.    
 
     Returns:
         Tuple[google.auth.credentials.Credentials, Optional[str]]: Loaded


### PR DESCRIPTION
For external account credentials, the project id is obtained through an API call and that involves creating a token first. If project id is set already in environment, that is the value that is going to be returned by google.auth.default and the value read through the API is discarded.
Updating logic so that if env var is set, then dont make an API call for project.