### PR TITLE
chore: update renovate to ignore docs/requirements-docs.txt

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml", "docs/requirements-docs.txt"],
+  "ignorePaths": [".github/workflows/unittest.yml", ".kokoro/requirements.txt", ".pre-commit-config.yaml", "docs/requirements-docs.txt", "setup.py"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
+  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml", "docs/requirements-docs.txt"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
   }


### PR DESCRIPTION
The dependencies in https://github.com/googleapis/google-auth-library-python/blob/main/docs/requirements-docs.txt are pinned because sphinx-docfx-yaml doesn't support sphinx 5.x. See follow up issue in https://github.com/googleapis/google-cloud-python/issues/15996 to add support for sphinx 5.x