### PR TITLE
fix(auth): Use public refresh method for source credentials in ImpersonatedCredentials

### DIFF
--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -286,7 +286,7 @@ class Credentials(
             self._source_credentials.token_state == credentials.TokenState.STALE
             or self._source_credentials.token_state == credentials.TokenState.INVALID
         ):
-            self._source_credentials._refresh_token(request)
+            self._source_credentials.refresh(request)
 
         body = {
             "delegates": self._delegates,


### PR DESCRIPTION
This PR addresses a bug in ImpersonatedCredentials that causes a issues when the source_credential is of a type that does not implement the private _refresh_token method (for example, a custom credential type). 