### PR TITLE
fix: retry 504 errors

### DIFF
--- a/google/auth/transport/__init__.py
+++ b/google/auth/transport/__init__.py
@@ -30,6 +30,7 @@ import http.client as http_client
 DEFAULT_RETRYABLE_STATUS_CODES = (
     http_client.INTERNAL_SERVER_ERROR,
     http_client.SERVICE_UNAVAILABLE,
+    http_client.GATEWAY_TIMEOUT,
     http_client.REQUEST_TIMEOUT,
     http_client.TOO_MANY_REQUESTS,
 )


### PR DESCRIPTION
Add 504 in the list of errors that are retried. The change is being made to mainly allow 504 errors to be retried in google cloud environements. 