### PR TITLE
chore: remove logging for async requests

### DIFF
--- a/google/auth/_helpers.py
+++ b/google/auth/_helpers.py
@@ -21,13 +21,13 @@ from email.message import Message
 import hashlib
 import logging
 import sys
-from typing import Optional, Mapping, Any
+from typing import Any, Mapping, Optional
 import urllib
 
 from google.auth import exceptions
 
 try:
-    from google.api_core import client_logging
+    from google.api_core import client_logging  # noqa: F401
 
     CLIENT_LOGGING_SUPPORTED = True  # pragma: NO COVER
 # TODO(https://github.com/googleapis/google-auth-library-python/issues/1690): Remove `pragma: NO COVER` once
@@ -314,7 +314,7 @@ def hash_sensitive_info(data: dict) -> dict:
     return hashed_data
 
 
-def _hash_value(value, field_name: str) -> str:
+def _hash_value(value, field_name: str) -> Optional[str]:
     """Hashes a value and returns a formatted hash string."""
     if value is None:
         return None

--- a/google/auth/_helpers.py
+++ b/google/auth/_helpers.py
@@ -27,7 +27,7 @@ import urllib
 from google.auth import exceptions
 
 try:
-    from google.api_core import client_logging  # noqa: F401
+    from google.api_core import client_logging  # type: ignore # noqa: F401
 
     CLIENT_LOGGING_SUPPORTED = True  # pragma: NO COVER
 # TODO(https://github.com/googleapis/google-auth-library-python/issues/1690): Remove `pragma: NO COVER` once

--- a/google/auth/_helpers.py
+++ b/google/auth/_helpers.py
@@ -27,6 +27,8 @@ import urllib
 from google.auth import exceptions
 
 try:
+    # TODO(https://github.com/googleapis/python-api-core/issues/813): Remove `# type: ignore` when
+    # `google-api-core` type hints issue is resolved.
     from google.api_core import client_logging  # type: ignore # noqa: F401
 
     CLIENT_LOGGING_SUPPORTED = True  # pragma: NO COVER

--- a/google/auth/_helpers.py
+++ b/google/auth/_helpers.py
@@ -21,7 +21,7 @@ from email.message import Message
 import hashlib
 import logging
 import sys
-from typing import Optional, Dict, Any
+from typing import Optional, Mapping, Any
 import urllib
 
 from google.auth import exceptions
@@ -343,7 +343,7 @@ def request_log(
     method: str,
     url: str,
     body: Optional[Any],
-    headers: Optional[Dict[str, str]],
+    headers: Optional[Mapping[str, str]],
 ) -> None:
     """
     Logs an HTTP request at the DEBUG level if logging is enabled.

--- a/google/auth/aio/transport/aiohttp.py
+++ b/google/auth/aio/transport/aiohttp.py
@@ -167,7 +167,7 @@ class Request(transport.Request):
                 timeout=client_timeout,
                 **kwargs,
             )
-            _helpers.response_log(_LOGGER, response)
+            # TODO(https://github.com/googleapis/google-auth-library-python/issues/1697): Add response log.
             return Response(response)
 
         except aiohttp.ClientError as caught_exc:

--- a/google/auth/transport/_aiohttp_requests.py
+++ b/google/auth/transport/_aiohttp_requests.py
@@ -22,14 +22,14 @@ from __future__ import absolute_import
 
 import asyncio
 import functools
+import logging
 
 import aiohttp  # type: ignore
-import logging
 import urllib3  # type: ignore
 
+from google.auth import _helpers
 from google.auth import exceptions
 from google.auth import transport
-from google.auth import _helpers
 from google.auth.transport import requests
 
 

--- a/google/auth/transport/_aiohttp_requests.py
+++ b/google/auth/transport/_aiohttp_requests.py
@@ -191,7 +191,7 @@ class Request(transport.Request):
             response = await self.session.request(
                 method, url, data=body, headers=headers, timeout=timeout, **kwargs
             )
-            _helpers.response_log(_LOGGER, response)
+            # TODO(https://github.com/googleapis/google-auth-library-python/issues/1697): Add response log.
             return _CombinedResponse(response)
 
         except aiohttp.ClientError as caught_exc:

--- a/google/auth/transport/_http_client.py
+++ b/google/auth/transport/_http_client.py
@@ -19,9 +19,9 @@ import logging
 import socket
 import urllib
 
+from google.auth import _helpers
 from google.auth import exceptions
 from google.auth import transport
-from google.auth import _helpers
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -34,10 +34,10 @@ from requests.packages.urllib3.util.ssl_ import (  # type: ignore
     create_urllib3_context,
 )  # pylint: disable=ungrouped-imports
 
+from google.auth import _helpers
 from google.auth import environment_vars
 from google.auth import exceptions
 from google.auth import transport
-from google.auth import _helpers
 import google.auth.transport._mtls_helper
 from google.oauth2 import service_account
 

--- a/google/auth/transport/urllib3.py
+++ b/google/auth/transport/urllib3.py
@@ -42,10 +42,10 @@ except ImportError as caught_exc:  # pragma: NO COVER
 
 from packaging import version  # type: ignore
 
+from google.auth import _helpers
 from google.auth import environment_vars
 from google.auth import exceptions
 from google.auth import transport
-from google.auth import _helpers
 from google.oauth2 import service_account
 
 if version.parse(urllib3.__version__) >= version.parse("2.0.0"):  # pragma: NO COVER

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,3 @@
 [mypy]
 python_version = 3.7
 namespace_packages = True
-disable_error_code = import-untyped
-
-[[mypy-google.api_core.*]]
-disable_error_code = import-untyped

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,7 @@
 [mypy]
 python_version = 3.7
 namespace_packages = True
+disable_error_code = import-untyped
+
+[[mypy-google.api_core.*]]
+disable_error_code = import-untyped

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import datetime
-import urllib
 import logging
 from unittest import mock
+import urllib
 
 import pytest  # type: ignore
 


### PR DESCRIPTION
Parsing async response requires making an async call to get `response.json()` resulting in the sync response logging helper to not work as expected in this case. Hence, this will be addressed separately https://github.com/googleapis/google-cloud-python/issues/15162 