### PR TITLE
feat: MDS connections use mTLS

### DIFF
--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -142,7 +142,7 @@ def detect_gce_residency_linux():
 def _prepare_request_for_mds(request, use_mtls=False):
     """Prepares a request for the metadata server.
 
-    This will check if mTLS should be used and return a new request object if so.
+    This will check if mTLS should be used and mount the mTLS adapter if needed.
 
     Args:
         request (google.auth.transport.Request): A callable used to make
@@ -151,8 +151,8 @@ def _prepare_request_for_mds(request, use_mtls=False):
 
     Returns:
         google.auth.transport.Request: A request object to use.
-            If mTLS is enabled, this will be a new request object with mTLS session configured.
-            Otherwise, it will be the same as the input request.
+            If mTLS is enabled, the request will have the mTLS adapter mounted.
+            Otherwise, the original request will be returned unchanged.
     """
     if not use_mtls:
         return request

--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -263,7 +263,7 @@ def get(
     Raises:
         google.auth.exceptions.TransportError: if an error occurred while
             retrieving metadata.
-        google.auth.exceptions.MutualTLSChannelError: if the environment
+        google.auth.exceptions.MutualTLSChannelError: if using mtls and the environment
             configuration is invalid for mTLS (for example, the metadata host
             has been overridden in strict mTLS mode).
 

--- a/google/auth/compute_engine/_metadata.py
+++ b/google/auth/compute_engine/_metadata.py
@@ -45,7 +45,8 @@ if not _GCE_METADATA_HOST:
         environment_vars.GCE_METADATA_ROOT, "metadata.google.internal"
     )
 
-GCE_MDS_HOSTS = ["metadata.google.internal", "169.254.169.254"]
+_GCE_DEFAULT_MDS_IP = "169.254.169.254"
+_GCE_MDS_HOSTS = ["metadata.google.internal", _GCE_DEFAULT_MDS_IP]
 
 
 def _get_metadata_root(use_mtls):
@@ -58,7 +59,7 @@ def _get_metadata_ip_root(use_mtls):
     """Returns the metadata server IP root URL."""
     scheme = "https" if use_mtls else "http"
     return "{}://{}".format(
-        scheme, os.getenv(environment_vars.GCE_METADATA_IP, "169.254.169.254")
+        scheme, os.getenv(environment_vars.GCE_METADATA_IP, _GCE_DEFAULT_MDS_IP)
     )
 
 
@@ -123,10 +124,12 @@ def _prepare_request_for_mds(request, use_mtls=False):
     Args:
         request (google.auth.transport.Request): A callable used to make
             HTTP requests.
+        use_mtls (bool): Whether to use mTLS for the request.
 
     Returns:
-        google.auth.transport.Request: Request
-            object to use.
+        google.auth.transport.Request: A request object to use.
+            If mTLS is enabled, this will be a new request object with mTLS session configured.
+            Otherwise, it will be the same as the input request.
     """
     if use_mtls:
         request = requests.Request(_mtls.create_session())

--- a/google/auth/compute_engine/_mtls.py
+++ b/google/auth/compute_engine/_mtls.py
@@ -16,10 +16,9 @@
 #
 """Mutual TLS for Google Compute Engine metadata server."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import enum
 import os
-from pathlib import Path
 import ssl
 
 import requests
@@ -27,14 +26,36 @@ from requests.adapters import HTTPAdapter
 
 from google.auth import environment_vars, exceptions
 
+# MDS mTLS certificate paths based on OS.
+# Documentation to well known locations can be found at:
+# https://cloud.google.com/compute/docs/metadata/overview#https-mds-certificates
+
+
+def _get_mds_root_crt_path():
+    if os.name == "nt":
+        return os.path.join(
+            "C:\\", "ProgramData", "Google", "ComputeEngine", "mds-mtls-root.crt"
+        )
+    else:
+        return os.path.join("/", "run", "google-mds-mtls", "root.crt")
+
+
+def _get_mds_client_combined_cert_path():
+    if os.name == "nt":
+        return os.path.join(
+            "C:\\", "ProgramData", "Google", "ComputeEngine", "mds-mtls-client.key"
+        )
+    else:
+        return os.path.join("/", "run", "google-mds-mtls", "client.key")
+
 
 @dataclass
 class MdsMtlsConfig:
-    ca_cert_path: str = os.path.join(
-        Path.home(), "mtls_mds_certificates", "root.crt"
+    ca_cert_path: str = field(
+        default_factory=_get_mds_root_crt_path
     )  # path to CA certificate
-    client_combined_cert_path: str = os.path.join(
-        Path.home(), "mtls_mds_certificates", "client_creds.key"
+    client_combined_cert_path: str = field(
+        default_factory=_get_mds_client_combined_cert_path
     )  # path to file containing client certificate and key
 
 

--- a/google/auth/compute_engine/_mtls.py
+++ b/google/auth/compute_engine/_mtls.py
@@ -39,7 +39,12 @@ class MdsMtlsConfig:
 
 
 class MdsMtlsMode(enum.Enum):
-    """MDS mTLS mode."""
+    """MDS mTLS mode. Used to configure connection behavior when connecting to MDS.
+
+    STRICT: Always use HTTPS/mTLS.  If certificates are not found locally, an error will be returned.
+    NONE: Never use mTLS. Requests will use regular HTTP.
+    DEFAULT: Use mTLS if certificates are found locally, otherwise use regular HTTP.
+    """
 
     STRICT = "strict"
     NONE = "none"

--- a/google/auth/compute_engine/_mtls.py
+++ b/google/auth/compute_engine/_mtls.py
@@ -57,10 +57,10 @@ def _get_mds_client_combined_cert_path():
 
 @dataclass
 class MdsMtlsConfig:
-    ca_cert_path: str = field(
+    ca_cert_path: Path = field(
         default_factory=_get_mds_root_crt_path
     )  # path to CA certificate
-    client_combined_cert_path: str = field(
+    client_combined_cert_path: Path = field(
         default_factory=_get_mds_client_combined_cert_path
     )  # path to file containing client certificate and key
 

--- a/google/auth/compute_engine/_mtls.py
+++ b/google/auth/compute_engine/_mtls.py
@@ -141,8 +141,14 @@ class MdsMtlsAdapter(HTTPAdapter):
 
         # In default mode, attempt mTLS first, then fallback to HTTP on failure
         try:
-            return super(MdsMtlsAdapter, self).send(request, **kwargs)
-        except (ssl.SSLError, requests.exceptions.SSLError) as e:
+            response = super(MdsMtlsAdapter, self).send(request, **kwargs)
+            response.raise_for_status()
+            return response
+        except (
+            ssl.SSLError,
+            requests.exceptions.SSLError,
+            requests.exceptions.HTTPError,
+        ) as e:
             _LOGGER.warning(
                 "mTLS connection to Compute Engine Metadata server failed. "
                 "Falling back to standard HTTP. Reason: %s",

--- a/google/auth/compute_engine/_mtls.py
+++ b/google/auth/compute_engine/_mtls.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Mutual TLS for Google Compute Engine metadata server."""
+
+from dataclasses import dataclass
+import enum
+import os
+from pathlib import Path
+import ssl
+
+import requests
+from requests.adapters import HTTPAdapter
+
+from google.auth import environment_vars, exceptions
+
+
+@dataclass
+class MdsMtlsConfig:
+    ca_cert_path: str = os.path.join(
+        Path.home(), "mtls_mds_certificates", "root.crt"
+    )  # path to CA certificate
+    client_combined_cert_path: str = os.path.join(
+        Path.home(), "mtls_mds_certificates", "client_creds.key"
+    )  # path to file containing client certificate and key
+
+
+class MdsMtlsMode(enum.Enum):
+    """MDS mTLS mode."""
+
+    STRICT = "strict"
+    NONE = "none"
+    DEFAULT = "default"
+
+
+def _parse_mds_mode():
+    """Parses the GCE_METADATA_MTLS_MODE environment variable."""
+    mode_str = os.environ.get(
+        environment_vars.GCE_METADATA_MTLS_MODE, "default"
+    ).lower()
+    try:
+        return MdsMtlsMode(mode_str)
+    except ValueError:
+        raise ValueError(
+            "Invalid value for GCE_METADATA_MTLS_MODE. Must be one of 'strict', 'none', or 'default'."
+        )
+
+
+def _certs_exist(mds_mtls_config: MdsMtlsConfig):
+    """Checks if the mTLS certificates exist."""
+    return os.path.exists(mds_mtls_config.ca_cert_path) and os.path.exists(
+        mds_mtls_config.client_combined_cert_path
+    )
+
+
+class MdsMtlsAdapter(HTTPAdapter):
+    """An HTTP adapter that uses mTLS for the metadata server."""
+
+    def __init__(self, mds_mtls_config: MdsMtlsConfig, *args, **kwargs):
+        self.ssl_context = ssl.create_default_context()
+        self.ssl_context.load_verify_locations(cafile=mds_mtls_config.ca_cert_path)
+        self.ssl_context.load_cert_chain(
+            certfile=mds_mtls_config.client_combined_cert_path
+        )
+        super(MdsMtlsAdapter, self).__init__(*args, **kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs["ssl_context"] = self.ssl_context
+        return super(MdsMtlsAdapter, self).init_poolmanager(*args, **kwargs)
+
+    def proxy_manager_for(self, *args, **kwargs):
+        kwargs["ssl_context"] = self.ssl_context
+        return super(MdsMtlsAdapter, self).proxy_manager_for(*args, **kwargs)
+
+
+def create_session(mds_mtls_config: MdsMtlsConfig = MdsMtlsConfig()):
+    """Creates a requests.Session configured for mTLS."""
+    session = requests.Session()
+    adapter = MdsMtlsAdapter(mds_mtls_config)
+    session.mount("https://", adapter)
+    return session
+
+
+def should_use_mds_mtls(mds_mtls_config: MdsMtlsConfig = MdsMtlsConfig()):
+    """Determines if mTLS should be used for the metadata server."""
+    mode = _parse_mds_mode()
+    if mode == MdsMtlsMode.STRICT:
+        if not _certs_exist(mds_mtls_config):
+            raise exceptions.MutualTLSChannelError(
+                "mTLS certificates not found in strict mode."
+            )
+        return True
+    elif mode == MdsMtlsMode.NONE:
+        return False
+    else:  # Default mode
+        return _certs_exist(mds_mtls_config)

--- a/google/auth/environment_vars.py
+++ b/google/auth/environment_vars.py
@@ -60,6 +60,12 @@ GCE_METADATA_IP = "GCE_METADATA_IP"
 """Environment variable providing an alternate ip:port to be used for ip-only
 GCE metadata requests."""
 
+GCE_METADATA_MTLS_MODE = "GCE_METADATA_MTLS_MODE"
+"""Environment variable controlling the mTLS behavior for GCE metadata requests.
+
+Can be one of "strict", "none", or "default".
+"""
+
 GOOGLE_API_USE_CLIENT_CERTIFICATE = "GOOGLE_API_USE_CLIENT_CERTIFICATE"
 """Environment variable controlling whether to use client certificate or not.
 

--- a/tests/compute_engine/test__metadata.py
+++ b/tests/compute_engine/test__metadata.py
@@ -329,6 +329,20 @@ def test_get_success_custom_root_old_variable():
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
 
+def test_get_success_custom_root():
+    request = make_request("{}", headers={"content-type": "application/json"})
+
+    fake_root = "http://another.metadata.service"
+
+    _metadata.get(request, PATH, root=fake_root)
+
+    request.assert_called_once_with(
+        method="GET",
+        url="{}/{}".format(fake_root, PATH),
+        headers=_metadata._METADATA_HEADERS,
+        timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
+    )
+
 
 @mock.patch("time.sleep", return_value=None)
 def test_get_failure(mock_sleep):

--- a/tests/compute_engine/test__metadata.py
+++ b/tests/compute_engine/test__metadata.py
@@ -329,6 +329,7 @@ def test_get_success_custom_root_old_variable():
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
 
+
 def test_get_success_custom_root():
     request = make_request("{}", headers={"content-type": "application/json"})
 

--- a/tests/compute_engine/test__metadata.py
+++ b/tests/compute_engine/test__metadata.py
@@ -20,12 +20,14 @@ import os
 
 import mock
 import pytest  # type: ignore
+import requests
 
 from google.auth import _helpers
 from google.auth import environment_vars
 from google.auth import exceptions
 from google.auth import transport
 from google.auth.compute_engine import _metadata
+from google.auth.transport import requests as google_auth_requests
 
 PATH = "instance/service-accounts/default"
 
@@ -104,7 +106,7 @@ def test_ping_success(mock_metrics_header_value):
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_IP_ROOT,
+        url="http://169.254.169.254",
         headers=MDS_PING_REQUEST_HEADER,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -118,7 +120,7 @@ def test_ping_success_retry(mock_metrics_header_value):
 
     request.assert_called_with(
         method="GET",
-        url=_metadata._METADATA_IP_ROOT,
+        url="http://169.254.169.254",
         headers=MDS_PING_REQUEST_HEADER,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -172,7 +174,7 @@ def test_get_success_json():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH,
+        url="http://metadata.google.internal/computeMetadata/v1/" + PATH,
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -191,7 +193,7 @@ def test_get_success_json_content_type_charset():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH,
+        url="http://metadata.google.internal/computeMetadata/v1/" + PATH,
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -211,7 +213,7 @@ def test_get_success_retry(mock_sleep):
 
     request.assert_called_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH,
+        url="http://metadata.google.internal/computeMetadata/v1/" + PATH,
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -227,7 +229,7 @@ def test_get_success_text():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH,
+        url="http://metadata.google.internal/computeMetadata/v1/" + PATH,
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -243,7 +245,9 @@ def test_get_success_params():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH + "?recursive=true",
+        url="http://metadata.google.internal/computeMetadata/v1/"
+        + PATH
+        + "?recursive=true",
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -258,7 +262,9 @@ def test_get_success_recursive_and_params():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH + "?recursive=true",
+        url="http://metadata.google.internal/computeMetadata/v1/"
+        + PATH
+        + "?recursive=true",
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -273,7 +279,9 @@ def test_get_success_recursive():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH + "?recursive=true",
+        url="http://metadata.google.internal/computeMetadata/v1/"
+        + PATH
+        + "?recursive=true",
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -333,7 +341,7 @@ def test_get_failure(mock_sleep):
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH,
+        url="http://metadata.google.internal/computeMetadata/v1/" + PATH,
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -346,7 +354,7 @@ def test_get_return_none_for_not_found_error():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH,
+        url="http://metadata.google.internal/computeMetadata/v1/" + PATH,
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -366,7 +374,7 @@ def test_get_failure_connection_failed(mock_sleep):
 
     request.assert_called_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH,
+        url="http://metadata.google.internal/computeMetadata/v1/" + PATH,
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -385,7 +393,7 @@ def test_get_too_many_requests_retryable_error_failure():
 
     request.assert_called_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH,
+        url="http://metadata.google.internal/computeMetadata/v1/" + PATH,
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -402,7 +410,7 @@ def test_get_failure_bad_json():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH,
+        url="http://metadata.google.internal/computeMetadata/v1/" + PATH,
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -416,7 +424,7 @@ def test_get_project_id():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + "project/project-id",
+        url="http://metadata.google.internal/computeMetadata/v1/project/project-id",
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -432,7 +440,7 @@ def test_get_universe_domain_success():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + "universe/universe-domain",
+        url="http://metadata.google.internal/computeMetadata/v1/universe/universe-domain",
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -446,7 +454,7 @@ def test_get_universe_domain_success_empty_response():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + "universe/universe-domain",
+        url="http://metadata.google.internal/computeMetadata/v1/universe/universe-domain",
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -462,7 +470,7 @@ def test_get_universe_domain_not_found():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + "universe/universe-domain",
+        url="http://metadata.google.internal/computeMetadata/v1/universe/universe-domain",
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -483,7 +491,7 @@ def test_get_universe_domain_retryable_error_failure():
 
     request.assert_called_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + "universe/universe-domain",
+        url="http://metadata.google.internal/computeMetadata/v1/universe/universe-domain",
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -526,13 +534,13 @@ def test_get_universe_domain_retryable_error_success():
 
     request_error.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + "universe/universe-domain",
+        url="http://metadata.google.internal/computeMetadata/v1/universe/universe-domain",
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
     request_ok.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + "universe/universe-domain",
+        url="http://metadata.google.internal/computeMetadata/v1/universe/universe-domain",
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -552,7 +560,7 @@ def test_get_universe_domain_other_error():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + "universe/universe-domain",
+        url="http://metadata.google.internal/computeMetadata/v1/universe/universe-domain",
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
@@ -574,7 +582,7 @@ def test_get_service_account_token(utcnow, mock_metrics_header_value):
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH + "/token",
+        url="http://metadata.google.internal/computeMetadata/v1/" + PATH + "/token",
         headers={
             "metadata-flavor": "Google",
             "x-goog-api-client": ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
@@ -601,7 +609,10 @@ def test_get_service_account_token_with_scopes_list(utcnow, mock_metrics_header_
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH + "/token" + "?scopes=foo%2Cbar",
+        url="http://metadata.google.internal/computeMetadata/v1/"
+        + PATH
+        + "/token"
+        + "?scopes=foo%2Cbar",
         headers={
             "metadata-flavor": "Google",
             "x-goog-api-client": ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
@@ -630,7 +641,10 @@ def test_get_service_account_token_with_scopes_string(
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH + "/token" + "?scopes=foo%2Cbar",
+        url="http://metadata.google.internal/computeMetadata/v1/"
+        + PATH
+        + "/token"
+        + "?scopes=foo%2Cbar",
         headers={
             "metadata-flavor": "Google",
             "x-goog-api-client": ACCESS_TOKEN_REQUEST_METRICS_HEADER_VALUE,
@@ -651,9 +665,99 @@ def test_get_service_account_info():
 
     request.assert_called_once_with(
         method="GET",
-        url=_metadata._METADATA_ROOT + PATH + "/?recursive=true",
+        url="http://metadata.google.internal/computeMetadata/v1/"
+        + PATH
+        + "/?recursive=true",
         headers=_metadata._METADATA_HEADERS,
         timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
     )
 
     assert info[key] == value
+
+
+def test__get_metadata_root_mtls():
+    assert (
+        _metadata._get_metadata_root(use_mtls=True)
+        == "https://metadata.google.internal/computeMetadata/v1/"
+    )
+
+
+def test__get_metadata_root_no_mtls():
+    assert (
+        _metadata._get_metadata_root(use_mtls=False)
+        == "http://metadata.google.internal/computeMetadata/v1/"
+    )
+
+
+def test__get_metadata_ip_root_mtls():
+    assert _metadata._get_metadata_ip_root(use_mtls=True) == "https://169.254.169.254"
+
+
+def test__get_metadata_ip_root_no_mtls():
+    assert _metadata._get_metadata_ip_root(use_mtls=False) == "http://169.254.169.254"
+
+
+@mock.patch("google.auth.compute_engine._mtls.create_session")
+def test__prepare_request_for_mds_mtls(mock_create_session):
+    request = mock.Mock()
+    new_request = _metadata._prepare_request_for_mds(request, use_mtls=True)
+    mock_create_session.assert_called_once()
+    assert isinstance(new_request, google_auth_requests.Request)
+
+
+def test__prepare_request_for_mds_no_mtls():
+    request = mock.Mock()
+    new_request = _metadata._prepare_request_for_mds(request, use_mtls=False)
+    assert new_request is request
+
+
+@mock.patch("google.auth.compute_engine._mtls.should_use_mds_mtls", return_value=True)
+@mock.patch("google.auth.compute_engine._mtls.create_session")
+@mock.patch("google.auth.metrics.mds_ping", return_value=MDS_PING_METRICS_HEADER_VALUE)
+def test_ping_mtls(
+    mock_metrics_header_value, mock_create_session, mock_should_use_mtls
+):
+    response = mock.create_autospec(requests.Response, instance=True)
+    response.status_code = http_client.OK
+    response.headers = _metadata._METADATA_HEADERS
+    mock_session = mock.Mock()
+    mock_session.request.return_value = response
+    mock_create_session.return_value = mock_session
+
+    initial_request = mock.Mock()
+    assert _metadata.ping(initial_request)
+
+    mock_should_use_mtls.assert_called_once()
+    mock_create_session.assert_called_once()
+    mock_session.request.assert_called_once_with(
+        "GET",
+        "https://169.254.169.254",
+        headers=MDS_PING_REQUEST_HEADER,
+        timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
+        data=None,
+    )
+
+
+@mock.patch("google.auth.compute_engine._mtls.should_use_mds_mtls", return_value=True)
+@mock.patch("google.auth.compute_engine._mtls.create_session")
+def test_get_mtls(mock_create_session, mock_should_use_mtls):
+    response = mock.create_autospec(requests.Response, instance=True)
+    response.status_code = http_client.OK
+    response.content = _helpers.to_bytes("{}")
+    response.headers = {"content-type": "application/json"}
+    mock_session = mock.Mock()
+    mock_session.request.return_value = response
+    mock_create_session.return_value = mock_session
+
+    initial_request = mock.Mock()
+    _metadata.get(initial_request, "some/path")
+
+    mock_should_use_mtls.assert_called_once()
+    mock_create_session.assert_called_once()
+    mock_session.request.assert_called_once_with(
+        "GET",
+        "https://metadata.google.internal/computeMetadata/v1/some/path",
+        data=None,
+        headers=_metadata._METADATA_HEADERS,
+        timeout=_metadata._METADATA_DEFAULT_TIMEOUT,
+    )

--- a/tests/compute_engine/test__mtls.py
+++ b/tests/compute_engine/test__mtls.py
@@ -16,7 +16,7 @@
 #
 
 import mock
-import pytest
+import pytest  # type: ignore
 
 from google.auth import environment_vars, exceptions
 from google.auth.compute_engine import _mtls

--- a/tests/compute_engine/test__mtls.py
+++ b/tests/compute_engine/test__mtls.py
@@ -113,3 +113,15 @@ def test_create_session(mock_adapter, mock_session, mock_mds_mtls_config):
     session_instance.mount.assert_called_once_with(
         "https://", mock_adapter.return_value
     )
+
+
+@mock.patch("ssl.create_default_context")
+@mock.patch("requests.adapters.HTTPAdapter.proxy_manager_for")
+def test_mds_mtls_adapter_proxy_manager_for(
+    mock_proxy_manager_for, mock_ssl_context, mock_mds_mtls_config
+):
+    adapter = _mtls.MdsMtlsAdapter(mock_mds_mtls_config)
+    adapter.proxy_manager_for("test_proxy")
+    mock_proxy_manager_for.assert_called_once_with(
+        "test_proxy", ssl_context=adapter.ssl_context
+    )

--- a/tests/compute_engine/test__mtls.py
+++ b/tests/compute_engine/test__mtls.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+from pathlib import Path
+
 import mock
 import pytest  # type: ignore
 import requests
@@ -26,7 +28,8 @@ from google.auth.compute_engine import _mtls
 @pytest.fixture
 def mock_mds_mtls_config():
     return _mtls.MdsMtlsConfig(
-        ca_cert_path="/fake/ca.crt", client_combined_cert_path="/fake/client.key"
+        ca_cert_path=Path("/fake/ca.crt"),
+        client_combined_cert_path=Path("/fake/client.key"),
     )
 
 

--- a/tests/compute_engine/test__mtls.py
+++ b/tests/compute_engine/test__mtls.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from google.auth import environment_vars, exceptions
+from google.auth.compute_engine import _mtls
+
+
+@pytest.fixture
+def mock_mds_mtls_config():
+    return _mtls.MdsMtlsConfig(
+        ca_cert_path="/fake/ca.crt", client_combined_cert_path="/fake/client.key"
+    )
+
+
+def test__parse_mds_mode_default(monkeypatch):
+    monkeypatch.delenv(environment_vars.GCE_METADATA_MTLS_MODE, raising=False)
+    assert _mtls._parse_mds_mode() == _mtls.MdsMtlsMode.DEFAULT
+
+
+@pytest.mark.parametrize(
+    "mode_str, expected_mode",
+    [
+        ("strict", _mtls.MdsMtlsMode.STRICT),
+        ("none", _mtls.MdsMtlsMode.NONE),
+        ("default", _mtls.MdsMtlsMode.DEFAULT),
+        ("STRICT", _mtls.MdsMtlsMode.STRICT),
+    ],
+)
+def test__parse_mds_mode_valid(monkeypatch, mode_str, expected_mode):
+    monkeypatch.setenv(environment_vars.GCE_METADATA_MTLS_MODE, mode_str)
+    assert _mtls._parse_mds_mode() == expected_mode
+
+
+def test__parse_mds_mode_invalid(monkeypatch):
+    monkeypatch.setenv(environment_vars.GCE_METADATA_MTLS_MODE, "invalid_mode")
+    with pytest.raises(ValueError):
+        _mtls._parse_mds_mode()
+
+
+@mock.patch("os.path.exists")
+def test__certs_exist_true(mock_exists, mock_mds_mtls_config):
+    mock_exists.return_value = True
+    assert _mtls._certs_exist(mock_mds_mtls_config) is True
+
+
+@mock.patch("os.path.exists")
+def test__certs_exist_false(mock_exists, mock_mds_mtls_config):
+    mock_exists.return_value = False
+    assert _mtls._certs_exist(mock_mds_mtls_config) is False
+
+
+@pytest.mark.parametrize(
+    "mtls_mode, certs_exist, expected_result",
+    [
+        ("strict", True, True),
+        ("strict", False, exceptions.MutualTLSChannelError),
+        ("none", True, False),
+        ("none", False, False),
+        ("default", True, True),
+        ("default", False, False),
+    ],
+)
+@mock.patch("os.path.exists")
+def test_should_use_mds_mtls(
+    mock_exists, monkeypatch, mtls_mode, certs_exist, expected_result
+):
+    monkeypatch.setenv(environment_vars.GCE_METADATA_MTLS_MODE, mtls_mode)
+    mock_exists.return_value = certs_exist
+
+    if isinstance(expected_result, type) and issubclass(expected_result, Exception):
+        with pytest.raises(expected_result):
+            _mtls.should_use_mds_mtls()
+    else:
+        assert _mtls.should_use_mds_mtls() is expected_result
+
+
+@mock.patch("ssl.create_default_context")
+def test_mds_mtls_adapter_init(mock_ssl_context, mock_mds_mtls_config):
+    adapter = _mtls.MdsMtlsAdapter(mock_mds_mtls_config)
+    mock_ssl_context.assert_called_once()
+    adapter.ssl_context.load_verify_locations.assert_called_once_with(
+        cafile=mock_mds_mtls_config.ca_cert_path
+    )
+    adapter.ssl_context.load_cert_chain.assert_called_once_with(
+        certfile=mock_mds_mtls_config.client_combined_cert_path
+    )
+
+
+@mock.patch("requests.Session")
+@mock.patch("google.auth.compute_engine._mtls.MdsMtlsAdapter")
+def test_create_session(mock_adapter, mock_session, mock_mds_mtls_config):
+    session_instance = mock_session.return_value
+    session = _mtls.create_session(mock_mds_mtls_config)
+    assert session is session_instance
+    mock_adapter.assert_called_once_with(mock_mds_mtls_config)
+    session_instance.mount.assert_called_once_with(
+        "https://", mock_adapter.return_value
+    )

--- a/tests/compute_engine/test__mtls.py
+++ b/tests/compute_engine/test__mtls.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+import os
+
 import mock
 import pytest  # type: ignore
 
@@ -26,6 +28,28 @@ from google.auth.compute_engine import _mtls
 def mock_mds_mtls_config():
     return _mtls.MdsMtlsConfig(
         ca_cert_path="/fake/ca.crt", client_combined_cert_path="/fake/client.key"
+    )
+
+
+@mock.patch("os.name", "nt")
+def test__MdsMtlsConfig_windows_defaults():
+    config = _mtls.MdsMtlsConfig()
+    assert config.ca_cert_path == os.path.join(
+        "C:\\", "ProgramData", "Google", "ComputeEngine", "mds-mtls-root.crt"
+    )
+    assert config.client_combined_cert_path == os.path.join(
+        "C:\\", "ProgramData", "Google", "ComputeEngine", "mds-mtls-client.key"
+    )
+
+
+@mock.patch("os.name", "posix")
+def test__MdsMtlsConfig_non_windows_defaults():
+    config = _mtls.MdsMtlsConfig()
+    assert config.ca_cert_path == os.path.join(
+        "/", "run", "google-mds-mtls", "root.crt"
+    )
+    assert config.client_combined_cert_path == os.path.join(
+        "/", "run", "google-mds-mtls", "client.key"
     )
 
 


### PR DESCRIPTION
**Feature Gating**
The `GCE_METADATA_MTLS_MODE` environment variable is introduced, which can be set to strict, none, or default.

The `should_use_mds_mtls` function determines whether to use mTLS based on the environment variable and the existence of the certificate files.

**Using MDS mTLS**
A custom `MdsMtlsAdapter` for requests is implemented to handle the SSL context for mTLS.

The `create_session` function mounts an MdsMtlsAdapter into the request.Session

**MdsMtlsAdapter**
Loads MDS mTLS certificates from well-known location (https://docs.cloud.google.com/compute/docs/metadata/overview#https-mds-certificates).

If HTTPS request fails, MdsMtlsAdapter will fallback to HTTP. 

**Integrating with existing code**
compute_engine/_metadata.py:
- The metadata server URL construction is now dynamic, supporting both http and https schemes based on whether mTLS is enabled.
- ping and get functions are updated to use mTLS when it's enabled.