### PR TITLE
chore: Add anonymous credentials json file

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -30,6 +30,7 @@ import google.auth.transport._http_client
 _LOGGER = logging.getLogger(__name__)
 
 # Valid types accepted for file-based credentials.
+_ANONYMOUS_TYPE = "anonymous"
 _AUTHORIZED_USER_TYPE = "authorized_user"
 _SERVICE_ACCOUNT_TYPE = "service_account"
 _EXTERNAL_ACCOUNT_TYPE = "external_account"
@@ -37,6 +38,7 @@ _EXTERNAL_ACCOUNT_AUTHORIZED_USER_TYPE = "external_account_authorized_user"
 _IMPERSONATED_SERVICE_ACCOUNT_TYPE = "impersonated_service_account"
 _GDCH_SERVICE_ACCOUNT_TYPE = "gdch_service_account"
 _VALID_TYPES = (
+    _ANONYMOUS_TYPE,
     _AUTHORIZED_USER_TYPE,
     _SERVICE_ACCOUNT_TYPE,
     _EXTERNAL_ACCOUNT_TYPE,
@@ -209,6 +211,8 @@ def _load_credentials_from_info(
         )
     elif credential_type == _GDCH_SERVICE_ACCOUNT_TYPE:
         credentials, project_id = _get_gdch_service_account_credentials(filename, info)
+    elif credential_type == _ANONYMOUS_TYPE:
+        credentials, project_id = _get_anonymous_credentials()
     else:
         raise exceptions.DefaultCredentialsError(
             "The file {file} does not have a valid type. "
@@ -424,6 +428,14 @@ def _get_external_account_authorized_user_credentials(
                 filename
             )
         )
+
+    return credentials, None
+
+
+def _get_anonymous_credentials():
+    from google.auth import credentials
+
+    credentials = credentials.AnonymousCredentials()
 
     return credentials, None
 

--- a/tests/data/anonymous.json
+++ b/tests/data/anonymous.json
@@ -1,0 +1,1 @@
+{"type": "anonymous"}

--- a/tests/test__default.py
+++ b/tests/test__default.py
@@ -140,6 +140,7 @@ IMPERSONATED_IDENTITY_POOL_WORKFORCE_DATA = {
     "service_account_impersonation_url": SERVICE_ACCOUNT_IMPERSONATION_URL,
     "workforce_pool_user_project": WORKFORCE_POOL_USER_PROJECT,
 }
+ANONYMOUS_DATA = {"type": "anonymous"}
 
 IMPERSONATED_SERVICE_ACCOUNT_AUTHORIZED_USER_SOURCE_FILE = os.path.join(
     DATA_DIR, "impersonated_service_account_authorized_user_source.json"
@@ -160,6 +161,7 @@ EXTERNAL_ACCOUNT_AUTHORIZED_USER_FILE = os.path.join(
 EXTERNAL_ACCOUNT_AUTHORIZED_USER_NON_GDU_FILE = os.path.join(
     DATA_DIR, "external_account_authorized_user_non_gdu.json"
 )
+ANONYMOUS_FILE = os.path.join(DATA_DIR, "anonymous.json")
 
 MOCK_CREDENTIALS = mock.Mock(spec=credentials.CredentialsWithQuotaProject)
 MOCK_CREDENTIALS.with_quota_project.return_value = MOCK_CREDENTIALS
@@ -1362,3 +1364,15 @@ def test_quota_gce_credentials(unused_get, unused_ping):
         quota_project_id=explicit_quota
     )
     assert credentials.quota_project_id == explicit_quota
+
+
+def test_load_credentials_from_file_anonymous():
+    credentials, project_id = _default.load_credentials_from_file(ANONYMOUS_FILE)
+    assert isinstance(credentials, google.auth.credentials.Credentials)
+    assert project_id is None
+
+
+def test_load_credentials_from_dict_anonymous():
+    credentials, project_id = _default.load_credentials_from_dict(ANONYMOUS_DATA)
+    assert isinstance(credentials, google.auth.credentials.Credentials)
+    assert project_id is None


### PR DESCRIPTION
This allows one to use a credentials json file to create anonymous credentials.  

https://googleapis.dev/python/google-auth/latest/_modules/google/auth/credentials.html#AnonymousCredentials

As the docs for `AnonymousCredentials` themselves states, this only useful for anonymous services and emulators.  But it would mean that one could include a credentials file in a project that used an emulator and authenticate in the exact same way as with real credentials.  Otherwise one needs to add application logic to allow for anonymous credentials and real credentials.