### PR TITLE
chore: update default python version for tests to 3.14

### DIFF
--- a/google/auth/_cloud_sdk.py
+++ b/google/auth/_cloud_sdk.py
@@ -83,7 +83,7 @@ def get_application_default_credentials_path():
 
 
 def _run_subprocess_ignore_stderr(command):
-    """ Return subprocess.check_output with the given command and ignores stderr."""
+    """Return subprocess.check_output with the given command and ignores stderr."""
     with open(os.devnull, "w") as devnull:
         output = subprocess.check_output(command, stderr=devnull)
     return output

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -538,8 +538,10 @@ def _get_impersonated_service_account_credentials(filename, info, scopes):
     from google.auth import impersonated_credentials
 
     try:
-        credentials = impersonated_credentials.Credentials.from_impersonated_service_account_info(
-            info, scopes=scopes
+        credentials = (
+            impersonated_credentials.Credentials.from_impersonated_service_account_info(
+                info, scopes=scopes
+            )
         )
     except ValueError as caught_exc:
         msg = "Failed to load impersonated service account credentials from {}".format(
@@ -554,8 +556,8 @@ def _get_gdch_service_account_credentials(filename, info):
     from google.oauth2 import gdch_credentials
 
     try:
-        credentials = gdch_credentials.ServiceAccountCredentials.from_service_account_info(
-            info
+        credentials = (
+            gdch_credentials.ServiceAccountCredentials.from_service_account_info(info)
         )
     except ValueError as caught_exc:
         msg = "Failed to load GDCH service account credentials from {}".format(filename)

--- a/google/auth/_refresh_worker.py
+++ b/google/auth/_refresh_worker.py
@@ -61,8 +61,8 @@ class RefreshThreadManager:
 
     def clear_error(self):
         """
-      Removes any errors that were stored from previous background refreshes.
-      """
+        Removes any errors that were stored from previous background refreshes.
+        """
         with self._lock:
             if self._worker:
                 self._worker._error_info = None

--- a/google/auth/aws.py
+++ b/google/auth/aws.py
@@ -348,10 +348,10 @@ def _generate_authentication_header_map(
 class AwsSecurityCredentials:
     """A class that models AWS security credentials with an optional session token.
 
-        Attributes:
-            access_key_id (str): The AWS security credentials access key id.
-            secret_access_key (str): The AWS security credentials secret access key.
-            session_token (Optional[str]): The optional AWS security credentials session token. This should be set when using temporary credentials.
+    Attributes:
+        access_key_id (str): The AWS security credentials access key id.
+        secret_access_key (str): The AWS security credentials secret access key.
+        session_token (Optional[str]): The optional AWS security credentials session token. This should be set when using temporary credentials.
     """
 
     access_key_id: str
@@ -420,7 +420,6 @@ class _DefaultAwsSecurityCredentialsSupplier(AwsSecurityCredentialsSupplier):
 
     @_helpers.copy_docstring(AwsSecurityCredentialsSupplier)
     def get_aws_security_credentials(self, context, request):
-
         # Check environment variables for permanent credentials first.
         # https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html
         env_aws_access_key_id = os.environ.get(environment_vars.AWS_ACCESS_KEY_ID)
@@ -688,8 +687,8 @@ class Credentials(external_account.Credentials):
             )
         else:
             environment_id = credential_source.get("environment_id") or ""
-            self._aws_security_credentials_supplier = _DefaultAwsSecurityCredentialsSupplier(
-                credential_source
+            self._aws_security_credentials_supplier = (
+                _DefaultAwsSecurityCredentialsSupplier(credential_source)
             )
             self._cred_verification_url = credential_source.get(
                 "regional_cred_verification_url"
@@ -759,8 +758,10 @@ class Credentials(external_account.Credentials):
 
         # Retrieve the AWS security credentials needed to generate the signed
         # request.
-        aws_security_credentials = self._aws_security_credentials_supplier.get_aws_security_credentials(
-            self._supplier_context, request
+        aws_security_credentials = (
+            self._aws_security_credentials_supplier.get_aws_security_credentials(
+                self._supplier_context, request
+            )
         )
         # Generate the signed request to AWS STS GetCallerIdentity API.
         # Use the required regional endpoint. Otherwise, the request will fail.

--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -399,7 +399,6 @@ class IDTokenCredentials(
 
     @_helpers.copy_docstring(credentials.CredentialsWithQuotaProject)
     def with_quota_project(self, quota_project_id):
-
         # since the signer is already instantiated,
         # the request is not needed
         if self._use_metadata_identity_endpoint:
@@ -423,7 +422,6 @@ class IDTokenCredentials(
 
     @_helpers.copy_docstring(credentials.CredentialsWithTokenUri)
     def with_token_uri(self, token_uri):
-
         # since the signer is already instantiated,
         # the request is not needed
         if self._use_metadata_identity_endpoint:

--- a/google/auth/external_account.py
+++ b/google/auth/external_account.py
@@ -98,7 +98,8 @@ class Credentials(
     is used.
     When the credential configuration is accepted from an
     untrusted source, you should validate it before using.
-    Refer https://cloud.google.com/docs/authentication/external/externally-sourced-credentials for more details."""
+    Refer https://cloud.google.com/docs/authentication/external/externally-sourced-credentials for more details.
+    """
 
     def __init__(
         self,

--- a/google/auth/external_account_authorized_user.py
+++ b/google/auth/external_account_authorized_user.py
@@ -70,7 +70,8 @@ class Credentials(
     is used.
     When the credential configuration is accepted from an
     untrusted source, you should validate it before using.
-    Refer https://cloud.google.com/docs/authentication/external/externally-sourced-credentials for more details."""
+    Refer https://cloud.google.com/docs/authentication/external/externally-sourced-credentials for more details.
+    """
 
     def __init__(
         self,

--- a/google/auth/identity_pool.py
+++ b/google/auth/identity_pool.py
@@ -83,9 +83,9 @@ class SubjectTokenSupplier(metaclass=abc.ABCMeta):
 
 class _TokenContent(NamedTuple):
     """Models the token content response from file and url internal suppliers.
-        Attributes:
-            content (str): The string content of the file or URL response.
-            location (str): The location the content was retrieved from. This will either be a file location or a URL.
+    Attributes:
+        content (str): The string content of the file or URL response.
+        location (str): The location the content was retrieved from. This will either be a file location or a URL.
     """
 
     content: str
@@ -93,7 +93,7 @@ class _TokenContent(NamedTuple):
 
 
 class _FileSupplier(SubjectTokenSupplier):
-    """ Internal implementation of subject token supplier which supports reading a subject token from a file."""
+    """Internal implementation of subject token supplier which supports reading a subject token from a file."""
 
     def __init__(self, path, format_type, subject_token_field_name):
         self._path = path
@@ -114,7 +114,7 @@ class _FileSupplier(SubjectTokenSupplier):
 
 
 class _UrlSupplier(SubjectTokenSupplier):
-    """ Internal implementation of subject token supplier which supports retrieving a subject token by calling a URL endpoint."""
+    """Internal implementation of subject token supplier which supports retrieving a subject token by calling a URL endpoint."""
 
     def __init__(self, url, format_type, subject_token_field_name, headers):
         self._url = url
@@ -261,7 +261,8 @@ class Credentials(external_account.Credentials):
     is used.
     When the credential configuration is accepted from an
     untrusted source, you should validate it before using.
-    Refer https://cloud.google.com/docs/authentication/external/externally-sourced-credentials for more details."""
+    Refer https://cloud.google.com/docs/authentication/external/externally-sourced-credentials for more details.
+    """
 
     def __init__(
         self,
@@ -566,8 +567,8 @@ class Credentials(external_account.Credentials):
             cert_bytes = self._get_cert_bytes()
             cert = _agent_identity_utils.parse_certificate(cert_bytes)
             if _agent_identity_utils.should_request_bound_token(cert):
-                cert_fingerprint = _agent_identity_utils.calculate_certificate_fingerprint(
-                    cert
+                cert_fingerprint = (
+                    _agent_identity_utils.calculate_certificate_fingerprint(cert)
                 )
 
         self._refresh_token(request, cert_fingerprint=cert_fingerprint)

--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -586,7 +586,7 @@ class Credentials(
 
     @property  # type: ignore
     def additional_claims(self):
-        """ Additional claims the JWT object was created with."""
+        """Additional claims the JWT object was created with."""
         return self._additional_claims
 
 
@@ -760,7 +760,6 @@ class OnDemandCredentials(
 
     @_helpers.copy_docstring(google.auth.credentials.CredentialsWithQuotaProject)
     def with_quota_project(self, quota_project_id):
-
         return self.__class__(
             self._signer,
             issuer=self._issuer,

--- a/google/auth/metrics.py
+++ b/google/auth/metrics.py
@@ -48,6 +48,7 @@ def python_and_auth_lib_version():
 
 # Token request metric header values
 
+
 # x-goog-api-client header value for access token request via metadata server.
 # Example: "gl-python/3.7 auth/1.1 auth-request-type/at cred-type/mds"
 def token_request_access_token_mds():
@@ -107,6 +108,7 @@ def token_request_user():
 
 
 # Miscellenous metrics
+
 
 # x-goog-api-client header value for metadata server ping.
 # Example: "gl-python/3.7 auth/1.1 auth-request-type/mds"

--- a/google/auth/pluggable.py
+++ b/google/auth/pluggable.py
@@ -66,7 +66,8 @@ class Credentials(external_account.Credentials):
     is used.
     When the credential configuration is accepted from an
     untrusted source, you should validate it before using.
-    Refer https://cloud.google.com/docs/authentication/external/externally-sourced-credentials for more details."""
+    Refer https://cloud.google.com/docs/authentication/external/externally-sourced-credentials for more details.
+    """
 
     def __init__(
         self,
@@ -129,17 +130,17 @@ class Credentials(external_account.Credentials):
             raise exceptions.MalformedError(
                 "Missing credential_source. An 'executable' must be provided."
             )
-        self._credential_source_executable_command = self._credential_source_executable.get(
-            "command"
+        self._credential_source_executable_command = (
+            self._credential_source_executable.get("command")
         )
-        self._credential_source_executable_timeout_millis = self._credential_source_executable.get(
-            "timeout_millis"
+        self._credential_source_executable_timeout_millis = (
+            self._credential_source_executable.get("timeout_millis")
         )
-        self._credential_source_executable_interactive_timeout_millis = self._credential_source_executable.get(
-            "interactive_timeout_millis"
+        self._credential_source_executable_interactive_timeout_millis = (
+            self._credential_source_executable.get("interactive_timeout_millis")
         )
-        self._credential_source_executable_output_file = self._credential_source_executable.get(
-            "output_file"
+        self._credential_source_executable_output_file = (
+            self._credential_source_executable.get("output_file")
         )
 
         # Dummy value. This variable is only used via injection, not exposed to ctor

--- a/google/auth/transport/_aiohttp_requests.py
+++ b/google/auth/transport/_aiohttp_requests.py
@@ -276,7 +276,6 @@ class AuthorizedSession(aiohttp.ClientSession):
         auto_decompress=False,
         **kwargs,
     ):
-
         """Implementation of Authorized Session aiohttp request.
 
         Args:
@@ -358,7 +357,6 @@ class AuthorizedSession(aiohttp.ClientSession):
                 response.status in self._refresh_status_codes
                 and _credential_refresh_attempt < self._max_refresh_attempts
             ):
-
                 requests._LOGGER.info(
                     "Refreshing credentials due to a %s response. Attempt %s/%s.",
                     response.status,

--- a/google/auth/transport/_http_client.py
+++ b/google/auth/transport/_http_client.py
@@ -100,7 +100,6 @@ class Request(transport.Request):
         connection = http_client.HTTPConnection(parts.netloc, timeout=timeout)
 
         try:
-
             _helpers.request_log(_LOGGER, method, url, body, headers)
             connection.request(method, path, body=body, headers=headers, **kwargs)
             response = connection.getresponse()

--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -561,7 +561,12 @@ class AuthorizedSession(requests.Session):
             # Handle unauthorized permission error(401 status code)
             if response.status_code == http_client.UNAUTHORIZED:
                 if self.is_mtls:
-                    call_cert_bytes, call_key_bytes, cached_fingerprint, current_cert_fingerprint = _mtls_helper.check_parameters_for_unauthorized_response(
+                    (
+                        call_cert_bytes,
+                        call_key_bytes,
+                        cached_fingerprint,
+                        current_cert_fingerprint,
+                    ) = _mtls_helper.check_parameters_for_unauthorized_response(
                         self._cached_cert
                     )
                     if cached_fingerprint != current_cert_fingerprint:

--- a/google/auth/transport/urllib3.py
+++ b/google/auth/transport/urllib3.py
@@ -416,7 +416,12 @@ class AuthorizedHttp(RequestMethods):  # type: ignore
         ):
             if response.status == http_client.UNAUTHORIZED:
                 if use_mtls:
-                    call_cert_bytes, call_key_bytes, cached_fingerprint, current_cert_fingerprint = _mtls_helper.check_parameters_for_unauthorized_response(
+                    (
+                        call_cert_bytes,
+                        call_key_bytes,
+                        cached_fingerprint,
+                        current_cert_fingerprint,
+                    ) = _mtls_helper.check_parameters_for_unauthorized_response(
                         self._cached_cert
                     )
                     if cached_fingerprint != current_cert_fingerprint:

--- a/google/oauth2/_client.py
+++ b/google/oauth2/_client.py
@@ -256,7 +256,11 @@ def _token_endpoint_request(
             an error.
     """
 
-    response_status_ok, response_data, retryable_error = _token_endpoint_request_no_throw(
+    (
+        response_status_ok,
+        response_data,
+        retryable_error,
+    ) = _token_endpoint_request_no_throw(
         request,
         token_uri,
         body,
@@ -568,9 +572,11 @@ def _lookup_trust_boundary_request(request, url, can_retry=True, headers=None):
         google.auth.exceptions.RefreshError: If the token endpoint returned
             an error.
     """
-    response_status_ok, response_data, retryable_error = _lookup_trust_boundary_request_no_throw(
-        request, url, can_retry, headers
-    )
+    (
+        response_status_ok,
+        response_data,
+        retryable_error,
+    ) = _lookup_trust_boundary_request_no_throw(request, url, can_retry, headers)
     if not response_status_ok:
         _handle_error_response(response_data, retryable_error)
     return response_data

--- a/google/oauth2/_client_async.py
+++ b/google/oauth2/_client_async.py
@@ -127,7 +127,11 @@ async def _token_endpoint_request(
             an error.
     """
 
-    response_status_ok, response_data, retryable_error = await _token_endpoint_request_no_throw(
+    (
+        response_status_ok,
+        response_data,
+        retryable_error,
+    ) = await _token_endpoint_request_no_throw(
         request,
         token_uri,
         body,

--- a/google/oauth2/_id_token_async.py
+++ b/google/oauth2/_id_token_async.py
@@ -252,8 +252,10 @@ async def fetch_id_token(request, audience):
 
                 info = json.load(f)
                 if info.get("type") == "service_account":
-                    credentials = service_account.IDTokenCredentials.from_service_account_info(
-                        info, target_audience=audience
+                    credentials = (
+                        service_account.IDTokenCredentials.from_service_account_info(
+                            info, target_audience=audience
+                        )
                     )
                     await credentials.refresh(request)
                     return credentials.token

--- a/google/oauth2/_reauth_async.py
+++ b/google/oauth2/_reauth_async.py
@@ -290,9 +290,11 @@ async def refresh_grant(
     if rapt_token:
         body["rapt"] = rapt_token
 
-    response_status_ok, response_data, retryable_error = await _client_async._token_endpoint_request_no_throw(
-        request, token_uri, body
-    )
+    (
+        response_status_ok,
+        response_data,
+        retryable_error,
+    ) = await _client_async._token_endpoint_request_no_throw(request, token_uri, body)
     if (
         not response_status_ok
         and response_data.get("error") == reauth._REAUTH_NEEDED_ERROR

--- a/google/oauth2/reauth.py
+++ b/google/oauth2/reauth.py
@@ -330,7 +330,11 @@ def refresh_grant(
         body["rapt"] = rapt_token
     metrics_header = {metrics.API_CLIENT_HEADER: metrics.token_request_user()}
 
-    response_status_ok, response_data, retryable_error = _client._token_endpoint_request_no_throw(
+    (
+        response_status_ok,
+        response_data,
+        retryable_error,
+    ) = _client._token_endpoint_request_no_throw(
         request, token_uri, body, headers=metrics_header
     )
 

--- a/google/oauth2/service_account.py
+++ b/google/oauth2/service_account.py
@@ -482,7 +482,6 @@ class Credentials(
                     self._jwt_credentials is None
                     or self._jwt_credentials._audience != audience
                 ):
-
                     self._jwt_credentials = jwt.Credentials.from_signing_credentials(
                         self, audience
                     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,7 @@ BLACK_PATHS = [
     "docs/conf.py",
 ]
 
-DEFAULT_PYTHON_VERSION = "3.10"
+DEFAULT_PYTHON_VERSION = "3.14"
 # TODO(https://github.com/googleapis/google-auth-library-python/issues/1787):
 # Remove or restore testing for Python 3.7/3.8
 UNIT_TEST_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -146,7 +146,7 @@ def cover(session):
     session.run("coverage", "report", "--show-missing", "--fail-under=100")
 
 
-@nox.session(python="3.9")
+@nox.session(python="3.10")
 def docs(session):
     """Build the docs for this library."""
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -129,19 +129,14 @@ def unit(session):
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def cover(session):
-    session.env["PIP_EXTRA_INDEX_URL"] = "https://pypi.org/simple"
-    session.install("-e", ".[testing]")
-    session.run(
-        "pytest",
-        "--cov=google.auth",
-        "--cov=google.oauth2",
-        "--cov=tests",
-        "--cov=tests_async",
-        "--cov-report=term-missing",
-        "tests",
-        "tests_async",
-    )
+    """Run the final coverage report.
+
+    This outputs the coverage report aggregating coverage from the unit
+    test runs (not system test runs), and then erases coverage data.
+    """
+    session.install("coverage", "pytest-cov")
     session.run("coverage", "report", "--show-missing", "--fail-under=100")
+    session.run("coverage", "erase")
 
 
 @nox.session(python="3.10")

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,10 +20,8 @@ import nox
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-# https://github.com/psf/black/issues/2964, pin click version to 8.0.4 to
-# avoid incompatiblity with black.
-CLICK_VERSION = "click==8.0.4"
-BLACK_VERSION = "black==19.3b0"
+CLICK_VERSION = "click"
+BLACK_VERSION = "black==23.7.0"
 BLACK_PATHS = [
     "google",
     "tests",

--- a/noxfile.py
+++ b/noxfile.py
@@ -118,6 +118,7 @@ def unit(session):
     session.run(
         "pytest",
         f"--junitxml=unit_{session.python}_sponge_log.xml",
+        "--cov-append",
         "--cov=google.auth",
         "--cov=google.oauth2",
         "--cov=tests",

--- a/tests/crypt/test__cryptography_rsa.py
+++ b/tests/crypt/test__cryptography_rsa.py
@@ -70,7 +70,7 @@ class TestRSAVerifier(object):
         assert verifier.verify(to_sign, actual_signature)
 
     def test_verify_unicode_success(self):
-        to_sign = u"foo"
+        to_sign = "foo"
         signer = _cryptography_rsa.RSASigner.from_string(PRIVATE_KEY_BYTES)
         actual_signature = signer.sign(to_sign)
 

--- a/tests/crypt/test__python_rsa.py
+++ b/tests/crypt/test__python_rsa.py
@@ -72,7 +72,7 @@ class TestRSAVerifier(object):
         assert verifier.verify(to_sign, actual_signature)
 
     def test_verify_unicode_success(self):
-        to_sign = u"foo"
+        to_sign = "foo"
         signer = _python_rsa.RSASigner.from_string(PRIVATE_KEY_BYTES)
         actual_signature = signer.sign(to_sign)
 

--- a/tests/crypt/test_es.py
+++ b/tests/crypt/test_es.py
@@ -68,7 +68,7 @@ class TestEsVerifier(object):
         assert verifier.verify(to_sign, actual_signature)
 
     def test_verify_unicode_success(self):
-        to_sign = u"foo"
+        to_sign = "foo"
         signer = es.EsSigner.from_string(PRIVATE_KEY_BYTES)
         actual_signature = signer.sign(to_sign)
 

--- a/tests/crypt/test_es256.py
+++ b/tests/crypt/test_es256.py
@@ -60,7 +60,7 @@ class TestES256Verifier(object):
         assert verifier.verify(to_sign, actual_signature)
 
     def test_verify_unicode_success(self):
-        to_sign = u"foo"
+        to_sign = "foo"
         signer = es256.ES256Signer.from_string(PRIVATE_KEY_BYTES)
         actual_signature = signer.sign(to_sign)
 

--- a/tests/oauth2/test_challenges.py
+++ b/tests/oauth2/test_challenges.py
@@ -87,7 +87,6 @@ def test_security_key():
         "google.oauth2.challenges.SecurityKeyChallenge._obtain_challenge_input_webauthn",
         return_value={"securityKey": "security key response"},
     ):
-
         assert challenge.obtain_challenge_input(metadata) == {
             "securityKey": "security key response"
         }

--- a/tests/oauth2/test_sts.py
+++ b/tests/oauth2/test_sts.py
@@ -97,7 +97,7 @@ class TestStsClient(object):
         assert request_kwargs["headers"] == headers
         assert request_kwargs["body"] is not None
         body_tuples = urllib.parse.parse_qsl(request_kwargs["body"])
-        for (k, v) in body_tuples:
+        for k, v in body_tuples:
             assert v.decode("utf-8") == request_data[k.decode("utf-8")]
         assert len(body_tuples) == len(request_data.keys())
 
@@ -172,8 +172,7 @@ class TestStsClient(object):
         assert response == self.SUCCESS_RESPONSE
 
     def test_exchange_token_non200_without_auth(self):
-        """Test token exchange without client auth responding with non-200 status.
-        """
+        """Test token exchange without client auth responding with non-200 status."""
         client = self.make_client()
         request = self.make_mock_request(
             status=http_client.BAD_REQUEST, data=self.ERROR_RESPONSE

--- a/tests/test__default.py
+++ b/tests/test__default.py
@@ -154,9 +154,11 @@ IMPERSONATED_SERVICE_ACCOUNT_SERVICE_ACCOUNT_SOURCE_FILE = os.path.join(
     DATA_DIR, "impersonated_service_account_service_account_source.json"
 )
 
-IMPERSONATED_SERVICE_ACCOUNT_EXTERNAL_ACCOUNT_AUTHORIZED_USER_SOURCE_FILE = os.path.join(
-    DATA_DIR,
-    "impersonated_service_account_external_account_authorized_user_source.json",
+IMPERSONATED_SERVICE_ACCOUNT_EXTERNAL_ACCOUNT_AUTHORIZED_USER_SOURCE_FILE = (
+    os.path.join(
+        DATA_DIR,
+        "impersonated_service_account_external_account_authorized_user_source.json",
+    )
 )
 
 EXTERNAL_ACCOUNT_AUTHORIZED_USER_FILE = os.path.join(

--- a/tests/test__exponential_backoff.py
+++ b/tests/test__exponential_backoff.py
@@ -35,7 +35,7 @@ def test_exponential_backoff(mock_time):
             assert (curr_wait - jitter) <= backoff_interval <= (curr_wait + jitter)
             assert attempt == iteration_count + 1
             assert eb.backoff_count == iteration_count + 1
-            assert eb._current_wait_in_seconds == eb._multiplier ** iteration_count
+            assert eb._current_wait_in_seconds == eb._multiplier**iteration_count
 
             curr_wait = eb._current_wait_in_seconds
         iteration_count += 1
@@ -75,7 +75,7 @@ async def test_exponential_backoff_async(mock_time_async):
             assert (curr_wait - jitter) <= backoff_interval <= (curr_wait + jitter)
             assert attempt == iteration_count + 1
             assert eb.backoff_count == iteration_count + 1
-            assert eb._current_wait_in_seconds == eb._multiplier ** iteration_count
+            assert eb._current_wait_in_seconds == eb._multiplier**iteration_count
 
             curr_wait = eb._current_wait_in_seconds
         iteration_count += 1

--- a/tests/test__oauth2client.py
+++ b/tests/test__oauth2client.py
@@ -115,7 +115,6 @@ def mock_oauth2client_gae_imports(mock_non_existent_module):
 def test__convert_appengine_app_assertion_credentials(
     app_identity, mock_oauth2client_gae_imports
 ):
-
     # `oauth2client` requires `cgi` which was removed in Python 3.13
     # See https://github.com/googleapis/oauth2client/blob/50d20532a748f18e53f7d24ccbe6647132c979a9/oauth2client/contrib/appengine.py#L20
     # oauth2client is no longer being updated so this test must be skipped on newer Python Runtimes

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -42,8 +42,10 @@ SERVICE_ACCOUNT_EMAIL = "service-1234@service-name.iam.gserviceaccount.com"
 SERVICE_ACCOUNT_IMPERSONATION_URL_BASE = (
     "https://us-east1-iamcredentials.googleapis.com"
 )
-SERVICE_ACCOUNT_IMPERSONATION_URL_ROUTE = "/v1/projects/-/serviceAccounts/{}:generateAccessToken".format(
-    SERVICE_ACCOUNT_EMAIL
+SERVICE_ACCOUNT_IMPERSONATION_URL_ROUTE = (
+    "/v1/projects/-/serviceAccounts/{}:generateAccessToken".format(
+        SERVICE_ACCOUNT_EMAIL
+    )
 )
 SERVICE_ACCOUNT_IMPERSONATION_URL = (
     SERVICE_ACCOUNT_IMPERSONATION_URL_BASE + SERVICE_ACCOUNT_IMPERSONATION_URL_ROUTE

--- a/tests/test_downscoped.py
+++ b/tests/test_downscoped.py
@@ -484,14 +484,13 @@ class TestCredentials(object):
     def assert_request_kwargs(
         request_kwargs, headers, request_data, token_endpoint=TOKEN_EXCHANGE_ENDPOINT
     ):
-        """Asserts the request was called with the expected parameters.
-        """
+        """Asserts the request was called with the expected parameters."""
         assert request_kwargs["url"] == token_endpoint
         assert request_kwargs["method"] == "POST"
         assert request_kwargs["headers"] == headers
         assert request_kwargs["body"] is not None
         body_tuples = urllib.parse.parse_qsl(request_kwargs["body"])
-        for (k, v) in body_tuples:
+        for k, v in body_tuples:
             assert v.decode("utf-8") == request_data[k.decode("utf-8")]
         assert len(body_tuples) == len(request_data.keys())
 

--- a/tests/test_external_account_authorized_user.py
+++ b/tests/test_external_account_authorized_user.py
@@ -32,8 +32,10 @@ REVOKE_URL = "https://sts.googleapis.com/v1/revoke"
 QUOTA_PROJECT_ID = "654321"
 POOL_ID = "POOL_ID"
 PROVIDER_ID = "PROVIDER_ID"
-AUDIENCE = "//iam.googleapis.com/locations/global/workforcePools/{}/providers/{}".format(
-    POOL_ID, PROVIDER_ID
+AUDIENCE = (
+    "//iam.googleapis.com/locations/global/workforcePools/{}/providers/{}".format(
+        POOL_ID, PROVIDER_ID
+    )
 )
 REFRESH_TOKEN = "REFRESH_TOKEN"
 NEW_REFRESH_TOKEN = "NEW_REFRESH_TOKEN"

--- a/tests/test_identity_pool.py
+++ b/tests/test_identity_pool.py
@@ -38,8 +38,10 @@ SERVICE_ACCOUNT_EMAIL = "service-1234@service-name.iam.gserviceaccount.com"
 SERVICE_ACCOUNT_IMPERSONATION_URL_BASE = (
     "https://us-east1-iamcredentials.googleapis.com"
 )
-SERVICE_ACCOUNT_IMPERSONATION_URL_ROUTE = "/v1/projects/-/serviceAccounts/{}:generateAccessToken".format(
-    SERVICE_ACCOUNT_EMAIL
+SERVICE_ACCOUNT_IMPERSONATION_URL_ROUTE = (
+    "/v1/projects/-/serviceAccounts/{}:generateAccessToken".format(
+        SERVICE_ACCOUNT_EMAIL
+    )
 )
 SERVICE_ACCOUNT_IMPERSONATION_URL = (
     SERVICE_ACCOUNT_IMPERSONATION_URL_BASE + SERVICE_ACCOUNT_IMPERSONATION_URL_ROUTE
@@ -1051,7 +1053,6 @@ class TestCredentials(object):
     def test_retrieve_subject_token_certificate_trust_chain_invalid_order(
         self, mock_get_workload_cert_and_key_paths
     ):
-
         credentials = self.make_credentials(
             credential_source=self.CREDENTIAL_SOURCE_CERTIFICATE_TRUST_CHAIN_WRONG_ORDER
         )
@@ -1070,7 +1071,6 @@ class TestCredentials(object):
     def test_retrieve_subject_token_certificate_trust_chain_file_does_not_exist(
         self, mock_get_workload_cert_and_key_paths
     ):
-
         credentials = self.make_credentials(
             credential_source={
                 "certificate": {
@@ -1092,7 +1092,6 @@ class TestCredentials(object):
     def test_retrieve_subject_token_certificate_invalid_trust_chain_file(
         self, mock_get_workload_cert_and_key_paths
     ):
-
         credentials = self.make_credentials(
             credential_source={
                 "certificate": {

--- a/tests/test_impersonated_credentials.py
+++ b/tests/test_impersonated_credentials.py
@@ -121,7 +121,6 @@ def mock_authorizedsession_idtoken():
 
 
 class TestImpersonatedCredentials(object):
-
     SERVICE_ACCOUNT_EMAIL = "service-account@example.com"
     TARGET_PRINCIPAL = "impersonated@project.iam.gserviceaccount.com"
     TARGET_SCOPES = ["https://www.googleapis.com/auth/devstorage.read_only"]
@@ -160,7 +159,6 @@ class TestImpersonatedCredentials(object):
         iam_endpoint_override=None,
         trust_boundary=None,  # Align with Credentials class default
     ):
-
         return Credentials(
             source_credentials=source_credentials,
             target_principal=target_principal,
@@ -173,16 +171,20 @@ class TestImpersonatedCredentials(object):
         )
 
     def test_from_impersonated_service_account_info(self):
-        credentials = impersonated_credentials.Credentials.from_impersonated_service_account_info(
-            IMPERSONATED_SERVICE_ACCOUNT_AUTHORIZED_USER_SOURCE_INFO
+        credentials = (
+            impersonated_credentials.Credentials.from_impersonated_service_account_info(
+                IMPERSONATED_SERVICE_ACCOUNT_AUTHORIZED_USER_SOURCE_INFO
+            )
         )
         assert isinstance(credentials, impersonated_credentials.Credentials)
 
     def test_from_impersonated_service_account_info_with_trust_boundary(self):
         info = copy.deepcopy(IMPERSONATED_SERVICE_ACCOUNT_AUTHORIZED_USER_SOURCE_INFO)
         info["trust_boundary"] = self.VALID_TRUST_BOUNDARY
-        credentials = impersonated_credentials.Credentials.from_impersonated_service_account_info(
-            info
+        credentials = (
+            impersonated_credentials.Credentials.from_impersonated_service_account_info(
+                info
+            )
         )
         assert isinstance(credentials, impersonated_credentials.Credentials)
         assert credentials._trust_boundary == self.VALID_TRUST_BOUNDARY
@@ -216,8 +218,10 @@ class TestImpersonatedCredentials(object):
     def test_from_impersonated_service_account_info_with_scopes(self):
         info = copy.deepcopy(IMPERSONATED_SERVICE_ACCOUNT_AUTHORIZED_USER_SOURCE_INFO)
         info["scopes"] = ["scope1", "scope2"]
-        credentials = impersonated_credentials.Credentials.from_impersonated_service_account_info(
-            info
+        credentials = (
+            impersonated_credentials.Credentials.from_impersonated_service_account_info(
+                info
+            )
         )
         assert credentials._target_scopes == ["scope1", "scope2"]
 
@@ -225,8 +229,10 @@ class TestImpersonatedCredentials(object):
         info = copy.deepcopy(IMPERSONATED_SERVICE_ACCOUNT_AUTHORIZED_USER_SOURCE_INFO)
         info["scopes"] = ["scope_from_info_1", "scope_from_info_2"]
         scopes_param = ["scope_from_param_1", "scope_from_param_2"]
-        credentials = impersonated_credentials.Credentials.from_impersonated_service_account_info(
-            info, scopes=scopes_param
+        credentials = (
+            impersonated_credentials.Credentials.from_impersonated_service_account_info(
+                info, scopes=scopes_param
+            )
         )
         assert credentials._target_scopes == scopes_param
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -343,9 +343,9 @@ def test_decode_no_key_id(token_factory):
 
 
 def test_decode_unknown_alg():
-    headers = json.dumps({u"kid": u"1", u"alg": u"fakealg"})
+    headers = json.dumps({"kid": "1", "alg": "fakealg"})
     token = b".".join(
-        map(lambda seg: base64.b64encode(seg.encode("utf-8")), [headers, u"{}", u"sig"])
+        map(lambda seg: base64.b64encode(seg.encode("utf-8")), [headers, "{}", "sig"])
     )
 
     with pytest.raises(ValueError) as excinfo:
@@ -355,9 +355,9 @@ def test_decode_unknown_alg():
 
 def test_decode_missing_crytography_alg(monkeypatch):
     monkeypatch.delitem(jwt._ALGORITHM_TO_VERIFIER_CLASS, "ES256")
-    headers = json.dumps({u"kid": u"1", u"alg": u"ES256"})
+    headers = json.dumps({"kid": "1", "alg": "ES256"})
     token = b".".join(
-        map(lambda seg: base64.b64encode(seg.encode("utf-8")), [headers, u"{}", u"sig"])
+        map(lambda seg: base64.b64encode(seg.encode("utf-8")), [headers, "{}", "sig"])
     )
 
     with pytest.raises(ValueError) as excinfo:

--- a/tests/test_pluggable.py
+++ b/tests/test_pluggable.py
@@ -32,8 +32,10 @@ SERVICE_ACCOUNT_EMAIL = "service-1234@service-name.iam.gserviceaccount.com"
 SERVICE_ACCOUNT_IMPERSONATION_URL_BASE = (
     "https://us-east1-iamcredentials.googleapis.com"
 )
-SERVICE_ACCOUNT_IMPERSONATION_URL_ROUTE = "/v1/projects/-/serviceAccounts/{}:generateAccessToken".format(
-    SERVICE_ACCOUNT_EMAIL
+SERVICE_ACCOUNT_IMPERSONATION_URL_ROUTE = (
+    "/v1/projects/-/serviceAccounts/{}:generateAccessToken".format(
+        SERVICE_ACCOUNT_EMAIL
+    )
 )
 SERVICE_ACCOUNT_IMPERSONATION_URL = (
     SERVICE_ACCOUNT_IMPERSONATION_URL_BASE + SERVICE_ACCOUNT_IMPERSONATION_URL_ROUTE
@@ -543,7 +545,6 @@ class TestCredentials(object):
 
     @mock.patch.dict(os.environ, {"GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES": "1"})
     def test_retrieve_subject_token_saml_interactive_mode(self, tmpdir):
-
         ACTUAL_CREDENTIAL_SOURCE_EXECUTABLE_OUTPUT_FILE = tmpdir.join(
             "actual_output_file"
         )
@@ -1108,7 +1109,7 @@ class TestCredentials(object):
 
     @mock.patch.dict(os.environ, {"GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES": "1"})
     def test_retrieve_subject_token_fail_on_validation_missing_interactive_timeout(
-        self
+        self,
     ):
         CREDENTIAL_SOURCE_EXECUTABLE = {
             "command": self.CREDENTIAL_SOURCE_EXECUTABLE_COMMAND,

--- a/tests_async/oauth2/test__client_async.py
+++ b/tests_async/oauth2/test__client_async.py
@@ -42,7 +42,6 @@ def make_request(response_data, status=http_client.OK, text=False):
 
 @pytest.mark.asyncio
 async def test__token_endpoint_request():
-
     request = make_request({"test": "response"})
 
     result = await _client._token_endpoint_request(
@@ -63,7 +62,6 @@ async def test__token_endpoint_request():
 
 @pytest.mark.asyncio
 async def test__token_endpoint_request_text():
-
     request = make_request("response", text=True)
 
     result = await _client._token_endpoint_request(
@@ -84,7 +82,6 @@ async def test__token_endpoint_request_text():
 
 @pytest.mark.asyncio
 async def test__token_endpoint_request_json():
-
     request = make_request({"test": "response"})
     access_token = "access_token"
 

--- a/tests_async/oauth2/test_credentials_async.py
+++ b/tests_async/oauth2/test_credentials_async.py
@@ -29,7 +29,6 @@ from tests.oauth2 import test_credentials
 
 
 class TestCredentials:
-
     TOKEN_URI = "https://example.com/oauth2/token"
     REFRESH_TOKEN = "refresh_token"
     CLIENT_ID = "client_id"

--- a/tests_async/transport/test_aiohttp_requests.py
+++ b/tests_async/transport/test_aiohttp_requests.py
@@ -39,7 +39,6 @@ class TestCombinedResponse:
 
     @pytest.mark.asyncio
     async def test_raw_content(self):
-
         mock_response = mock.AsyncMock()
         mock_response.content.read.return_value = mock.sentinel.read
         combined_response = aiohttp_requests._CombinedResponse(response=mock_response)


### PR DESCRIPTION
Also update the `docs` session to 3.10 to match the Python GAPIC code generator used to generate Cloud Client libraries: https://github.com/googleapis/gapic-generator-python/blob/d20dd2876fbf8c35f6a994639864815b0d7608ab/gapic/templates/noxfile.py.j2#L360-L361

Also update black to 23.7.0 to resolve the following stack trace

```
nox > python -m pip install flake8 flake8-import-order docutils click==8.0.4 black==19.3b0
nox > python -m pip install -e .
nox > black --check google tests tests_async noxfile.py setup.py docs/conf.py
Traceback (most recent call last):
  File "/tmpfs/src/github/google-auth-library-python/.nox/lint/bin/black", line 8, in <module>
    sys.exit(patched_main())
             ~~~~~~~~~~~~^^
  File "/tmpfs/src/github/google-auth-library-python/.nox/lint/lib/python3.14/site-packages/black.py", line 3754, in patched_main
    main()
    ~~~~^^
  File "/tmpfs/src/github/google-auth-library-python/.nox/lint/lib/python3.14/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/tmpfs/src/github/google-auth-library-python/.nox/lint/lib/python3.14/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/tmpfs/src/github/google-auth-library-python/.nox/lint/lib/python3.14/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmpfs/src/github/google-auth-library-python/.nox/lint/lib/python3.14/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/tmpfs/src/github/google-auth-library-python/.nox/lint/lib/python3.14/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/tmpfs/src/github/google-auth-library-python/.nox/lint/lib/python3.14/site-packages/black.py", line 434, in main
    loop = asyncio.get_event_loop()
  File "/usr/local/lib/python3.14/asyncio/events.py", line 715, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
                       % threading.current_thread().name)
RuntimeError: There is no current event loop in thread 'MainThread'.
nox > Command black --check google tests tests_async noxfile.py setup.py docs/conf.py failed with exit code 1
```

This PR also fixes the coverage presubmit to append the coverage check to run across python runtimes. 