### PR TITLE
fix: add type hints to credentials

### DIFF
--- a/google/auth/_credentials_base.py
+++ b/google/auth/_credentials_base.py
@@ -19,6 +19,7 @@ import abc
 from typing import Optional
 
 from google.auth import _helpers
+from google.auth.transport.requests import Request
 
 
 class BaseCredentials(metaclass=abc.ABCMeta):
@@ -48,7 +49,7 @@ class BaseCredentials(metaclass=abc.ABCMeta):
         self.token: Optional[str] = None
 
     @abc.abstractmethod
-    def refresh(self, request):
+    def refresh(self, request: Request) -> None:
         """Refreshes the access token.
 
         Args:

--- a/google/auth/_credentials_base.py
+++ b/google/auth/_credentials_base.py
@@ -16,11 +16,12 @@
 """Interface for base credentials."""
 
 import abc
+from typing import Optional
 
 from google.auth import _helpers
 
 
-class _BaseCredentials(metaclass=abc.ABCMeta):
+class BaseCredentials(metaclass=abc.ABCMeta):
     """Base class for all credentials.
 
     All credentials have a :attr:`token` that is used for authentication and
@@ -44,7 +45,7 @@ class _BaseCredentials(metaclass=abc.ABCMeta):
     """
 
     def __init__(self):
-        self.token = None
+        self.token: Optional[str] = None
 
     @abc.abstractmethod
     def refresh(self, request):
@@ -62,7 +63,7 @@ class _BaseCredentials(metaclass=abc.ABCMeta):
         # (pylint doesn't recognize that this is abstract)
         raise NotImplementedError("Refresh must be implemented")
 
-    def _apply(self, headers, token=None):
+    def _apply(self, headers: dict[str, str], token: Optional[str] = None):
         """Apply the token to the authentication header.
 
         Args:

--- a/google/auth/_credentials_base.py
+++ b/google/auth/_credentials_base.py
@@ -68,10 +68,14 @@ class BaseCredentials(metaclass=abc.ABCMeta):
         """Apply the token to the authentication header.
 
         Args:
-            headers (Mapping): The HTTP request headers.
+            headers (dict[str, str]): The HTTP request headers.
             token (Optional[str]): If specified, overrides the current access
                 token.
         """
-        headers["authorization"] = "Bearer {}".format(
-            _helpers.from_bytes(token or self.token)
-        )
+        if token is not None:
+            value = token
+        elif self.token is not None:
+            value = self.token
+        else:
+            assert False, "token must be set"
+        headers["authorization"] = "Bearer {}".format(_helpers.from_bytes(value))

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -21,10 +21,12 @@ import io
 import json
 import logging
 import os
+from typing import Optional, Sequence
 import warnings
 
 from google.auth import environment_vars
 from google.auth import exceptions
+from google.auth.credentials import Credentials
 import google.auth.transport._http_client
 
 _LOGGER = logging.getLogger(__name__)
@@ -77,8 +79,12 @@ def _warn_about_problematic_credentials(credentials):
 
 
 def load_credentials_from_file(
-    filename, scopes=None, default_scopes=None, quota_project_id=None, request=None
-):
+    filename: str,
+    scopes: Optional[Sequence[str]] = None,
+    default_scopes: Optional[Sequence[str]] = None,
+    quota_project_id: Optional[str] = None,
+    request: Optional[google.auth.transport.Request] = None,
+) -> tuple[Credentials, Optional[str]]:
     """Loads Google credentials from a file.
 
     The credentials file must be a service account key, stored authorized
@@ -173,7 +179,12 @@ def load_credentials_from_dict(
 
 
 def _load_credentials_from_info(
-    filename, info, scopes, default_scopes, quota_project_id, request
+    filename: str,
+    info,
+    scopes: Optional[Sequence[str]],
+    default_scopes: Optional[Sequence[str]],
+    quota_project_id: Optional[str],
+    request: Optional[google.auth.transport.Request],
 ):
     from google.auth.credentials import CredentialsWithQuotaProject
 
@@ -508,8 +519,8 @@ def _get_gdch_service_account_credentials(filename, info):
     from google.oauth2 import gdch_credentials
 
     try:
-        credentials = gdch_credentials.ServiceAccountCredentials.from_service_account_info(
-            info
+        credentials = (
+            gdch_credentials.ServiceAccountCredentials.from_service_account_info(info)
         )
     except ValueError as caught_exc:
         msg = "Failed to load GDCH service account credentials from {}".format(filename)

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -551,7 +551,12 @@ def _apply_quota_project_id(credentials, quota_project_id):
     return credentials
 
 
-def default(scopes=None, request=None, quota_project_id=None, default_scopes=None):
+def default(
+    scopes: Optional[Sequence[str]] = None,
+    request: Optional[google.auth.transport.Request] = None,
+    quota_project_id: Optional[str] = None,
+    default_scopes: Optional[Sequence[str]] = None,
+) -> tuple[Credentials, Optional[str]]:
     """Gets the default credentials for the current environment.
 
     `Application Default Credentials`_ provides an easy way to obtain

--- a/google/auth/_refresh_worker.py
+++ b/google/auth/_refresh_worker.py
@@ -34,7 +34,7 @@ class RefreshThreadManager:
         self._worker = None
         self._lock = threading.Lock()  # protects access to worker threads.
 
-    def start_refresh(self, cred: Credentials, request: Request):
+    def start_refresh(self, cred: Credentials, request: Request) -> bool:
         """Starts a refresh thread for the given credentials.
         The credentials are refreshed using the request parameter.
         request and cred MUST not be None
@@ -61,7 +61,7 @@ class RefreshThreadManager:
                 self._worker.start()
         return True
 
-    def clear_error(self):
+    def clear_error(self) -> None:
         """
         Removes any errors that were stored from previous background refreshes.
         """

--- a/google/auth/_refresh_worker.py
+++ b/google/auth/_refresh_worker.py
@@ -16,7 +16,9 @@ import copy
 import logging
 import threading
 
+from google.auth.credentials import Credentials
 import google.auth.exceptions as e
+from google.auth.transport import Request
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +34,7 @@ class RefreshThreadManager:
         self._worker = None
         self._lock = threading.Lock()  # protects access to worker threads.
 
-    def start_refresh(self, cred, request):
+    def start_refresh(self, cred: Credentials, request: Request):
         """Starts a refresh thread for the given credentials.
         The credentials are refreshed using the request parameter.
         request and cred MUST not be None
@@ -61,8 +63,8 @@ class RefreshThreadManager:
 
     def clear_error(self):
         """
-      Removes any errors that were stored from previous background refreshes.
-      """
+        Removes any errors that were stored from previous background refreshes.
+        """
         with self._lock:
             if self._worker:
                 self._worker._error_info = None

--- a/google/auth/aio/credentials.py
+++ b/google/auth/aio/credentials.py
@@ -15,13 +15,12 @@
 
 """Interfaces for asynchronous credentials."""
 
-
 from google.auth import _helpers
 from google.auth import exceptions
-from google.auth._credentials_base import _BaseCredentials
+from google.auth._credentials_base import BaseCredentials
 
 
-class Credentials(_BaseCredentials):
+class Credentials(BaseCredentials):
     """Base class for all asynchronous credentials.
 
     All credentials have a :attr:`token` that is used for authentication and

--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -16,9 +16,10 @@
 """Interfaces for credentials."""
 
 import abc
+import datetime
 from enum import Enum
 import os
-from typing import Optional, Self, Sequence
+from typing import Mapping, Optional, Self, Sequence
 
 from google.auth import _helpers, environment_vars
 from google.auth import exceptions
@@ -29,6 +30,19 @@ from google.auth.crypt import Signer
 from google.auth.transport import Request
 
 DEFAULT_UNIVERSE_DOMAIN = "googleapis.com"
+
+
+class TokenState(Enum):
+    """
+    Tracks the state of a token.
+    FRESH: The token is valid. It is not expired or close to expired, or the token has no expiry.
+    STALE: The token is close to expired, and should be refreshed. The token can be used normally.
+    INVALID: The token is expired or invalid. The token cannot be used for a normal operation.
+    """
+
+    FRESH = 1
+    STALE = 2
+    INVALID = 3
 
 
 class Credentials(BaseCredentials):
@@ -53,21 +67,21 @@ class Credentials(BaseCredentials):
     def __init__(self):
         super(Credentials, self).__init__()
 
-        self.expiry = None
+        self.expiry: Optional[datetime.datetime] = None
         """Optional[datetime]: When the token expires and is no longer valid.
         If this is None, the token is assumed to never expire."""
-        self._quota_project_id = None
+        self._quota_project_id: Optional[str] = None
         """Optional[str]: Project to use for quota and billing purposes."""
-        self._trust_boundary = None
+        self._trust_boundary: Optional[dict[str, str]] = None
         """Optional[dict]: Cache of a trust boundary response which has a list
         of allowed regions and an encoded string representation of credentials
         trust boundary."""
-        self._universe_domain = DEFAULT_UNIVERSE_DOMAIN
+        self._universe_domain: Optional[str] = DEFAULT_UNIVERSE_DOMAIN
         """Optional[str]: The universe domain value, default is googleapis.com
         """
 
-        self._use_non_blocking_refresh = False
-        self._refresh_worker = RefreshThreadManager()
+        self._use_non_blocking_refresh: bool = False
+        self._refresh_worker: RefreshThreadManager = RefreshThreadManager()
 
     @property
     def expired(self) -> bool:
@@ -100,7 +114,7 @@ class Credentials(BaseCredentials):
         return self.token is not None and not self.expired
 
     @property
-    def token_state(self):
+    def token_state(self) -> TokenState:
         """
         See `:obj:`TokenState`
         """
@@ -122,16 +136,16 @@ class Credentials(BaseCredentials):
         return TokenState.FRESH
 
     @property
-    def quota_project_id(self):
+    def quota_project_id(self) -> Optional[str]:
         """Project to use for quota and billing purposes."""
         return self._quota_project_id
 
     @property
-    def universe_domain(self):
+    def universe_domain(self) -> Optional[str]:
         """The universe domain value."""
         return self._universe_domain
 
-    def get_cred_info(self):
+    def get_cred_info(self) -> Optional[Mapping[str, str]]:
         """The credential information JSON.
 
         The credential information will be added to auth related error messages
@@ -158,7 +172,7 @@ class Credentials(BaseCredentials):
         # (pylint doesn't recognize that this is abstract)
         raise NotImplementedError("Refresh must be implemented")
 
-    def _metric_header_for_usage(self):
+    def _metric_header_for_usage(self) -> Optional[str]:
         """The x-goog-api-client header for token usage metric.
 
         This header will be added to the API service requests in before_request
@@ -173,7 +187,7 @@ class Credentials(BaseCredentials):
         """
         return None
 
-    def apply(self, headers: dict[str, str], token: Optional[str] = None):
+    def apply(self, headers: dict[str, str], token: Optional[str] = None) -> None:
         """Apply the token to the authentication header.
 
         Args:
@@ -200,11 +214,11 @@ class Credentials(BaseCredentials):
         if self.quota_project_id:
             headers["x-goog-user-project"] = self.quota_project_id
 
-    def _blocking_refresh(self, request: Request):
+    def _blocking_refresh(self, request: Request) -> None:
         if not self.valid:
             self.refresh(request)
 
-    def _non_blocking_refresh(self, request: Request):
+    def _non_blocking_refresh(self, request: Request) -> None:
         use_blocking_refresh_fallback = False
 
         if self.token_state == TokenState.STALE:
@@ -221,7 +235,7 @@ class Credentials(BaseCredentials):
 
     def before_request(
         self, request: Request, method: str, url: str, headers: dict[str, str]
-    ):
+    ) -> None:
         """Performs credential-specific before request logic.
 
         Refreshes the credentials if necessary, then calls :meth:`apply` to
@@ -246,14 +260,14 @@ class Credentials(BaseCredentials):
         metrics.add_metric_header(headers, self._metric_header_for_usage())
         self.apply(headers)
 
-    def with_non_blocking_refresh(self):
+    def with_non_blocking_refresh(self) -> None:
         self._use_non_blocking_refresh = True
 
 
 class CredentialsWithQuotaProject(Credentials):
     """Abstract base for credentials supporting ``with_quota_project`` factory"""
 
-    def with_quota_project(self, quota_project_id: str) -> Self:
+    def with_quota_project(self, quota_project_id: str) -> Credentials:
         """Returns a copy of these credentials with a modified quota project.
 
         Args:
@@ -265,7 +279,7 @@ class CredentialsWithQuotaProject(Credentials):
         """
         raise NotImplementedError("This credential does not support quota project.")
 
-    def with_quota_project_from_environment(self) -> Self:
+    def with_quota_project_from_environment(self) -> Credentials:
         quota_from_env = os.environ.get(environment_vars.GOOGLE_CLOUD_QUOTA_PROJECT)
         if quota_from_env:
             return self.with_quota_project(quota_from_env)
@@ -275,7 +289,7 @@ class CredentialsWithQuotaProject(Credentials):
 class CredentialsWithTokenUri(Credentials):
     """Abstract base for credentials supporting ``with_token_uri`` factory"""
 
-    def with_token_uri(self, token_uri: str) -> Self:
+    def with_token_uri(self, token_uri: str) -> Credentials:
         """Returns a copy of these credentials with a modified token uri.
 
         Args:
@@ -290,7 +304,7 @@ class CredentialsWithTokenUri(Credentials):
 class CredentialsWithUniverseDomain(Credentials):
     """Abstract base for credentials supporting ``with_universe_domain`` factory"""
 
-    def with_universe_domain(self, universe_domain: str) -> Self:
+    def with_universe_domain(self, universe_domain: str) -> Credentials:
         """Returns a copy of these credentials with a modified universe domain.
 
         Args:
@@ -321,12 +335,12 @@ class AnonymousCredentials(Credentials):
         """Returns `True`, anonymous credentials are always valid."""
         return True
 
-    def refresh(self, request: Request):
+    def refresh(self, request: Request) -> None:
         """Raises :class:``InvalidOperation``, anonymous credentials cannot be
         refreshed."""
         raise exceptions.InvalidOperation("Anonymous credentials cannot be refreshed.")
 
-    def apply(self, headers: dict[str, str], token: Optional[str] = None):
+    def apply(self, headers: dict[str, str], token: Optional[str] = None) -> None:
         """Anonymous credentials do nothing to the request.
 
         The optional ``token`` argument is not supported.
@@ -339,7 +353,7 @@ class AnonymousCredentials(Credentials):
 
     def before_request(
         self, request: Request, method: str, url: str, headers: dict[str, str]
-    ):
+    ) -> None:
         """Anonymous credentials do nothing to the request."""
 
 
@@ -374,22 +388,22 @@ class ReadOnlyScoped(metaclass=abc.ABCMeta):
 
     def __init__(self):
         super(ReadOnlyScoped, self).__init__()
-        self._scopes = None
-        self._default_scopes = None
+        self._scopes: Optional[Sequence[str]] = None
+        self._default_scopes: Optional[Sequence[str]] = None
 
     @property
-    def scopes(self):
+    def scopes(self) -> Optional[Sequence[str]]:
         """Sequence[str]: the credentials' current set of scopes."""
         return self._scopes
 
     @property
-    def default_scopes(self):
+    def default_scopes(self) -> Optional[Sequence[str]]:
         """Sequence[str]: the credentials' current set of default scopes."""
         return self._default_scopes
 
     @property
     @abc.abstractmethod
-    def requires_scopes(self):
+    def requires_scopes(self) -> bool:
         """True if these credentials require scopes to obtain an access token."""
         return False
 
@@ -522,16 +536,3 @@ class Signing(metaclass=abc.ABCMeta):
         # pylint: disable=missing-raises-doc
         # (pylint doesn't recognize that this is abstract)
         raise NotImplementedError("Signer must be implemented.")
-
-
-class TokenState(Enum):
-    """
-    Tracks the state of a token.
-    FRESH: The token is valid. It is not expired or close to expired, or the token has no expiry.
-    STALE: The token is close to expired, and should be refreshed. The token can be used normally.
-    INVALID: The token is expired or invalid. The token cannot be used for a normal operation.
-    """
-
-    FRESH = 1
-    STALE = 2
-    INVALID = 3

--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -25,7 +25,6 @@ from google.auth import exceptions
 from google.auth import metrics
 from google.auth._credentials_base import BaseCredentials
 from google.auth._refresh_worker import RefreshThreadManager
-from google.auth.credentials import Credentials
 from google.auth.crypt import Signer
 from google.auth.transport import Request
 

--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -72,7 +72,7 @@ class Credentials(BaseCredentials):
         If this is None, the token is assumed to never expire."""
         self._quota_project_id: Optional[str] = None
         """Optional[str]: Project to use for quota and billing purposes."""
-        self._trust_boundary: Optional[dict[str, str]] = None
+        self._trust_boundary: Optional[dict[str, object]] = None
         """Optional[dict]: Cache of a trust boundary response which has a list
         of allowed regions and an encoded string representation of credentials
         trust boundary."""

--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -18,12 +18,12 @@
 import abc
 from enum import Enum
 import os
-from typing import Mapping, Optional, Self, Sequence
+from typing import Optional, Self, Sequence
 
 from google.auth import _helpers, environment_vars
 from google.auth import exceptions
 from google.auth import metrics
-from google.auth._credentials_base import _BaseCredentials
+from google.auth._credentials_base import BaseCredentials
 from google.auth._refresh_worker import RefreshThreadManager
 from google.auth.credentials import Credentials
 from google.auth.crypt import Signer
@@ -32,7 +32,7 @@ from google.auth.transport import Request
 DEFAULT_UNIVERSE_DOMAIN = "googleapis.com"
 
 
-class Credentials(_BaseCredentials):
+class Credentials(BaseCredentials):
     """Base class for all credentials.
 
     All credentials have a :attr:`token` that is used for authentication and
@@ -144,7 +144,7 @@ class Credentials(_BaseCredentials):
         return None
 
     @abc.abstractmethod
-    def refresh(self, request: Request):
+    def refresh(self, request: Request) -> None:
         """Refreshes the access token.
 
         Args:
@@ -174,7 +174,7 @@ class Credentials(_BaseCredentials):
         """
         return None
 
-    def apply(self, headers: Mapping, token: Optional[str] = None):
+    def apply(self, headers: dict[str, str], token: Optional[str] = None):
         """Apply the token to the authentication header.
 
         Args:
@@ -220,7 +220,9 @@ class Credentials(_BaseCredentials):
             # background thread.
             self._refresh_worker.clear_error()
 
-    def before_request(self, request: Request, method: str, url: str, headers: Mapping):
+    def before_request(
+        self, request: Request, method: str, url: str, headers: dict[str, str]
+    ):
         """Performs credential-specific before request logic.
 
         Refreshes the credentials if necessary, then calls :meth:`apply` to
@@ -325,7 +327,7 @@ class AnonymousCredentials(Credentials):
         refreshed."""
         raise exceptions.InvalidOperation("Anonymous credentials cannot be refreshed.")
 
-    def apply(self, headers: Mapping, token: Optional[str] = None):
+    def apply(self, headers: dict[str, str], token: Optional[str] = None):
         """Anonymous credentials do nothing to the request.
 
         The optional ``token`` argument is not supported.
@@ -336,7 +338,9 @@ class AnonymousCredentials(Credentials):
         if token is not None:
             raise exceptions.InvalidValue("Anonymous credentials don't support tokens.")
 
-    def before_request(self, request: Request, method: str, url: str, headers: Mapping):
+    def before_request(
+        self, request: Request, method: str, url: str, headers: dict[str, str]
+    ):
         """Anonymous credentials do nothing to the request."""
 
 
@@ -439,7 +443,7 @@ class Scoped(ReadOnlyScoped):
 
     @abc.abstractmethod
     def with_scopes(
-        self, scopes: Sequence[str], default_scopes: Optional[: Sequence[str]] = None
+        self, scopes: Sequence[str], default_scopes: Optional[Sequence[str]] = None
     ) -> Self:
         """Create a copy of these credentials with the specified scopes.
 

--- a/google/auth/metrics.py
+++ b/google/auth/metrics.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" We use x-goog-api-client header to report metrics. This module provides
+"""We use x-goog-api-client header to report metrics. This module provides
 the constants and helper methods to construct x-goog-api-client header.
 """
 
 import platform
+from typing import Mapping, Optional
 
 from google.auth import version
 
@@ -47,6 +48,7 @@ def python_and_auth_lib_version():
 
 
 # Token request metric header values
+
 
 # x-goog-api-client header value for access token request via metadata server.
 # Example: "gl-python/3.7 auth/1.1 auth-request-type/at cred-type/mds"
@@ -108,6 +110,7 @@ def token_request_user():
 
 # Miscellenous metrics
 
+
 # x-goog-api-client header value for metadata server ping.
 # Example: "gl-python/3.7 auth/1.1 auth-request-type/mds"
 def mds_ping():
@@ -135,7 +138,7 @@ def byoid_metrics_header(metrics_options):
     return header
 
 
-def add_metric_header(headers, metric_header_value):
+def add_metric_header(headers: Mapping[str, str], metric_header_value: Optional[str]):
     """Add x-goog-api-client header with the given value.
 
     Args:

--- a/google/auth/metrics.py
+++ b/google/auth/metrics.py
@@ -138,11 +138,11 @@ def byoid_metrics_header(metrics_options):
     return header
 
 
-def add_metric_header(headers: Mapping[str, str], metric_header_value: Optional[str]):
+def add_metric_header(headers: dict[str, str], metric_header_value: Optional[str]):
     """Add x-goog-api-client header with the given value.
 
     Args:
-        headers (Mapping[str, str]): The headers to which we will add the
+        headers (dict[str, str]): The headers to which we will add the
             metric header.
         metric_header_value (Optional[str]): If value is None, do nothing;
             if headers already has a x-goog-api-client header, append the value


### PR DESCRIPTION
Enables https://github.com/googleapis/python-cloud-core/pull/302

I checked:
- [x] `pyright google/auth/_credentials_base.py`
- [ ] `pyright google/auth/_default.py`
- [x] `pyright google/auth/_refresh_worker.py`
- [ ] `pyright google/auth/aio/credentials.py`
- [ ] `pyright google/auth/credentials.py`
- [x] `pyright google/auth/metrics.py`
- [x] `pyright google/oauth2/service_account.py`