### PR TITLE
feat: opt-in logging support for request / response

### DIFF
--- a/google/auth/_helpers.py
+++ b/google/auth/_helpers.py
@@ -28,7 +28,7 @@ from google.auth import exceptions
 
 try:
     from google.api_core import client_logging
-    CLIENT_LOGGING_SUPPORTED = True
+    CLIENT_LOGGING_SUPPORTED = True  # pragma: NO COVER
 # TODO(https://github.com/googleapis/google-auth-library-python/issues/1690): Remove `pragma: NO COVER` once
 # logging is supported in minimum version of google-api-core.
 except ImportError:  # pragma: NO COVER

--- a/google/auth/_helpers.py
+++ b/google/auth/_helpers.py
@@ -29,7 +29,9 @@ from google.auth import exceptions
 try:
     from google.api_core import client_logging
     CLIENT_LOGGING_SUPPORTED = True
-except ImportError:
+# TODO(https://github.com/googleapis/google-auth-library-python/issues/1690): Remove `pragma: NO COVER` once
+# logging is supported in minimum version of google-api-core.
+except ImportError:  # pragma: NO COVER
     CLIENT_LOGGING_SUPPORTED = False
 
 # The smallest MDS cache used by this library stores tokens until 4 minutes from

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -301,20 +301,24 @@ def test_is_logging_enabled_with_debug_enabled(caplog, logger):
 
 def test_request_log_debug_enabled(logger, caplog):
     logger.setLevel(logging.DEBUG)
-    _helpers.request_log(logger, "GET", "http://example.com", {"key": "value"}, {"Authorization": "Bearer token"})
+    with mock.patch("google.auth._helpers.CLIENT_LOGGING_SUPPORTED", True):
+        _helpers.request_log(logger, "GET", "http://example.com", {"key": "value"}, {"Authorization": "Bearer token"})
     assert "Making request: GET http://example.com" in caplog.text
 
 def test_request_log_debug_disabled(logger, caplog):
     logger.setLevel(logging.INFO)
-    _helpers.request_log(logger, "POST", "https://api.example.com", "data", {"Content-Type": "application/json"})
+    with mock.patch("google.auth._helpers.CLIENT_LOGGING_SUPPORTED", True):
+        _helpers.request_log(logger, "POST", "https://api.example.com", "data", {"Content-Type": "application/json"})
     assert "Making request: POST https://api.example.com" not in caplog.text
 
 def test_response_log_debug_enabled(logger, caplog):
     logger.setLevel(logging.DEBUG)
-    _helpers.response_log(logger, "response_object")
+    with mock.patch("google.auth._helpers.CLIENT_LOGGING_SUPPORTED", True):
+        _helpers.response_log(logger, "response_object")
     assert "Response received..." in caplog.text
 
 def test_response_log_debug_disabled(logger, caplog):
     logger.setLevel(logging.INFO)
-    _helpers.response_log(logger, "another_response")
+    with mock.patch("google.auth._helpers.CLIENT_LOGGING_SUPPORTED", True):
+        _helpers.response_log(logger, "another_response")
     assert "Response received..." not in caplog.text

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -297,3 +297,24 @@ def test_is_logging_enabled_with_debug_enabled(caplog, logger):
     with mock.patch("google.auth._helpers.CLIENT_LOGGING_SUPPORTED", True):
         caplog.set_level(logging.DEBUG, logger=__name__)
         assert _helpers.is_logging_enabled(logger)
+
+
+def test_request_log_debug_enabled(logger, caplog):
+    logger.setLevel(logging.DEBUG)
+    _helpers.request_log(logger, "GET", "http://example.com", {"key": "value"}, {"Authorization": "Bearer token"})
+    assert "Making request: GET http://example.com" in caplog.text
+
+def test_request_log_debug_disabled(logger, caplog):
+    logger.setLevel(logging.INFO)
+    _helpers.request_log(logger, "POST", "https://api.example.com", "data", {"Content-Type": "application/json"})
+    assert "Making request: POST https://api.example.com" not in caplog.text
+
+def test_response_log_debug_enabled(logger, caplog):
+    logger.setLevel(logging.DEBUG)
+    _helpers.response_log(logger, "response_object")
+    assert "Response received..." in caplog.text
+
+def test_response_log_debug_disabled(logger, caplog):
+    logger.setLevel(logging.INFO)
+    _helpers.response_log(logger, "another_response")
+    assert "Response received..." not in caplog.text

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -14,10 +14,18 @@
 
 import datetime
 import urllib
+import logging
+from unittest import mock
 
 import pytest  # type: ignore
 
 from google.auth import _helpers
+
+
+@pytest.fixture
+def logger():
+    """Provides a basic logger instance for testing."""
+    return logging.getLogger(__name__)
 
 
 class SourceClass(object):
@@ -263,3 +271,29 @@ def test_hash_value_different_hashing():
 
 def test_hash_value_none():
     assert _helpers._hash_value(None, "test") is None
+
+
+def test_is_logging_enabled_with_no_level_set(logger):
+    
+    with mock.patch("google.auth._helpers.CLIENT_LOGGING_SUPPORTED", True):
+        assert _helpers.is_logging_enabled(logger) is False
+
+
+def test_is_logging_enabled_with_client_logging_not_supported(caplog, logger):
+    
+    with mock.patch("google.auth._helpers.CLIENT_LOGGING_SUPPORTED", False):
+        caplog.set_level(logging.DEBUG, logger=__name__)
+        assert _helpers.is_logging_enabled(logger) is False
+
+
+def test_is_logging_enabled_with_debug_disabled(caplog, logger):
+    
+    with mock.patch("google.auth._helpers.CLIENT_LOGGING_SUPPORTED", True):
+        caplog.set_level(logging.INFO, logger=__name__)
+        assert _helpers.is_logging_enabled(logger) is False
+
+
+def test_is_logging_enabled_with_debug_enabled(caplog, logger):
+    with mock.patch("google.auth._helpers.CLIENT_LOGGING_SUPPORTED", True):
+        caplog.set_level(logging.DEBUG, logger=__name__)
+        assert _helpers.is_logging_enabled(logger)


### PR DESCRIPTION
This PR adds the functionality to optionally log request / response i.e. logs will only show up if a google-based logger is explicitly configured by the user.

Note that not all log events within this repo have optional opt-in. The log events which are untouched will be logged unconditionally [This should probably be a future work item to make them optional].

This PR only focuses on request / response logs i.e. code locations which call `request_log` or `response_log`.

Fixes: https://github.com/googleapis/google-auth-library-python/issues/1680