### PR TITLE
fix: make requests import conditional for gce universe domain

### DIFF
--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -148,8 +148,9 @@ class Credentials(
     def universe_domain(self):
         if self._universe_domain_cached:
             return self._universe_domain
-        
+
         from google.auth.transport import requests as google_auth_requests
+
         self._universe_domain = _metadata.get_universe_domain(
             google_auth_requests.Request()
         )

--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -83,7 +83,6 @@ class Credentials(
         self._scopes = scopes
         self._default_scopes = default_scopes
         self._universe_domain_cached = False
-        self._universe_domain_request = None
         if universe_domain:
             self._universe_domain = universe_domain
             self._universe_domain_cached = True
@@ -149,11 +148,10 @@ class Credentials(
     def universe_domain(self):
         if self._universe_domain_cached:
             return self._universe_domain
-        if self._universe_domain_request is None:
-            from google.auth.transport import requests as google_auth_requests
-            self._universe_domain_request = google_auth_requests.Request()
+        
+        from google.auth.transport import requests as google_auth_requests
         self._universe_domain = _metadata.get_universe_domain(
-            self._universe_domain_request
+            google_auth_requests.Request()
         )
         self._universe_domain_cached = True
         return self._universe_domain

--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -28,7 +28,6 @@ from google.auth import iam
 from google.auth import jwt
 from google.auth import metrics
 from google.auth.compute_engine import _metadata
-from google.auth.transport import requests as google_auth_requests
 from google.oauth2 import _client
 
 
@@ -84,7 +83,7 @@ class Credentials(
         self._scopes = scopes
         self._default_scopes = default_scopes
         self._universe_domain_cached = False
-        self._universe_domain_request = google_auth_requests.Request()
+        self._universe_domain_request = None
         if universe_domain:
             self._universe_domain = universe_domain
             self._universe_domain_cached = True
@@ -150,6 +149,9 @@ class Credentials(
     def universe_domain(self):
         if self._universe_domain_cached:
             return self._universe_domain
+        if self._universe_domain_request is None:
+            from google.auth.transport import requests as google_auth_requests
+            self._universe_domain_request = google_auth_requests.Request()
         self._universe_domain = _metadata.get_universe_domain(
             self._universe_domain_request
         )

--- a/tests/compute_engine/test_credentials.py
+++ b/tests/compute_engine/test_credentials.py
@@ -257,16 +257,12 @@ class TestCredentials(object):
         assert self.credentials.universe_domain == "fake_universe_domain"
         assert self.credentials._universe_domain == "fake_universe_domain"
         assert self.credentials._universe_domain_cached
-        get_universe_domain.assert_called_once_with(
-            self.credentials._universe_domain_request
-        )
+        get_universe_domain.assert_called_once()
 
         # calling the universe_domain property the second time should use the
         # cached value instead of calling get_universe_domain
         assert self.credentials.universe_domain == "fake_universe_domain"
-        get_universe_domain.assert_called_once_with(
-            self.credentials._universe_domain_request
-        )
+        get_universe_domain.assert_called_once()
 
     @mock.patch("google.auth.compute_engine._metadata.get_universe_domain")
     def test_user_provided_universe_domain(self, get_universe_domain):


### PR DESCRIPTION
In [#1433](https://github.com/googleapis/google-auth-library-python/issues/1433) a dependency for requests was introduced unconditionally i.e. requests lib was required for anyone use gce mds even if they are not using TPC. This PR makes the import conditional.