### PR TITLE
feat: Implement asynchronous `AuthorizedSession` class

### DIFF
--- a/google/auth/aio/transport/__init__.py
+++ b/google/auth/aio/transport/__init__.py
@@ -29,6 +29,8 @@ import http.client as http_client
 from typing import AsyncGenerator, Dict, Mapping, Optional
 
 
+_DEFAULT_TIMEOUT_SECONDS = 180
+
 DEFAULT_RETRYABLE_STATUS_CODES = (
     http_client.INTERNAL_SERVER_ERROR,
     http_client.SERVICE_UNAVAILABLE,

--- a/google/auth/aio/transport/__init__.py
+++ b/google/auth/aio/transport/__init__.py
@@ -41,7 +41,6 @@ DEFAULT_REFRESH_STATUS_CODES = google.auth.transport.DEFAULT_REFRESH_STATUS_CODE
 refreshed.
 """
 
-# TODO (ohmayr): We are no longer using this. Should this be removed?
 DEFAULT_MAX_REFRESH_ATTEMPTS = google.auth.transport.DEFAULT_MAX_REFRESH_ATTEMPTS
 """int: How many times to refresh the credentials and retry a request."""
 

--- a/google/auth/aio/transport/__init__.py
+++ b/google/auth/aio/transport/__init__.py
@@ -25,7 +25,7 @@ for the return value of :class:`Request`.
 """
 
 import abc
-from typing import AsyncGenerator, Dict, Mapping, Optional
+from typing import AsyncGenerator, Mapping, Optional
 
 import google.auth.transport
 
@@ -52,7 +52,7 @@ class Response(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def status_code(self) -> int:
         """
-        The HTTP response status code..
+        The HTTP response status code.
 
         Returns:
             int: The HTTP response status code.
@@ -62,11 +62,11 @@ class Response(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def headers(self) -> Dict[str, str]:
+    def headers(self) -> Mapping[str, str]:
         """The HTTP response headers.
 
         Returns:
-            Dict[str, str]: The HTTP response headers.
+            Mapping[str, str]: The HTTP response headers.
         """
         raise NotImplementedError("headers must be implemented.")
 
@@ -112,7 +112,7 @@ class Request(metaclass=abc.ABCMeta):
         self,
         url: str,
         method: str,
-        body: bytes,
+        body: Optional[bytes],
         headers: Optional[Mapping[str, str]],
         timeout: float,
         **kwargs
@@ -123,7 +123,7 @@ class Request(metaclass=abc.ABCMeta):
             url (str): The URI to be requested.
             method (str): The HTTP method to use for the request. Defaults
                 to 'GET'.
-            body (bytes): The payload / body in HTTP request.
+            body (Optional[bytes]): The payload / body in HTTP request.
             headers (Mapping[str, str]): Request headers.
             timeout (float): The number of seconds to wait for a
                 response from the server. If not specified or if None, the

--- a/google/auth/aio/transport/__init__.py
+++ b/google/auth/aio/transport/__init__.py
@@ -41,7 +41,7 @@ DEFAULT_REFRESH_STATUS_CODES = google.auth.transport.DEFAULT_REFRESH_STATUS_CODE
 refreshed.
 """
 
-DEFAULT_MAX_REFRESH_ATTEMPTS = google.auth.transport.DEFAULT_MAX_REFRESH_ATTEMPTS
+DEFAULT_MAX_REFRESH_ATTEMPTS = 3
 """int: How many times to refresh the credentials and retry a request."""
 
 

--- a/google/auth/aio/transport/__init__.py
+++ b/google/auth/aio/transport/__init__.py
@@ -23,3 +23,24 @@ to support HTTP libraries. :class:`Request` defines the interface expected by
 :mod:`google.auth` to make asynchronous requests. :class:`Response` defines the interface
 for the return value of :class:`Request`.
 """
+
+
+import http.client as http_client
+
+DEFAULT_RETRYABLE_STATUS_CODES = (
+    http_client.INTERNAL_SERVER_ERROR,
+    http_client.SERVICE_UNAVAILABLE,
+    http_client.REQUEST_TIMEOUT,
+    http_client.TOO_MANY_REQUESTS,
+)
+"""Sequence[int]:  HTTP status codes indicating a request can be retried.
+"""
+
+
+DEFAULT_REFRESH_STATUS_CODES = (http_client.UNAUTHORIZED,)
+"""Sequence[int]:  Which HTTP status code indicate that credentials should be
+refreshed.
+"""
+
+DEFAULT_MAX_REFRESH_ATTEMPTS = 2
+"""int: How many times to refresh the credentials and retry a request."""

--- a/google/auth/aio/transport/__init__.py
+++ b/google/auth/aio/transport/__init__.py
@@ -25,27 +25,24 @@ for the return value of :class:`Request`.
 """
 
 import abc
-import http.client as http_client
 from typing import AsyncGenerator, Dict, Mapping, Optional
+
+import google.auth.transport
 
 
 _DEFAULT_TIMEOUT_SECONDS = 180
 
-DEFAULT_RETRYABLE_STATUS_CODES = (
-    http_client.INTERNAL_SERVER_ERROR,
-    http_client.SERVICE_UNAVAILABLE,
-    http_client.REQUEST_TIMEOUT,
-    http_client.TOO_MANY_REQUESTS,
-)
+DEFAULT_RETRYABLE_STATUS_CODES = google.auth.transport.DEFAULT_RETRYABLE_STATUS_CODES
 """Sequence[int]:  HTTP status codes indicating a request can be retried.
 """
 
-DEFAULT_REFRESH_STATUS_CODES = (http_client.UNAUTHORIZED,)
+DEFAULT_REFRESH_STATUS_CODES = google.auth.transport.DEFAULT_REFRESH_STATUS_CODES
 """Sequence[int]:  Which HTTP status code indicate that credentials should be
 refreshed.
 """
 
-DEFAULT_MAX_REFRESH_ATTEMPTS = 2
+# TODO (ohmayr): We are no longer using this. Should this be removed?
+DEFAULT_MAX_REFRESH_ATTEMPTS = google.auth.transport.DEFAULT_MAX_REFRESH_ATTEMPTS
 """int: How many times to refresh the credentials and retry a request."""
 
 

--- a/google/auth/aio/transport/aiohttp.py
+++ b/google/auth/aio/transport/aiohttp.py
@@ -16,10 +16,10 @@
 """
 
 import asyncio
-from typing import AsyncGenerator, Dict, Mapping, Optional
+from typing import AsyncGenerator, Mapping, Optional
 
 try:
-    import aiohttp
+    import aiohttp  # type: ignore
 except ImportError as caught_exc:  # pragma: NO COVER
     raise ImportError(
         "The aiohttp library is not installed from please install the aiohttp package to use the aiohttp transport."
@@ -39,7 +39,7 @@ class Response(transport.Response):
 
     Attributes:
         status_code (int): The HTTP status code of the response.
-        headers (Dict[str, str]): A case-insensitive multidict proxy wiht HTTP headers of response.
+        headers (Mapping[str, str]): The HTTP headers of the response.
     """
 
     def __init__(self, response: aiohttp.ClientResponse):
@@ -52,7 +52,7 @@ class Response(transport.Response):
 
     @property
     @_helpers.copy_docstring(transport.Response)
-    def headers(self) -> Dict[str, str]:
+    def headers(self) -> Mapping[str, str]:
         return {key: value for key, value in self._response.headers.items()}
 
     @_helpers.copy_docstring(transport.Response)
@@ -149,14 +149,14 @@ class Request(transport.Request):
             return Response(response)
 
         except aiohttp.ClientError as caught_exc:
-            new_exc = exceptions.TransportError(f"Failed to send request to {url}.")
-            raise new_exc from caught_exc
+            client_exc = exceptions.TransportError(f"Failed to send request to {url}.")
+            raise client_exc from caught_exc
 
         except asyncio.TimeoutError as caught_exc:
-            new_exc = exceptions.TimeoutError(
+            timeout_exc = exceptions.TimeoutError(
                 f"Request timed out after {timeout} seconds."
             )
-            raise new_exc from caught_exc
+            raise timeout_exc from caught_exc
 
     async def close(self) -> None:
         """

--- a/google/auth/aio/transport/sessions.py
+++ b/google/auth/aio/transport/sessions.py
@@ -1,0 +1,252 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Mapping, Optional
+
+from google.auth.aio import transport
+from google.auth.aio.credentials import Credentials
+
+try:
+    import aiohttp
+
+    AIOHTTP_INSTALLED = True
+except ImportError:
+    AIOHTTP_INSTALLED = False
+
+# TODO (ohmayr): Uncomment this when the timeout guard PR is merged.
+# from google.auth.exceptions import TimeoutError
+
+# TODO (ohmayr): Maybe move _DEFAULT_TIMEOUT to __init__.py
+_DEFAULT_TIMEOUT = 180  # in seconds
+
+
+class AuthorizedSession:
+
+    """This is an asynchronous implementation of the Authorized Session class. We utilize an
+    instance of a class that implements `google.auth.aio.transport.Request` configured by the caller
+    or otherwise default to `google.auth.aio.transport.aiohttp.Request` if the external aiohttp package
+    is installed.
+
+    A Requests Session class with credentials.
+
+    This class is used to perform asynchronous requests to API endpoints that require
+    authorization::
+
+        import aiohttp
+        from google.auth.aio.transport import sessions
+        
+        async with sessions.AuthorizedSession(credentials) as authed_session:
+            response = await authed_session.request(
+                'GET', 'https://www.googleapis.com/storage/v1/b')
+
+    The underlying :meth:`request` implementation handles adding the
+    credentials' headers to the request and refreshing credentials as needed.
+
+    Args:
+        credentials (google.auth.aio.credentials.Credentials):
+            The credentials to add to the request.
+        auth_request (google.auth.aio.transport.Request):
+            (Optional) An instance of a class that implements
+            :class:`~google.auth.aio.transport.Request` used to make requests
+            and refresh credentials. If not passed,
+            an instance of :class:`~google.auth.aio.transport.aiohttp.Request`
+            is created.
+
+    Raises:
+        ValueError: If `auth_request` is `None` and the external package `aiohttp` is not installed.
+    """
+
+    def __init__(
+        self, credentials: Credentials, auth_request: transport.Request = None
+    ):
+        self._auth_request = auth_request or (
+            AIOHTTP_INSTALLED and transport.aiohttp.Request()
+        )
+        if not self._auth_request:
+            raise ValueError(
+                "`auth_request` must either be configured or the external package `aiohttp` must be installed to use the default value."
+            )
+
+        self._credentials = credentials
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        data: bytes = None,
+        headers: Mapping[str, str] = None,
+        max_allowed_time: Optional[
+            float
+        ] = None,  # TODO (ohmayr): set a default value for timeout.
+        timeout: Optional[float] = _DEFAULT_TIMEOUT,
+        **kwargs,
+    ) -> transport.Response:
+
+        """
+        Args:
+                method (str): The http method used to make the request.
+                url (str): The URI to be requested.
+                data (bytes): The payload or body in HTTP request.
+                headers (Mapping[str, str]): Request headers.       
+                timeout (Optional[float]):
+                The amount of time in seconds to wait for the server response
+                with each individual request.
+                max_allowed_time (Optional[float]):
+                If the method runs longer than this, a ``Timeout`` exception is
+                automatically raised. Unlike the ``timeout`` parameter, this
+                value applies to the total method execution time, even if
+                multiple requests are made under the hood.
+
+                Mind that it is not guaranteed that the timeout error is raised
+                at ``max_allowed_time``. It might take longer, for example, if
+                an underlying request takes a lot of time, but the request
+                itself does not timeout, e.g. if a large file is being
+                transmitted. The timout error will be raised after such
+                request completes.
+        
+        Raises:
+        # TODO (ohmayr): populate this.
+
+        Returns:
+        # TODO (ohmayr): populate this.
+
+        # TODO (ohmayr): Investigate if this is required.
+        # I think it is reasonable to agree on a strict type for headers and 
+        # let the caller handle any translation.
+            if headers:
+                for key in headers.keys():
+                    if type(headers[key]) is bytes:
+                        headers[key] = headers[key].decode("utf-8")
+
+        # Headers come in as bytes which isn't expected behavior, the resumable
+        # media libraries in some cases expect a str type for the header values,
+        # but sometimes the operations return these in bytes types.
+        """
+
+        if not isinstance(self._credentials, Credentials):
+            raise ValueError(
+                "The configured credentials are invalid and must be of type `google.auth.aio.credentials.Credentials`"
+            )
+
+        _credentials_refresh_attempt = 0
+        response = None
+
+        try:
+            async with timeout_guard(max_allowed_time) as with_timeout:
+                while (
+                    _credentials_refresh_attempt
+                    < transport.DEFAULT_MAX_REFRESH_ATTEMPTS
+                ):
+                    if self.credentials and not _credentials_refresh_attempt:
+                        await with_timeout(
+                            self.credentials.before_request(None, method, url, headers)
+                        )
+
+                    response = await with_timeout(
+                        self._auth_request(
+                            url, method, data, headers, timeout, **kwargs
+                        )
+                    )
+                    if response.status_code in transport.DEFAULT_REFRESH_STATUS_CODES:
+                        await with_timeout(self.credentials.refresh(self._auth_request))
+                        _credentials_refresh_attempt += 1
+                    else:
+                        return response
+
+        except TimeoutError as exc:
+            raise exc
+
+        return response
+
+    async def get(
+        self,
+        url: str,
+        data: bytes = None,
+        headers: Mapping[str, str] = None,
+        max_allowed_time: Optional[
+            float
+        ] = None,  # TODO (ohmayr): set a default value for timeout.
+        timeout: Optional[float] = _DEFAULT_TIMEOUT,
+        **kwargs,
+    ) -> transport.Response:
+        return await self.request(
+            "get", url, data, headers, max_allowed_time, timeout, **kwargs
+        )
+
+    async def post(
+        self,
+        url: str,
+        data: bytes = None,
+        headers: Mapping[str, str] = None,
+        max_allowed_time: Optional[
+            float
+        ] = None,  # TODO (ohmayr): set a default value for timeout.
+        timeout: Optional[float] = _DEFAULT_TIMEOUT,
+        **kwargs,
+    ) -> transport.Response:
+        return await self.request(
+            "post", url, data, headers, max_allowed_time, timeout, **kwargs
+        )
+
+    async def put(
+        self,
+        url: str,
+        data: bytes = None,
+        headers: Mapping[str, str] = None,
+        max_allowed_time: Optional[
+            float
+        ] = None,  # TODO (ohmayr): set a default value for timeout.
+        timeout: Optional[float] = _DEFAULT_TIMEOUT,
+        **kwargs,
+    ) -> transport.Response:
+        return await self.request(
+            "put", url, data, headers, max_allowed_time, timeout, **kwargs
+        )
+
+    async def patch(
+        self,
+        url: str,
+        data: bytes = None,
+        headers: Mapping[str, str] = None,
+        max_allowed_time: Optional[
+            float
+        ] = None,  # TODO (ohmayr): set a default value for timeout.
+        timeout: Optional[float] = _DEFAULT_TIMEOUT,
+        **kwargs,
+    ) -> transport.Response:
+        return await self.request(
+            "patch", url, data, headers, max_allowed_time, timeout, **kwargs
+        )
+
+    async def delete(
+        self,
+        url: str,
+        data: bytes = None,
+        headers: Mapping[str, str] = None,
+        max_allowed_time: Optional[
+            float
+        ] = None,  # TODO (ohmayr): set a default value for timeout.
+        timeout: Optional[float] = _DEFAULT_TIMEOUT,
+        **kwargs,
+    ) -> transport.Response:
+        return await self.request(
+            "delete", url, data, headers, max_allowed_time, timeout, **kwargs
+        )
+
+    async def close(self) -> None:
+        """
+        Close the underlying auth request session.
+        """
+        if self._auth_request:
+            await self._auth_request.close()

--- a/google/auth/aio/transport/sessions.py
+++ b/google/auth/aio/transport/sessions.py
@@ -159,6 +159,11 @@ class AuthorizedSession:
                         )
                     )
                     if response.status_code in transport.DEFAULT_REFRESH_STATUS_CODES:
+                        
+                        # Note: Credentials should not be refreshed if an attempt to refresh
+                        # is already made by another request. To ensure that multiple, requests
+                        # do not attempt to refresh credentials, acquiring and releasing lock
+                        # to safeguard this should happen within the refresh method.
                         await with_timeout(self.credentials.refresh(self._auth_request))
                         _credentials_refresh_attempt += 1
                     else:

--- a/google/auth/aio/transport/sessions.py
+++ b/google/auth/aio/transport/sessions.py
@@ -27,7 +27,7 @@ try:
     from google.auth.aio.transport.aiohttp import Request as AiohttpRequest
 
     AIOHTTP_INSTALLED = True
-except ImportError:
+except ImportError:  # pragma: NO COVER
     AIOHTTP_INSTALLED = False
 
 
@@ -181,7 +181,9 @@ class AuthorizedSession:
                     self._auth_request, method, url, headers
                 )
             )
-            async for _ in retries:
+            # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+            # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
+            async for _ in retries:  # pragma: no branch
                 response = await with_timeout(
                     self._auth_request(url, method, data, headers, timeout, **kwargs)
                 )

--- a/google/auth/aio/transport/sessions.py
+++ b/google/auth/aio/transport/sessions.py
@@ -207,10 +207,8 @@ class AuthorizedSession:
                         not in transport.DEFAULT_RETRYABLE_STATUS_CODES
                     ):
                         return response
-
         except TimeoutError as exc:
             raise exc
-
         return response
 
     async def get(

--- a/tests/test__exponential_backoff.py
+++ b/tests/test__exponential_backoff.py
@@ -57,17 +57,17 @@ def test_minimum_total_attempts():
 
 
 @pytest.mark.asyncio
-@mock.patch("asyncio.sleep", return_value=mock.AsyncMock(return_value=None))
-async def test_exponential_backoff_async(mock_time):
+@mock.patch("asyncio.sleep", return_value=None)
+async def test_exponential_backoff_async(mock_time_async):
     eb = _exponential_backoff.AsyncExponentialBackoff()
     curr_wait = eb._current_wait_in_seconds
     iteration_count = 0
 
     async for attempt in eb:
         if attempt == 1:
-            assert mock_time.call_count == 0
+            assert mock_time_async.call_count == 0
         else:
-            backoff_interval = mock_time.call_args[0][0]
+            backoff_interval = mock_time_async.call_args[0][0]
             jitter = curr_wait * eb._randomization_factor
 
             assert (curr_wait - jitter) <= backoff_interval <= (curr_wait + jitter)
@@ -82,7 +82,8 @@ async def test_exponential_backoff_async(mock_time):
     assert eb.backoff_count == _exponential_backoff._DEFAULT_RETRY_TOTAL_ATTEMPTS
     assert iteration_count == _exponential_backoff._DEFAULT_RETRY_TOTAL_ATTEMPTS
     assert (
-        mock_time.call_count == _exponential_backoff._DEFAULT_RETRY_TOTAL_ATTEMPTS - 1
+        mock_time_async.call_count
+        == _exponential_backoff._DEFAULT_RETRY_TOTAL_ATTEMPTS - 1
     )
 
 

--- a/tests/test__exponential_backoff.py
+++ b/tests/test__exponential_backoff.py
@@ -63,7 +63,9 @@ async def test_exponential_backoff_async(mock_time_async):
     curr_wait = eb._current_wait_in_seconds
     iteration_count = 0
 
-    async for attempt in eb:
+    # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+    # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
+    async for attempt in eb:  # pragma: no branch
         if attempt == 1:
             assert mock_time_async.call_count == 0
         else:

--- a/tests/test__exponential_backoff.py
+++ b/tests/test__exponential_backoff.py
@@ -54,3 +54,41 @@ def test_minimum_total_attempts():
     with pytest.raises(exceptions.InvalidValue):
         _exponential_backoff.ExponentialBackoff(total_attempts=-1)
     _exponential_backoff.ExponentialBackoff(total_attempts=1)
+
+
+@pytest.mark.asyncio
+@mock.patch("asyncio.sleep", return_value=mock.AsyncMock(return_value=None))
+async def test_exponential_backoff_async(mock_time):
+    eb = _exponential_backoff.AsyncExponentialBackoff()
+    curr_wait = eb._current_wait_in_seconds
+    iteration_count = 0
+
+    async for attempt in eb:
+        if attempt == 1:
+            assert mock_time.call_count == 0
+        else:
+            backoff_interval = mock_time.call_args[0][0]
+            jitter = curr_wait * eb._randomization_factor
+
+            assert (curr_wait - jitter) <= backoff_interval <= (curr_wait + jitter)
+            assert attempt == iteration_count + 1
+            assert eb.backoff_count == iteration_count + 1
+            assert eb._current_wait_in_seconds == eb._multiplier ** iteration_count
+
+            curr_wait = eb._current_wait_in_seconds
+        iteration_count += 1
+
+    assert eb.total_attempts == _exponential_backoff._DEFAULT_RETRY_TOTAL_ATTEMPTS
+    assert eb.backoff_count == _exponential_backoff._DEFAULT_RETRY_TOTAL_ATTEMPTS
+    assert iteration_count == _exponential_backoff._DEFAULT_RETRY_TOTAL_ATTEMPTS
+    assert (
+        mock_time.call_count == _exponential_backoff._DEFAULT_RETRY_TOTAL_ATTEMPTS - 1
+    )
+
+
+def test_minimum_total_attempts_async():
+    with pytest.raises(exceptions.InvalidValue):
+        _exponential_backoff.AsyncExponentialBackoff(total_attempts=0)
+    with pytest.raises(exceptions.InvalidValue):
+        _exponential_backoff.AsyncExponentialBackoff(total_attempts=-1)
+    _exponential_backoff.AsyncExponentialBackoff(total_attempts=1)

--- a/tests/transport/aio/test_aiohttp.py
+++ b/tests/transport/aio/test_aiohttp.py
@@ -14,17 +14,17 @@
 
 import asyncio
 
-from aioresponses import aioresponses
+from aioresponses import aioresponses  # type: ignore
 from mock import AsyncMock, Mock
 import pytest  # type: ignore
-import pytest_asyncio
+import pytest_asyncio  # type: ignore
 
 from google.auth import exceptions
 import google.auth.aio.transport.aiohttp as auth_aiohttp
 
 
 try:
-    import aiohttp
+    import aiohttp  # type: ignore
 except ImportError as caught_exc:  # pragma: NO COVER
     raise ImportError(
         "The aiohttp library is not installed from please install the aiohttp package to use the aiohttp transport."

--- a/tests/transport/aio/test_aiohttp.py
+++ b/tests/transport/aio/test_aiohttp.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import asyncio
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 
 from aioresponses import aioresponses
 import pytest  # type: ignore
@@ -21,7 +21,6 @@ import pytest_asyncio
 
 from google.auth import exceptions
 import google.auth.aio.transport.aiohttp as auth_aiohttp
-from google.auth.exceptions import TimeoutError
 
 
 try:
@@ -30,11 +29,6 @@ except ImportError as caught_exc:  # pragma: NO COVER
     raise ImportError(
         "The aiohttp library is not installed from please install the aiohttp package to use the aiohttp transport."
     ) from caught_exc
-
-
-@pytest.fixture
-async def simple_async_task():
-    return True
 
 
 @pytest.fixture
@@ -89,65 +83,6 @@ class TestResponse(object):
         except StopAsyncIteration:
             pass
         assert b"".join(content) == b"Cavefish have no sight."
-
-
-class TestTimeoutGuard(object):
-    default_timeout = 1
-
-    def make_timeout_guard(self, timeout):
-        return auth_aiohttp.timeout_guard(timeout)
-
-    @pytest.mark.asyncio
-    async def test_timeout_with_simple_async_task_within_bounds(
-        self, simple_async_task
-    ):
-        task = False
-        with patch("time.monotonic", side_effect=[0, 0.25, 0.75]):
-            with patch("asyncio.wait_for", lambda coro, timeout: coro):
-                async with self.make_timeout_guard(
-                    timeout=self.default_timeout
-                ) as with_timeout:
-                    task = await with_timeout(simple_async_task)
-
-        # Task succeeds.
-        assert task is True
-
-    @pytest.mark.asyncio
-    async def test_timeout_with_simple_async_task_out_of_bounds(
-        self, simple_async_task
-    ):
-        task = False
-        with patch("time.monotonic", side_effect=[0, 1, 1]):
-            with patch("asyncio.wait_for", lambda coro, timeout: coro):
-                with pytest.raises(TimeoutError) as exc:
-                    async with self.make_timeout_guard(
-                        timeout=self.default_timeout
-                    ) as with_timeout:
-                        task = await with_timeout(simple_async_task)
-
-        # Task does not succeed and the context manager times out i.e. no remaining time left.
-        assert task is False
-        assert exc.match(
-            f"Context manager exceeded the configured timeout of {self.default_timeout}s."
-        )
-
-    @pytest.mark.asyncio
-    async def test_timeout_with_async_task_timing_out_before_context(
-        self, simple_async_task
-    ):
-        task = False
-        with pytest.raises(TimeoutError) as exc:
-            async with self.make_timeout_guard(
-                timeout=self.default_timeout
-            ) as with_timeout:
-                with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
-                    task = await with_timeout(simple_async_task)
-
-        # Task does not complete i.e. the operation times out.
-        assert task is False
-        assert exc.match(
-            f"The operation {simple_async_task} exceeded the configured timeout of {self.default_timeout}s."
-        )
 
 
 @pytest.mark.asyncio

--- a/tests/transport/aio/test_aiohttp.py
+++ b/tests/transport/aio/test_aiohttp.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import asyncio
-from unittest.mock import AsyncMock, Mock
 
 from aioresponses import aioresponses
+from mock import AsyncMock, Mock
 import pytest  # type: ignore
 import pytest_asyncio
 

--- a/tests/transport/aio/test_sessions.py
+++ b/tests/transport/aio/test_sessions.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/transport/aio/test_sessions.py
+++ b/tests/transport/aio/test_sessions.py
@@ -11,3 +11,75 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest  # type: ignore
+
+import google.auth.aio.transport.sessions as auth_sessions
+from google.auth.exceptions import TimeoutError
+
+
+@pytest.fixture
+async def simple_async_task():
+    return True
+
+
+class TestTimeoutGuard(object):
+    default_timeout = 1
+
+    def make_timeout_guard(self, timeout):
+        return auth_sessions.timeout_guard(timeout)
+
+    @pytest.mark.asyncio
+    async def test_timeout_with_simple_async_task_within_bounds(
+        self, simple_async_task
+    ):
+        task = False
+        with patch("time.monotonic", side_effect=[0, 0.25, 0.75]):
+            with patch("asyncio.wait_for", lambda coro, timeout: coro):
+                async with self.make_timeout_guard(
+                    timeout=self.default_timeout
+                ) as with_timeout:
+                    task = await with_timeout(simple_async_task)
+
+        # Task succeeds.
+        assert task is True
+
+    @pytest.mark.asyncio
+    async def test_timeout_with_simple_async_task_out_of_bounds(
+        self, simple_async_task
+    ):
+        task = False
+        with patch("time.monotonic", side_effect=[0, 1, 1]):
+            with patch("asyncio.wait_for", lambda coro, timeout: coro):
+                with pytest.raises(TimeoutError) as exc:
+                    async with self.make_timeout_guard(
+                        timeout=self.default_timeout
+                    ) as with_timeout:
+                        task = await with_timeout(simple_async_task)
+
+        # Task does not succeed and the context manager times out i.e. no remaining time left.
+        assert task is False
+        assert exc.match(
+            f"Context manager exceeded the configured timeout of {self.default_timeout}s."
+        )
+
+    @pytest.mark.asyncio
+    async def test_timeout_with_async_task_timing_out_before_context(
+        self, simple_async_task
+    ):
+        task = False
+        with pytest.raises(TimeoutError) as exc:
+            async with self.make_timeout_guard(
+                timeout=self.default_timeout
+            ) as with_timeout:
+                with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+                    task = await with_timeout(simple_async_task)
+
+        # Task does not complete i.e. the operation times out.
+        assert task is False
+        assert exc.match(
+            f"The operation {simple_async_task} exceeded the configured timeout of {self.default_timeout}s."
+        )

--- a/tests/transport/aio/test_sessions.py
+++ b/tests/transport/aio/test_sessions.py
@@ -14,9 +14,9 @@
 
 import asyncio
 from typing import AsyncGenerator
-from unittest.mock import Mock, patch
 
 from aioresponses import aioresponses
+from mock import Mock, patch
 import pytest  # type: ignore
 
 from google.auth.aio.credentials import AnonymousCredentials
@@ -254,30 +254,51 @@ class TestAuthorizedSession(object):
             assert auth_request.call_count == DEFAULT_MAX_REFRESH_ATTEMPTS
 
     @pytest.mark.asyncio
-    async def test_http_methods_success(self):
+    async def test_http_get_method_success(self):
+        expected_payload = b"content is retrieved."
+        authed_session = sessions.AuthorizedSession(self.credentials)
         with aioresponses() as m:
-            mocked_chunks = [b"Cavefish ", b"have ", b"no ", b"sight."]
-            mocked_response = b"".join(mocked_chunks)
-            authed_session = sessions.AuthorizedSession(self.credentials)
-
-            m.get(self.TEST_URL, status=200, body=mocked_response)
+            m.get(self.TEST_URL, status=200, body=expected_payload)
             response = await authed_session.get(self.TEST_URL)
-            assert response.status_code == 200
+            assert await response.read() == expected_payload
+            response = await authed_session.close()
 
-            m.post(self.TEST_URL, status=200, body=mocked_response)
+    @pytest.mark.asyncio
+    async def test_http_post_method_success(self):
+        expected_payload = b"content is posted."
+        authed_session = sessions.AuthorizedSession(self.credentials)
+        with aioresponses() as m:
+            m.post(self.TEST_URL, status=200, body=expected_payload)
             response = await authed_session.post(self.TEST_URL)
-            assert response.status_code == 200
+            assert await response.read() == expected_payload
+            response = await authed_session.close()
 
-            m.put(self.TEST_URL, status=200, body=mocked_response)
+    @pytest.mark.asyncio
+    async def test_http_put_method_success(self):
+        expected_payload = b"content is retrieved."
+        authed_session = sessions.AuthorizedSession(self.credentials)
+        with aioresponses() as m:
+            m.put(self.TEST_URL, status=200, body=expected_payload)
             response = await authed_session.put(self.TEST_URL)
-            assert response.status_code == 200
+            assert await response.read() == expected_payload
+            response = await authed_session.close()
 
-            m.patch(self.TEST_URL, status=200, body=mocked_response)
+    @pytest.mark.asyncio
+    async def test_http_patch_method_success(self):
+        expected_payload = b"content is retrieved."
+        authed_session = sessions.AuthorizedSession(self.credentials)
+        with aioresponses() as m:
+            m.patch(self.TEST_URL, status=200, body=expected_payload)
             response = await authed_session.patch(self.TEST_URL)
-            assert response.status_code == 200
+            assert await response.read() == expected_payload
+            response = await authed_session.close()
 
-            m.delete(self.TEST_URL, status=200, body=mocked_response)
+    @pytest.mark.asyncio
+    async def test_http_delete_method_success(self):
+        expected_payload = b"content is deleted."
+        authed_session = sessions.AuthorizedSession(self.credentials)
+        with aioresponses() as m:
+            m.delete(self.TEST_URL, status=200, body=expected_payload)
             response = await authed_session.delete(self.TEST_URL)
-            assert response.status_code == 200
-
-        await authed_session.close()
+            assert await response.read() == expected_payload
+            response = await authed_session.close()

--- a/tests/transport/aio/test_sessions.py
+++ b/tests/transport/aio/test_sessions.py
@@ -13,23 +13,20 @@
 # limitations under the License.
 
 import asyncio
+from typing import AsyncGenerator
 from unittest.mock import Mock, patch
 
+from aioresponses import aioresponses
 import pytest  # type: ignore
 
+from google.auth.aio.credentials import AnonymousCredentials
 from google.auth.aio.transport import (
-    sessions,
+    _DEFAULT_TIMEOUT_SECONDS,
     Request,
     Response,
-    _DEFAULT_TIMEOUT_SECONDS,
+    sessions,
 )
-from google.auth.exceptions import TimeoutError, TransportError, InvalidType
-from google.auth.aio.credentials import AnonymousCredentials
-
-# import aiohttp
-from aioresponses import aioresponses
-
-from typing import AsyncGenerator
+from google.auth.exceptions import InvalidType, TimeoutError, TransportError
 
 
 @pytest.fixture
@@ -90,7 +87,7 @@ class TestTimeoutGuard(object):
     default_timeout = 1
 
     def make_timeout_guard(self, timeout):
-        return auth_sessions.timeout_guard(timeout)
+        return sessions.timeout_guard(timeout)
 
     @pytest.mark.asyncio
     async def test_timeout_with_simple_async_task_within_bounds(


### PR DESCRIPTION
This PR implements the asynchronous `AuthorizedSession` class which will be used to perform asynchronous requests to API endpoints that require authorization in the following way:


```python3
import aiohttp
from google.auth.aio.transport import sessions

async with sessions.AuthorizedSession(credentials) as authed_session:
    response = await authed_session.request(
        'GET', 'https://www.googleapis.com/storage/v1/b')

```