### PR TITLE
fix: add impersonated SA via local ADC support for fetch_id_token

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -484,7 +484,7 @@ def _get_impersonated_service_account_credentials(filename, info, scopes):
     from google.auth import impersonated_credentials
 
     try:
-        credentials = impersonated_credentials.Credentials.from_impersonated_account_info(
+        credentials = impersonated_credentials.Credentials.from_impersonated_service_account_info(
             info, scopes=scopes
         )
     except ValueError as caught_exc:

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -484,42 +484,8 @@ def _get_impersonated_service_account_credentials(filename, info, scopes):
     from google.auth import impersonated_credentials
 
     try:
-        source_credentials_info = info.get("source_credentials")
-        source_credentials_type = source_credentials_info.get("type")
-        if source_credentials_type == _AUTHORIZED_USER_TYPE:
-            source_credentials, _ = _get_authorized_user_credentials(
-                filename, source_credentials_info
-            )
-        elif source_credentials_type == _SERVICE_ACCOUNT_TYPE:
-            source_credentials, _ = _get_service_account_credentials(
-                filename, source_credentials_info
-            )
-        elif source_credentials_type == _EXTERNAL_ACCOUNT_AUTHORIZED_USER_TYPE:
-            source_credentials, _ = _get_external_account_authorized_user_credentials(
-                filename, source_credentials_info
-            )
-        else:
-            raise exceptions.InvalidType(
-                "source credential of type {} is not supported.".format(
-                    source_credentials_type
-                )
-            )
-        impersonation_url = info.get("service_account_impersonation_url")
-        start_index = impersonation_url.rfind("/")
-        end_index = impersonation_url.find(":generateAccessToken")
-        if start_index == -1 or end_index == -1 or start_index > end_index:
-            raise exceptions.InvalidValue(
-                "Cannot extract target principal from {}".format(impersonation_url)
-            )
-        target_principal = impersonation_url[start_index + 1 : end_index]
-        delegates = info.get("delegates")
-        quota_project_id = info.get("quota_project_id")
-        credentials = impersonated_credentials.Credentials(
-            source_credentials,
-            target_principal,
-            scopes,
-            delegates,
-            quota_project_id=quota_project_id,
+        credentials = impersonated_credentials.Credentials.from_impersonated_account_info(
+            info, scopes=scopes
         )
     except ValueError as caught_exc:
         msg = "Failed to load impersonated service account credentials from {}".format(

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -434,12 +434,12 @@ class Credentials(
         source_credentials_type = source_credentials_info.get("type")
         if source_credentials_type == _AUTHORIZED_USER_TYPE:
             from google.oauth2 import credentials
-            source_credentials, _ = credentials.Credentials.from_authorized_user_info(
-                info
+            source_credentials = credentials.Credentials.from_authorized_user_info(
+                source_credentials_info
             )
         elif source_credentials_type == _SERVICE_ACCOUNT_TYPE:
             from google.oauth2 import service_account
-            source_credentials, _ = service_account.Credentials.from_service_account_info(
+            source_credentials = service_account.Credentials.from_service_account_info(
                 source_credentials_info
             )
         elif source_credentials_type == _EXTERNAL_ACCOUNT_AUTHORIZED_USER_TYPE:

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -424,7 +424,7 @@ class Credentials(
 
         Raises:
             InvalidType: If the source_credentials are not a support impersonation type
-            ValueError: If the info is not in the expected format.
+            ValueError: If the source_credentials info is not in the expected format.
         """
         _AUTHORIZED_USER_TYPE = "authorized_user"
         _SERVICE_ACCOUNT_TYPE = "service_account"

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -457,8 +457,6 @@ class Credentials(credentials.ReadOnlyScoped, credentials.CredentialsWithQuotaPr
         Raises:
             ValueError: If the info is not in the expected format.
         """
-        print("NTRACE: from_authorizer_user_info")
-        print(info)
         keys_needed = set(("refresh_token", "client_id", "client_secret"))
         missing = keys_needed.difference(info.keys())
 

--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -457,6 +457,8 @@ class Credentials(credentials.ReadOnlyScoped, credentials.CredentialsWithQuotaPr
         Raises:
             ValueError: If the info is not in the expected format.
         """
+        print("NTRACE: from_authorizer_user_info")
+        print(info)
         keys_needed = set(("refresh_token", "client_id", "client_secret"))
         missing = keys_needed.difference(info.keys())
 

--- a/google/oauth2/id_token.py
+++ b/google/oauth2/id_token.py
@@ -284,6 +284,19 @@ def fetch_id_token_credentials(audience, request=None):
                     return service_account.IDTokenCredentials.from_service_account_info(
                         info, target_audience=audience
                     )
+                elif info.get("type") == "impersonated_service_account":
+                    from google.auth import impersonated_credentials
+
+                    target_credentials =  impersonated_credentials.Credentials.from_impersonated_account_info(
+                        info
+                    )
+
+                    id_creds = impersonated_credentials.IDTokenCredentials(
+                        target_credentials=target_credentials,
+                        target_audience=audience,
+                        include_email=True,
+                    )
+                    return id_creds
         except ValueError as caught_exc:
             new_exc = exceptions.DefaultCredentialsError(
                 "GOOGLE_APPLICATION_CREDENTIALS is not valid service account credentials.",

--- a/google/oauth2/id_token.py
+++ b/google/oauth2/id_token.py
@@ -287,16 +287,15 @@ def fetch_id_token_credentials(audience, request=None):
                 elif info.get("type") == "impersonated_service_account":
                     from google.auth import impersonated_credentials
 
-                    target_credentials =  impersonated_credentials.Credentials.from_impersonated_account_info(
+                    target_credentials = impersonated_credentials.Credentials.from_impersonated_service_account_info(
                         info
                     )
 
-                    id_creds = impersonated_credentials.IDTokenCredentials(
+                    return impersonated_credentials.IDTokenCredentials(
                         target_credentials=target_credentials,
                         target_audience=audience,
                         include_email=True,
                     )
-                    return id_creds
         except ValueError as caught_exc:
             new_exc = exceptions.DefaultCredentialsError(
                 "GOOGLE_APPLICATION_CREDENTIALS is not valid service account credentials.",

--- a/tests/oauth2/test_id_token.py
+++ b/tests/oauth2/test_id_token.py
@@ -20,17 +20,18 @@ import pytest  # type: ignore
 
 from google.auth import environment_vars
 from google.auth import exceptions
+from google.auth import impersonated_credentials
 from google.auth import transport
 from google.oauth2 import id_token
 from google.oauth2 import service_account
-from google.auth import impersonated_credentials
 
 SERVICE_ACCOUNT_FILE = os.path.join(
     os.path.dirname(__file__), "../data/service_account.json"
 )
 
 IMPERSONATED_SERVICE_ACCOUNT_FILE = os.path.join(
-    os.path.dirname(__file__), "../data/impersonated_service_account_authorized_user_source.json"
+    os.path.dirname(__file__),
+    "../data/impersonated_service_account_authorized_user_source.json",
 )
 
 ID_TOKEN_AUDIENCE = "https://pubsub.googleapis.com"
@@ -269,7 +270,6 @@ def test_fetch_id_token_credentials_from_explicit_cred_json_file(monkeypatch):
 
 
 def test_fetch_id_token_credentials_from_impersonated_cred_json_file(monkeypatch):
-    ## Test: Can I Fetch ID token Credentials?
     monkeypatch.setenv(environment_vars.CREDENTIALS, IMPERSONATED_SERVICE_ACCOUNT_FILE)
 
     cred = id_token.fetch_id_token_credentials(ID_TOKEN_AUDIENCE)

--- a/tests/oauth2/test_id_token.py
+++ b/tests/oauth2/test_id_token.py
@@ -23,10 +23,16 @@ from google.auth import exceptions
 from google.auth import transport
 from google.oauth2 import id_token
 from google.oauth2 import service_account
+from google.auth import impersonated_credentials
 
 SERVICE_ACCOUNT_FILE = os.path.join(
     os.path.dirname(__file__), "../data/service_account.json"
 )
+
+IMPERSONATED_SERVICE_ACCOUNT_FILE = os.path.join(
+    os.path.dirname(__file__), "../data/impersonated_service_account_authorized_user_source.json"
+)
+
 ID_TOKEN_AUDIENCE = "https://pubsub.googleapis.com"
 
 
@@ -259,6 +265,15 @@ def test_fetch_id_token_credentials_from_explicit_cred_json_file(monkeypatch):
 
     cred = id_token.fetch_id_token_credentials(ID_TOKEN_AUDIENCE)
     assert isinstance(cred, service_account.IDTokenCredentials)
+    assert cred._target_audience == ID_TOKEN_AUDIENCE
+
+
+def test_fetch_id_token_credentials_from_impersonated_cred_json_file(monkeypatch):
+    ## Test: Can I Fetch ID token Credentials?
+    monkeypatch.setenv(environment_vars.CREDENTIALS, IMPERSONATED_SERVICE_ACCOUNT_FILE)
+
+    cred = id_token.fetch_id_token_credentials(ID_TOKEN_AUDIENCE)
+    assert isinstance(cred, impersonated_credentials.IDTokenCredentials)
     assert cred._target_audience == ID_TOKEN_AUDIENCE
 
 


### PR DESCRIPTION
fetch_id_token was only supported for service accounts and fetch ID token from metadata server if it exists. 

This PR adds support for impersonated service accounts. 