### PR TITLE
fix: read `token_uri` field from authorized user ADC JSON

### DIFF
--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -418,7 +418,7 @@ class Credentials(credentials.ReadOnlyScoped, credentials.CredentialsWithQuotaPr
         return cls(
             token=info.get("token"),
             refresh_token=info.get("refresh_token"),
-            token_uri=_GOOGLE_OAUTH2_TOKEN_ENDPOINT,  # always overrides
+            token_uri=info.get("token_uri", _GOOGLE_OAUTH2_TOKEN_ENDPOINT),
             scopes=scopes,
             client_id=info.get("client_id"),
             client_secret=info.get("client_secret"),


### PR DESCRIPTION
Authorized user type ADC credentials have `token_uri` hardcoded to `"https://oauth2.googleapis.com/token"`. For GCP products such as Cloud Interconnect, customers can create their own custom token URI for authorization. Currently, custom `token_uri` does not work for authorized user type credentials because the value is hardcoded.

This PR checks if `token_uri` is set in the authorized user generated ADC json, otherwise defaults to regular token URI. 