### PR TITLE
fix: don't re-add metrics to x-goog-api-client header

### DIFF
--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -229,7 +229,7 @@ class Credentials(metaclass=abc.ABCMeta):
         else:
             self._blocking_refresh(request)
 
-        metrics.add_metric_header(headers, self._metric_header_for_usage())
+        # metrics.add_metric_header(headers, self._metric_header_for_usage())
         self.apply(headers)
 
     def with_non_blocking_refresh(self):

--- a/google/auth/metrics.py
+++ b/google/auth/metrics.py
@@ -150,5 +150,7 @@ def add_metric_header(headers, metric_header_value):
         return
     if API_CLIENT_HEADER not in headers:
         headers[API_CLIENT_HEADER] = metric_header_value
-    elif metric_header_value not in headers[API_CLIENT_HEADER]:
-        headers[API_CLIENT_HEADER] += " " + metric_header_value
+        return
+    if "cred-type" in headers[API_CLIENT_HEADER]:
+        return
+    headers[API_CLIENT_HEADER] += " " + metric_header_value

--- a/google/auth/metrics.py
+++ b/google/auth/metrics.py
@@ -150,5 +150,5 @@ def add_metric_header(headers, metric_header_value):
         return
     if API_CLIENT_HEADER not in headers:
         headers[API_CLIENT_HEADER] = metric_header_value
-    else:
+    elif metric_header_value not in headers[API_CLIENT_HEADER]:
         headers[API_CLIENT_HEADER] += " " + metric_header_value

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -29,9 +29,9 @@ def test_add_metric_header():
     metrics.add_metric_header(headers, "bar")
     assert headers == {"x-goog-api-client": "foo bar"}
 
-    headers = {"x-goog-api-client": "foo"}
-    metrics.add_metric_header(headers, "foo")
-    assert headers == {"x-goog-api-client": "foo"}
+    headers = {"x-goog-api-client": "cred-type/mds"}
+    metrics.add_metric_header(headers, "cred-type/mds")
+    assert headers == {"x-goog-api-client": "cred-type/mds"}
 
     headers = {}
     metrics.add_metric_header(headers, "bar")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -29,6 +29,10 @@ def test_add_metric_header():
     metrics.add_metric_header(headers, "bar")
     assert headers == {"x-goog-api-client": "foo bar"}
 
+    headers = {"x-goog-api-client": "foo"}
+    metrics.add_metric_header(headers, "foo")
+    assert headers == {"x-goog-api-client": "foo"}
+
     headers = {}
     metrics.add_metric_header(headers, "bar")
     assert headers == {"x-goog-api-client": "bar"}


### PR DESCRIPTION
attempt to fix #1539 