### PR TITLE
fix: expose universe domain in credentials

### DIFF
--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -54,6 +54,9 @@ class Credentials(metaclass=abc.ABCMeta):
         self._trust_boundary = None
         """Optional[str]: Encoded string representation of credentials trust
         boundary."""
+        self._universe_domain = "googleapis.com"
+        """Optional[str]: The universe domain value, default is googleapis.com
+        """
 
     @property
     def expired(self):
@@ -84,6 +87,11 @@ class Credentials(metaclass=abc.ABCMeta):
     def quota_project_id(self):
         """Project to use for quota and billing purposes."""
         return self._quota_project_id
+
+    @property
+    def universe_domain(self):
+        """The universe domain value."""
+        return self._universe_domain
 
     @abc.abstractmethod
     def refresh(self, request):

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -173,6 +173,7 @@ class Credentials(credentials.ReadOnlyScoped, credentials.CredentialsWithQuotaPr
         self._rapt_token = d.get("_rapt_token")
         self._enable_reauth_refresh = d.get("_enable_reauth_refresh")
         self._trust_boundary = d.get("_trust_boundary")
+        self._universe_domain = d.get("_universe_domain")
         # The refresh_handler setter should be used to repopulate this.
         self._refresh_handler = None
 

--- a/tests/oauth2/test_service_account.py
+++ b/tests/oauth2/test_service_account.py
@@ -71,6 +71,7 @@ class TestCredentials(object):
             SIGNER, self.SERVICE_ACCOUNT_EMAIL, self.TOKEN_URI, universe_domain=None
         )
         assert credentials._universe_domain == service_account._DEFAULT_UNIVERSE_DOMAIN
+        assert credentials.universe_domain == service_account._DEFAULT_UNIVERSE_DOMAIN
 
     def test_from_service_account_info(self):
         credentials = service_account.Credentials.from_service_account_info(
@@ -89,6 +90,7 @@ class TestCredentials(object):
         )
 
         assert credentials._universe_domain == FAKE_UNIVERSE_DOMAIN
+        assert credentials.universe_domain == FAKE_UNIVERSE_DOMAIN
         assert credentials._always_use_jwt_access
 
     def test_from_service_account_info_args(self):

--- a/tests/oauth2/test_service_account.py
+++ b/tests/oauth2/test_service_account.py
@@ -70,7 +70,6 @@ class TestCredentials(object):
         credentials = service_account.Credentials(
             SIGNER, self.SERVICE_ACCOUNT_EMAIL, self.TOKEN_URI, universe_domain=None
         )
-        assert credentials._universe_domain == service_account._DEFAULT_UNIVERSE_DOMAIN
         assert credentials.universe_domain == service_account._DEFAULT_UNIVERSE_DOMAIN
 
     def test_from_service_account_info(self):
@@ -89,7 +88,6 @@ class TestCredentials(object):
             SERVICE_ACCOUNT_INFO_NON_GDU
         )
 
-        assert credentials._universe_domain == FAKE_UNIVERSE_DOMAIN
         assert credentials.universe_domain == FAKE_UNIVERSE_DOMAIN
         assert credentials._always_use_jwt_access
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -42,6 +42,7 @@ def test_credentials_constructor():
     assert not credentials.expiry
     assert not credentials.expired
     assert not credentials.valid
+    assert credentials.universe_domain == "googleapis.com"
 
 
 def test_expired_and_valid():

--- a/tests/test_external_account.py
+++ b/tests/test_external_account.py
@@ -498,6 +498,13 @@ class TestCredentials(object):
             "universe_domain": "dummy_universe.com",
         }
 
+    def test_universe_domain(self):
+        credentials = self.make_credentials(universe_domain="dummy_universe.com")
+        assert credentials.universe_domain == "dummy_universe.com"
+
+        credentials = self.make_credentials()
+        assert credentials.universe_domain == external_account._DEFAULT_UNIVERSE_DOMAIN
+
     def test_info_workforce_pool(self):
         credentials = self.make_workforce_pool_credentials(
             workforce_pool_user_project=self.WORKFORCE_POOL_USER_PROJECT


### PR DESCRIPTION
Expose `universe_domain` by adding a property in the credential base class.