### PR TITLE
feat: add a new config path to _cloud_sdk.py

### DIFF
--- a/google/auth/_cloud_sdk.py
+++ b/google/auth/_cloud_sdk.py
@@ -24,6 +24,8 @@ from google.auth import exceptions
 
 # The ~/.config subdirectory containing gcloud credentials.
 _CONFIG_DIRECTORY = "gcloud"
+# The subdirectory containing shared configs for other first-party applications.
+_CONFIG_DIRECTORY_CLI = "cli"
 # Windows systems store config at %APPDATA%\gcloud
 _WINDOWS_CONFIG_ROOT_ENV_VAR = "APPDATA"
 # The name of the file in the Cloud SDK config that contains default
@@ -54,10 +56,10 @@ def get_config_path():
     except KeyError:
         pass
 
-    # Non-windows systems store this at ~/.config/gcloud
+    # Non-windows systems store this at ~/.config/gcloud.
     if os.name != "nt":
         return os.path.join(os.path.expanduser("~"), ".config", _CONFIG_DIRECTORY)
-    # Windows systems store config at %APPDATA%\gcloud
+    # Windows systems store config at %APPDATA%\gcloud.
     else:
         try:
             return os.path.join(
@@ -68,6 +70,15 @@ def get_config_path():
             # messing with things, but we'll cover the case anyway.
             drive = os.environ.get("SystemDrive", "C:")
             return os.path.join(drive, "\\", _CONFIG_DIRECTORY)
+
+
+def get_cli_config_path():
+    """Returns the absolute path of the Cloud CLI shared config files.
+
+    Returns:
+        str: The full path to shared config.
+    """
+    return os.path.join(get_config_path(), _CONFIG_DIRECTORY_CLI)
 
 
 def get_application_default_credentials_path():

--- a/tests/test__cloud_sdk.py
+++ b/tests/test__cloud_sdk.py
@@ -148,6 +148,50 @@ def test_get_config_path_no_appdata(monkeypatch):
     assert os.path.split(config_path) == ("G:/\\", _cloud_sdk._CONFIG_DIRECTORY)
 
 
+def test_get_cli_config_path_env_var(monkeypatch):
+    config_path_sentinel = "config_path"
+    monkeypatch.setenv(environment_vars.CLOUD_SDK_CONFIG_DIR, config_path_sentinel)
+    config_path = _cloud_sdk.get_cli_config_path()
+    assert config_path == os.path.join(
+        config_path_sentinel, _cloud_sdk._CONFIG_DIRECTORY_CLI
+    )
+
+
+@mock.patch("os.path.expanduser")
+def test_get_cli_config_path_unix(expanduser):
+    expanduser.side_effect = lambda path: path
+
+    config_path = _cloud_sdk.get_cli_config_path()
+
+    assert config_path == os.path.join(
+        "~/.config", _cloud_sdk._CONFIG_DIRECTORY, _cloud_sdk._CONFIG_DIRECTORY_CLI
+    )
+
+
+@mock.patch("os.name", new="nt")
+def test_get_cli_config_path_windows(monkeypatch):
+    appdata = "appdata"
+    monkeypatch.setenv(_cloud_sdk._WINDOWS_CONFIG_ROOT_ENV_VAR, appdata)
+
+    config_path = _cloud_sdk.get_cli_config_path()
+
+    assert config_path == os.path.join(
+        appdata, _cloud_sdk._CONFIG_DIRECTORY, _cloud_sdk._CONFIG_DIRECTORY_CLI
+    )
+
+
+@mock.patch("os.name", new="nt")
+def test_get_cli_config_path_no_appdata(monkeypatch):
+    monkeypatch.delenv(_cloud_sdk._WINDOWS_CONFIG_ROOT_ENV_VAR, raising=False)
+    monkeypatch.setenv("SystemDrive", "G:")
+
+    config_path = _cloud_sdk.get_cli_config_path()
+
+    assert config_path == os.path.join(
+        "G:/\\", _cloud_sdk._CONFIG_DIRECTORY, _cloud_sdk._CONFIG_DIRECTORY_CLI
+    )
+
+
 @mock.patch("os.name", new="nt")
 @mock.patch("subprocess.check_output", autospec=True)
 def test_get_auth_access_token_windows(check_output):


### PR DESCRIPTION
Will be used by the Cloud CLI's config to write a credential file for the bq tool to use. Part of the work to support BQ CLI's auth library upgrade from oauth2client to google-auth. Originally https://github.com/googleapis/google-auth-library-python/pull/1358.