### PR TITLE
chore: Made Compute Engine Metadata service exceptions more informative

### DIFF
--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -202,6 +202,7 @@ def get(
 
     backoff = ExponentialBackoff(total_attempts=retry_count)
 
+    last_exception = None
     for attempt in backoff:
         try:
             response = request(url=url, method="GET", headers=headers_to_use)
@@ -218,6 +219,7 @@ def get(
                 break
 
         except exceptions.TransportError as e:
+            last_exception = e
             _LOGGER.warning(
                 "Compute Engine Metadata server unavailable on "
                 "attempt %s of %s. Reason: %s",
@@ -229,7 +231,7 @@ def get(
         raise exceptions.TransportError(
             "Failed to retrieve {} from the Google Compute Engine "
             "metadata service. Compute Engine Metadata server unavailable".format(url)
-        )
+        ) from last_exception
 
     content = _helpers.from_bytes(response.data)
 

--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -210,7 +210,8 @@ def get(
                 raise exceptions.TransportError(
                     "Compute Engine Metadata server unavailable. "
                     "Response status: {}; Response:\n{}".format(
-                         response.status, response.data),
+                         response.status, response.data
+                    ),
                     response,
                     retryable=True,
                 )

--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -207,14 +207,12 @@ def get(
         try:
             response = request(url=url, method="GET", headers=headers_to_use)
             if response.status in transport.DEFAULT_RETRYABLE_STATUS_CODES:
-                _LOGGER.warning(
-                    "Compute Engine Metadata server unavailable on "
-                    "attempt %s of %s. Response status: %s",
-                    attempt,
-                    retry_count,
-                    response.status,
+                raise exceptions.TransportError(
+                    f"Compute Engine Metadata server unavailable. "
+                    f"Response status: {response.status}",
+                    response,
+                    retryable=True,
                 )
-                continue
             else:
                 break
 

--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -208,8 +208,9 @@ def get(
             response = request(url=url, method="GET", headers=headers_to_use)
             if response.status in transport.DEFAULT_RETRYABLE_STATUS_CODES:
                 raise exceptions.TransportError(
-                    f"Compute Engine Metadata server unavailable. "
-                    f"Response status: {response.status}",
+                    "Compute Engine Metadata server unavailable. "
+                    "Response status: {}; Response:\n{}".format(
+                         response.status, response.data),
                     response,
                     retryable=True,
                 )


### PR DESCRIPTION
Previously, the information about the original exceptions was omitted.