### PR TITLE
fix: add timeout for auth requests

### DIFF
--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -137,9 +137,10 @@ class Request(transport.Request):
     .. automethod:: __call__
     """
 
-    def __init__(self, session=None):
+    def __init__(self, session=None, timeout=_DEFAULT_TIMEOUT):
         if not session:
             session = requests.Session()
+        self.timeout = timeout
 
         self.session = session
 
@@ -184,6 +185,7 @@ class Request(transport.Request):
         """
         try:
             _LOGGER.debug("Making request: %s %s", method, url)
+            timeout = timeout if timeout != _DEFAULT_TIMEOUT else self.timeout
             response = self.session.request(
                 method, url, data=body, headers=headers, timeout=timeout, **kwargs
             )


### PR DESCRIPTION
expose a parameter in the request constructor to allow the end user to pass in the custom timeout value. Currently _DEFAULT_TIMEOUT is being used, which may not be suitable for all the users 