### PR TITLE
fix: remove sync response logs in AuthorizedSession

### DIFF
--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -545,7 +545,6 @@ class AuthorizedSession(requests.Session):
                 timeout=timeout,
                 **kwargs
             )
-            _helpers.response_log(_LOGGER, response)
         remaining_time = guard.remaining_timeout
 
         # If the response indicated that the credentials needed to be


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: remove sync response logs in AuthorizedSession
END_COMMIT_OVERRIDE

Currently, response logs require decoding response via `response.json()` before the actual response is consumed. This results in issues for a streaming API call where the stream is empty due to it being consumed already for logs.

Removing the response log from `AuthorizedSession` resolves this issue. We'll still be logging request and response (including the response body) for credentials to satisfy the requirement for client logging.

For logging API responses, we need to log the response body within the gapics.