### PR TITLE
fix: remove dependency on api-core for logging

### DIFF
--- a/google/auth/_helpers.py
+++ b/google/auth/_helpers.py
@@ -27,16 +27,6 @@ import urllib
 
 from google.auth import exceptions
 
-try:
-    # TODO(https://github.com/googleapis/python-api-core/issues/813): Remove `# type: ignore` when
-    # `google-api-core` type hints issue is resolved.
-    from google.api_core import client_logging  # type: ignore # noqa: F401
-
-    CLIENT_LOGGING_SUPPORTED = True  # pragma: NO COVER
-# TODO(https://github.com/googleapis/google-auth-library-python/issues/1690): Remove `pragma: NO COVER` once
-# logging is supported in minimum version of google-api-core.
-except ImportError:  # pragma: NO COVER
-    CLIENT_LOGGING_SUPPORTED = False
 
 # The smallest MDS cache used by this library stores tokens until 4 minutes from
 # expiry.
@@ -354,7 +344,7 @@ def is_logging_enabled(logger: logging.Logger) -> bool:
     Returns:
         True if debug logging is enabled, False otherwise.
     """
-    return CLIENT_LOGGING_SUPPORTED and logger.isEnabledFor(logging.DEBUG)
+    return logger.isEnabledFor(logging.DEBUG)
 
 
 def request_log(

--- a/tests/aio/test__helpers.py
+++ b/tests/aio/test__helpers.py
@@ -14,7 +14,6 @@
 
 import json
 import logging
-from unittest import mock
 
 import pytest  # type: ignore
 


### PR DESCRIPTION
This PR removes the dependency  on `google-api-core` which was added earlier to ensure whether logging is supported in the client calling it.

Instead, we're now disabling the propagation of logs to the root logger within the auth layer which will avoid logging if a root logger is configured and a google-based logger is not explicitly configured.

This logic similar to the logging setup performed during a GAPIC client construction. However, adding it here ensures that logs aren't emitted by default (if a root logger is configured) for the following scenarios:

- If Apiary client is used with a version of `google-auth` which supports logging (since apiary does not currently disable log propagation in the client layer).
- If an older version of GAPIC which does not support logging is used with a version of `google-auth` which supports logging.


This logic is implemented within `is_logging_enabled` since this function is always called before any log is emitted i.e. within `request_log`, `response_log`, `response_log_async`.

We do not want to configure the base logger before each log event. It is sufficient to check this once and we can expect the behaviour to be consistent for all other events for an application client. `_LOGGING_INITIALIZED` ensures this and if already set to `True`, does not re-configure the base logger.
