### PR TITLE
fix: Correct webauthn JSON parsing to be compliant with standard.

### DIFF
--- a/google/oauth2/webauthn_types.py
+++ b/google/oauth2/webauthn_types.py
@@ -67,7 +67,7 @@ class GetRequest:
     extensions: Optional[AuthenticationExtensionsClientInputs] = None
 
     def to_json(self) -> str:
-        req_options: Dict[str, Any] = {"rpid": self.rpid, "challenge": self.challenge}
+        req_options: Dict[str, Any] = {"rpId": self.rpid, "challenge": self.challenge}
         if self.timeout_ms:
             req_options["timeout"] = self.timeout_ms
         if self.allow_credentials:

--- a/tests/oauth2/test_webauthn_handler.py
+++ b/tests/oauth2/test_webauthn_handler.py
@@ -118,7 +118,7 @@ def test_success_get_assertion(os_get_stub, subprocess_run_stub):
         "type": "get",
         "origin": "fake_origin",
         "requestData": {
-            "rpid": "fake_rpid",
+            "rpId": "fake_rpid",
             "challenge": "fake_challenge",
             "allowCredentials": [{"type": "public-key", "id": "fake_id_1"}],
         },

--- a/tests/oauth2/test_webauthn_types.py
+++ b/tests/oauth2/test_webauthn_types.py
@@ -82,7 +82,7 @@ def test_GetRequest(has_allow_credentials):
         "type": "get",
         "origin": "fake_origin",
         "requestData": {
-            "rpid": "fake_rpid",
+            "rpId": "fake_rpid",
             "timeout": 123,
             "challenge": "fake_challenge",
             "userVerification": "preferred",


### PR DESCRIPTION
'rpid' -> 'rpId': according to the standard documentation. https://www.w3.org/TR/webauthn-3/#dom-publickeycredentialrequestoptionsjson-rpid