### PR TITLE
build: treat warnings as errors

### DIFF
--- a/google/auth/pluggable.py
+++ b/google/auth/pluggable.py
@@ -229,9 +229,8 @@ class Credentials(external_account.Credentials):
         # Handle executable output.
         response = json.loads(result.stdout.decode("utf-8")) if result.stdout else None
         if not response and self._credential_source_executable_output_file is not None:
-            response = json.load(
-                open(self._credential_source_executable_output_file, encoding="utf-8")
-            )
+            with open(self._credential_source_executable_output_file, encoding="utf-8") as file:
+                response = json.load(file)
 
         subject_token = self._parse_subject_token(response)
         return subject_token

--- a/google/auth/pluggable.py
+++ b/google/auth/pluggable.py
@@ -229,7 +229,9 @@ class Credentials(external_account.Credentials):
         # Handle executable output.
         response = json.loads(result.stdout.decode("utf-8")) if result.stdout else None
         if not response and self._credential_source_executable_output_file is not None:
-            with open(self._credential_source_executable_output_file, encoding="utf-8") as file:
+            with open(
+                self._credential_source_executable_output_file, encoding="utf-8"
+            ) as file:
                 response = json.load(file)
 
         subject_token = self._parse_subject_token(response)

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,6 @@ filterwarnings =
     ignore:After January 1, 2024, new releases of this library will drop support for Python 3.7:DeprecationWarning
     # Remove once https://github.com/googleapis/google-auth-library-python/issues/1431 is fixed
     ignore:coroutine 'AsyncMockMixin._execute_mock_call' was never awaited:RuntimeWarning
-    # Remove once https://github.com/googleapis/python-api-common-protos/pull/187/files is merged
+    # Remove once release PR https://github.com/googleapis/python-api-common-protos/pull/191 is merged
     ignore:.*pkg_resources.declare_namespace:DeprecationWarning
     ignore:.*pkg_resources is deprecated as an API:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+filterwarnings =
+    # treat all warnings as errors
+    error
+    # Remove once https://github.com/googleapis/google-auth-library-python/issues/1422 is fixed
+    ignore:Inheritance class AuthorizedSession from ClientSession is discouraged:DeprecationWarning
+    # Remove once support for Python 3.7 is dropped
+    ignore:After January 1, 2024, new releases of this library will drop support for Python 3.7:DeprecationWarning
+    # Remove once https://github.com/googleapis/google-auth-library-python/issues/1431 is fixed
+    ignore:coroutine 'AsyncMockMixin._execute_mock_call' was never awaited:RuntimeWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,6 @@ filterwarnings =
     ignore:After January 1, 2024, new releases of this library will drop support for Python 3.7:DeprecationWarning
     # Remove once https://github.com/googleapis/google-auth-library-python/issues/1431 is fixed
     ignore:coroutine 'AsyncMockMixin._execute_mock_call' was never awaited:RuntimeWarning
+    # Remove once https://github.com/googleapis/python-api-common-protos/pull/187/files is merged
+    ignore:.*pkg_resources.declare_namespace:DeprecationWarning
+    ignore:.*pkg_resources is deprecated as an API:DeprecationWarning

--- a/tests_async/oauth2/test_credentials_async.py
+++ b/tests_async/oauth2/test_credentials_async.py
@@ -489,25 +489,28 @@ class TestCredentials:
 
 class TestUserAccessTokenCredentials(object):
     def test_instance(self):
-        cred = _credentials_async.UserAccessTokenCredentials()
-        assert cred._account is None
+        with pytest.warns(UserWarning, match="UserAccessTokenCredentials is deprecated"):
+            cred = _credentials_async.UserAccessTokenCredentials()
+            assert cred._account is None
 
-        cred = cred.with_account("account")
-        assert cred._account == "account"
+            cred = cred.with_account("account")
+            assert cred._account == "account"
 
     @mock.patch("google.auth._cloud_sdk.get_auth_access_token", autospec=True)
     def test_refresh(self, get_auth_access_token):
-        get_auth_access_token.return_value = "access_token"
-        cred = _credentials_async.UserAccessTokenCredentials()
-        cred.refresh(None)
-        assert cred.token == "access_token"
+        with pytest.warns(UserWarning, match="UserAccessTokenCredentials is deprecated"):
+            get_auth_access_token.return_value = "access_token"
+            cred = _credentials_async.UserAccessTokenCredentials()
+            cred.refresh(None)
+            assert cred.token == "access_token"
 
     def test_with_quota_project(self):
-        cred = _credentials_async.UserAccessTokenCredentials()
-        quota_project_cred = cred.with_quota_project("project-foo")
+        with pytest.warns(UserWarning, match="UserAccessTokenCredentials is deprecated"):
+            cred = _credentials_async.UserAccessTokenCredentials()
+            quota_project_cred = cred.with_quota_project("project-foo")
 
-        assert quota_project_cred._quota_project_id == "project-foo"
-        assert quota_project_cred._account == cred._account
+            assert quota_project_cred._quota_project_id == "project-foo"
+            assert quota_project_cred._account == cred._account
 
     @mock.patch(
         "google.oauth2._credentials_async.UserAccessTokenCredentials.apply",
@@ -518,7 +521,8 @@ class TestUserAccessTokenCredentials(object):
         autospec=True,
     )
     def test_before_request(self, refresh, apply):
-        cred = _credentials_async.UserAccessTokenCredentials()
-        cred.before_request(mock.Mock(), "GET", "https://example.com", {})
-        refresh.assert_called()
-        apply.assert_called()
+        with pytest.warns(UserWarning, match="UserAccessTokenCredentials is deprecated"):
+            cred = _credentials_async.UserAccessTokenCredentials()
+            cred.before_request(mock.Mock(), "GET", "https://example.com", {})
+            refresh.assert_called()
+            apply.assert_called()

--- a/tests_async/oauth2/test_credentials_async.py
+++ b/tests_async/oauth2/test_credentials_async.py
@@ -489,7 +489,9 @@ class TestCredentials:
 
 class TestUserAccessTokenCredentials(object):
     def test_instance(self):
-        with pytest.warns(UserWarning, match="UserAccessTokenCredentials is deprecated"):
+        with pytest.warns(
+            UserWarning, match="UserAccessTokenCredentials is deprecated"
+        ):
             cred = _credentials_async.UserAccessTokenCredentials()
             assert cred._account is None
 
@@ -498,14 +500,18 @@ class TestUserAccessTokenCredentials(object):
 
     @mock.patch("google.auth._cloud_sdk.get_auth_access_token", autospec=True)
     def test_refresh(self, get_auth_access_token):
-        with pytest.warns(UserWarning, match="UserAccessTokenCredentials is deprecated"):
+        with pytest.warns(
+            UserWarning, match="UserAccessTokenCredentials is deprecated"
+        ):
             get_auth_access_token.return_value = "access_token"
             cred = _credentials_async.UserAccessTokenCredentials()
             cred.refresh(None)
             assert cred.token == "access_token"
 
     def test_with_quota_project(self):
-        with pytest.warns(UserWarning, match="UserAccessTokenCredentials is deprecated"):
+        with pytest.warns(
+            UserWarning, match="UserAccessTokenCredentials is deprecated"
+        ):
             cred = _credentials_async.UserAccessTokenCredentials()
             quota_project_cred = cred.with_quota_project("project-foo")
 
@@ -521,7 +527,9 @@ class TestUserAccessTokenCredentials(object):
         autospec=True,
     )
     def test_before_request(self, refresh, apply):
-        with pytest.warns(UserWarning, match="UserAccessTokenCredentials is deprecated"):
+        with pytest.warns(
+            UserWarning, match="UserAccessTokenCredentials is deprecated"
+        ):
             cred = _credentials_async.UserAccessTokenCredentials()
             cred.before_request(mock.Mock(), "GET", "https://example.com", {})
             refresh.assert_called()

--- a/tests_async/test_credentials_async.py
+++ b/tests_async/test_credentials_async.py
@@ -76,7 +76,7 @@ async def test_before_request():
     headers = {}
 
     # Second call shouldn't call refresh.
-    credentials.before_request(request, "http://example.com", "GET", headers)
+    await credentials.before_request(request, "http://example.com", "GET", headers)
 
     assert credentials.valid
     assert credentials.token == "token"


### PR DESCRIPTION
This PR adds a `pytest.ini` to treat warnings as errors.

I also included some simple fixes. Let me know if these should be pulled out into separate PRs with corresponding issues created.