### PR TITLE
chore: librarian release pull request: 20251212T161150Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator:latest
 libraries:
   - id: google-auth
-    version: 2.43.0
+    version: 2.44.0
     last_generated_commit: 102d9f92ac6ed649a61efd9b208e4d1de278e9bb
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 [1]: https://pypi.org/project/google-auth/#history
 
+## [2.44.0](https://github.com/googleapis/google-auth-library-python/compare/v2.43.0...v2.44.0) (2025-12-13)
+
+
+### Features
+
+* support Python 3.14 (#1822) ([0f7097e78f247665b6ef0287d482033f7be2ed6d](https://github.com/googleapis/google-auth-library-python/commit/0f7097e78f247665b6ef0287d482033f7be2ed6d))
+* add ecdsa p-384 support (#1872) ([39c381a5f6881b590025f36d333d12eff8dc60fc](https://github.com/googleapis/google-auth-library-python/commit/39c381a5f6881b590025f36d333d12eff8dc60fc))
+* MDS connections use mTLS (#1856) ([0387bb95713653d47e846cad3a010eb55ef2db4c](https://github.com/googleapis/google-auth-library-python/commit/0387bb95713653d47e846cad3a010eb55ef2db4c))
+* Implement token revocation in STS client and add revoke() metho… (#1849) ([d5638986ca03ee95bfffa9ad821124ed7e903e63](https://github.com/googleapis/google-auth-library-python/commit/d5638986ca03ee95bfffa9ad821124ed7e903e63))
+* Add shlex to correctly parse executable commands with spaces (#1855) ([cf6fc3cced78bc1362a7fe596c32ebc9ce03c26b](https://github.com/googleapis/google-auth-library-python/commit/cf6fc3cced78bc1362a7fe596c32ebc9ce03c26b))
+
+
+### Bug Fixes
+
+* Use public refresh method for source credentials in ImpersonatedCredentials (#1884) ([e0c3296f471747258f6d98d2d9bfde636358ecde](https://github.com/googleapis/google-auth-library-python/commit/e0c3296f471747258f6d98d2d9bfde636358ecde))
+* Add temporary patch to workload cert logic to accomodate Cloud Run mis-configuration (#1880) ([78de7907b8bdb7b5510e3c6fa8a3f3721e2436d7](https://github.com/googleapis/google-auth-library-python/commit/78de7907b8bdb7b5510e3c6fa8a3f3721e2436d7))
+* Delegate workload cert and key default lookup to helper function (#1877) ([b0993c7edaba505d0fb0628af28760c43034c959](https://github.com/googleapis/google-auth-library-python/commit/b0993c7edaba505d0fb0628af28760c43034c959))
+
 ## [2.43.0](https://github.com/googleapis/google-cloud-python/compare/google-auth-v2.42.1...google-auth-v2.43.0) (2025-11-05)
 
 

--- a/google/auth/version.py
+++ b/google/auth/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.43.0"
+__version__ = "2.44.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator:latest
<details><summary>google-auth: 2.44.0</summary>

## [2.44.0](https://github.com/googleapis/google-auth-library-python/compare/v2.43.0...v2.44.0) (2025-12-12)

### Features

* MDS connections use mTLS (#1856) ([0387bb95](https://github.com/googleapis/google-auth-library-python/commit/0387bb95))

* support Python 3.14 (#1822) ([0f7097e7](https://github.com/googleapis/google-auth-library-python/commit/0f7097e7))

* add ecdsa p-384 support (#1872) ([39c381a5](https://github.com/googleapis/google-auth-library-python/commit/39c381a5))

* Add shlex to correctly parse executable commands with spaces (#1855) ([cf6fc3cc](https://github.com/googleapis/google-auth-library-python/commit/cf6fc3cc))

* Implement token revocation in STS client and add revoke() metho… (#1849) ([d5638986](https://github.com/googleapis/google-auth-library-python/commit/d5638986))

### Bug Fixes

* Add temporary patch to workload cert logic to accomodate Cloud Run mis-configuration (#1880) ([78de7907](https://github.com/googleapis/google-auth-library-python/commit/78de7907))

* Delegate workload cert and key default lookup to helper function (#1877) ([b0993c7e](https://github.com/googleapis/google-auth-library-python/commit/b0993c7e))

* Use public refresh method for source credentials in ImpersonatedCredentials (#1884) ([e0c3296f](https://github.com/googleapis/google-auth-library-python/commit/e0c3296f))

</details>