### PR TITLE
fix: auth fetch token from default endpoint

### DIFF
--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -124,8 +124,9 @@ class Credentials(
         scopes = self._scopes if self._scopes is not None else self._default_scopes
         try:
             self._retrieve_info(request)
+            # Always fetch token with default service account email.
             self.token, self.expiry = _metadata.get_service_account_token(
-                request, service_account=self._service_account_email, scopes=scopes
+                request, service_account="default", scopes=scopes
             )
         except exceptions.TransportError as caught_exc:
             new_exc = exceptions.RefreshError(caught_exc)

--- a/tests/compute_engine/test_credentials.py
+++ b/tests/compute_engine/test_credentials.py
@@ -501,7 +501,7 @@ class TestIDTokenCredentials(object):
         responses.add(
             responses.GET,
             "http://metadata.google.internal/computeMetadata/v1/instance/"
-            "service-accounts/service-account@example.com/token",
+            "service-accounts/default/token",
             status=200,
             content_type="application/json",
             json={
@@ -659,7 +659,7 @@ class TestIDTokenCredentials(object):
         responses.add(
             responses.GET,
             "http://metadata.google.internal/computeMetadata/v1/instance/"
-            "service-accounts/service-account@example.com/token",
+            "service-accounts/default/token",
             status=200,
             content_type="application/json",
             json={


### PR DESCRIPTION
Fetch the token using "default" service account email. For other purposes, the call is still available for customers. As sometimes if a customer has overridden the principal to something else then this call fails. Therefore, to avoid such cases fetching the token using "default" endpoint. The reason this change works is because mds is associated with only 1 service account, so we do not need to provide an email address for fetching the token.