### PR TITLE
Make init.py to can load google.auth and google.outh2 with import google

### DIFF
--- a/google/__init__.py
+++ b/google/__init__.py
@@ -1,0 +1,2 @@
+import google.auth
+import google.oauth2


### PR DESCRIPTION
For fix this issue https://github.com/googleapis/google-auth-library-python/issues/1426
You can load google.auth and google.outh2 with import google