### PR TITLE
chore: librarian release pull request: 20251105T223742Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator:latest
 libraries:
   - id: google-auth
-    version: 2.41.1
+    version: 2.42.0
     last_generated_commit: 102d9f92ac6ed649a61efd9b208e4d1de278e9bb
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@
 
 [1]: https://pypi.org/project/google-auth/#history
 
+## [2.42.0](https://github.com/googleapis/google-cloud-python/compare/google-auth-v2.41.1...google-auth-v2.42.0) (2025-11-05)
+
+
+### Features
+
+* Add public wrapper for _mtls_helper.check_use_client_cert which enables mTLS if GOOGLE_API_USE_CLIENT_CERTIFICATE is not set, when the MWID/X.509 cert sources detected (#1859) Add public wrapper for check_use_client_cert which enables mTLS if
+GOOGLE_API_USE_CLIENT_CERTIFICATE is not set, when the MWID/X.509 cert
+sources detected. Also, fix check_use_client_cert to return boolean
+value.
+Change #1848 added the check_use_client_cert method that helps know if
+client cert should be used for mTLS connection. However, that was in a
+private class, thus, created a public wrapper of the same function so
+that it can be used by python Client Libraries. Also, updated
+check_use_client_cert to return a boolean value instead of existing
+string value for better readability and future scope.
+--------- ([1535eccbff0ad8f3fd6a9775316ac8b77dca66ba](https://github.com/googleapis/google-cloud-python/commit/1535eccbff0ad8f3fd6a9775316ac8b77dca66ba))
+* Enable mTLS if GOOGLE_API_USE_CLIENT_CERTIFICATE  is not set, if the MWID/X.509 cert sources detected (#1848) The Python SDK will use a hybrid approach for mTLS enablement:
+- If the GOOGLE_API_USE_CLIENT_CERTIFICATE environment variable is set
+(either true or false), the SDK will respect that setting. This is
+necessary for test scenarios and users who need to explicitly control
+mTLS behavior.
+- If the GOOGLE_API_USE_CLIENT_CERTIFICATE environment variable is not
+set, the SDK will automatically enable mTLS only if it detects Managed
+Workload Identity (MWID) or X.509 Workforce Identity Federation (WIF)
+certificate sources. In other cases where the variable is not set, mTLS
+will remain disabled.
+** This change also adds the helper method `check_use_client_cert` and
+it's unit test, which will be used for checking the criteria for setting
+the mTLS to true
+** This change is only for Auth-Library, other changes will be created
+for Client-Library use-cases.
+--------- ([395e405b64b56ddb82ee639958c2e8056ad2e82b](https://github.com/googleapis/google-cloud-python/commit/395e405b64b56ddb82ee639958c2e8056ad2e82b))
+* onboard `google-auth` to librarian (#1838) This PR onboards `google-auth` library to the Librarian system.
+Wait for
+https://github.com/googleapis/google-auth-library-python/pull/1819. ([c503eaa511357d7a76cc1e1f1d3a3be2dabd5bca](https://github.com/googleapis/google-cloud-python/commit/c503eaa511357d7a76cc1e1f1d3a3be2dabd5bca))
+* Add trust boundary support for external accounts. (#1809) * feat: Add trust boundary support for external accounts.
+* Add trust boundary support to external account authorized users.
+* Fix lint issues
+* Implement additional unit tests for external account authorized user.
+* fix formatting issue
+* Add a unit test with invalid audiance
+* add missing unit tests ([36ecb1d65883477d27faf9c2281fc289659b9903](https://github.com/googleapis/google-cloud-python/commit/36ecb1d65883477d27faf9c2281fc289659b9903))
+
+
+### Bug Fixes
+
+* catch ValueError for json.loads() (#1842) see internal bug 448976223 ([b074cad460589633adfc6744c01726ae86f2aa2b](https://github.com/googleapis/google-cloud-python/commit/b074cad460589633adfc6744c01726ae86f2aa2b))
+* Read scopes from ADC json for impersoanted cred (#1820) * fix: Read scopes from ADC json for impersoanted cred
+* secret
+* secret update
+* secret update
+* 🦉 Updates from OwlBot post-processor
+See https://github.com/googleapis/repo-automation-bots/blob/main/packages/owl-bot/README.md
+--------- ([62c0fc82a3625542381f85c698595446fc99ddae](https://github.com/googleapis/google-cloud-python/commit/62c0fc82a3625542381f85c698595446fc99ddae))
+
 ## [2.42.1](https://github.com/googleapis/google-auth-library-python/compare/v2.42.0...v2.42.1) (2025-10-30)
 
 

--- a/google/auth/version.py
+++ b/google/auth/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.42.1"
+__version__ = "2.42.0"


### PR DESCRIPTION
Librarian Version: v0.5.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator:latest
<details><summary>google-auth: 2.42.0</summary>

## [2.42.0](https://github.com/googleapis/google-auth-library-python/compare/v2.41.1...v2.42.0) (2025-11-05)

### Features

* Add public wrapper for _mtls_helper.check_use_client_cert which enables mTLS if GOOGLE_API_USE_CLIENT_CERTIFICATE is not set, when the MWID/X.509 cert sources detected (#1859) ([1535eccb](https://github.com/googleapis/google-auth-library-python/commit/1535eccb))

* Enable mTLS if GOOGLE_API_USE_CLIENT_CERTIFICATE  is not set, if the MWID/X.509 cert sources detected (#1848) ([395e405b](https://github.com/googleapis/google-auth-library-python/commit/395e405b))

* onboard `google-auth` to librarian (#1838) ([c503eaa5](https://github.com/googleapis/google-auth-library-python/commit/c503eaa5))

* Add trust boundary support for external accounts. (#1809) ([36ecb1d6](https://github.com/googleapis/google-auth-library-python/commit/36ecb1d6))

### Bug Fixes

* catch ValueError for json.loads() (#1842) ([b074cad4](https://github.com/googleapis/google-auth-library-python/commit/b074cad4))

* Read scopes from ADC json for impersoanted cred (#1820) ([62c0fc82](https://github.com/googleapis/google-auth-library-python/commit/62c0fc82))

</details>