### PR TITLE
chore: rename _refresh_token to _perform_refresh_token

### DIFF
--- a/google/auth/compute_engine/credentials.py
+++ b/google/auth/compute_engine/credentials.py
@@ -123,7 +123,7 @@ class Credentials(
     def _metric_header_for_usage(self):
         return metrics.CRED_TYPE_SA_MDS
 
-    def _refresh_token(self, request):
+    def _perform_refresh_token(self, request):
         """Refresh the access token and scopes.
 
         Args:

--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -292,7 +292,7 @@ class CredentialsWithTrustBoundary(Credentials):
     """Abstract base for credentials supporting ``with_trust_boundary`` factory"""
 
     @abc.abstractmethod
-    def _refresh_token(self, request):
+    def _perform_refresh_token(self, request):
         """Refreshes the access token.
 
         Args:
@@ -303,7 +303,7 @@ class CredentialsWithTrustBoundary(Credentials):
             google.auth.exceptions.RefreshError: If the credentials could
                 not be refreshed.
         """
-        raise NotImplementedError("_refresh_token must be implemented")
+        raise NotImplementedError("_perfrom_refresh_token must be implemented")
 
     def with_trust_boundary(self, trust_boundary):
         """Returns a copy of these credentials with a modified trust boundary.
@@ -362,7 +362,7 @@ class CredentialsWithTrustBoundary(Credentials):
         This method calls the subclass's token refresh logic and then
         refreshes the trust boundary if applicable.
         """
-        self._refresh_token(request)
+        self._perform_refresh_token(request)
         self._refresh_trust_boundary(request)
 
     def _refresh_trust_boundary(self, request):

--- a/google/auth/credentials.py
+++ b/google/auth/credentials.py
@@ -303,7 +303,7 @@ class CredentialsWithTrustBoundary(Credentials):
             google.auth.exceptions.RefreshError: If the credentials could
                 not be refreshed.
         """
-        raise NotImplementedError("_perfrom_refresh_token must be implemented")
+        raise NotImplementedError("_perform_refresh_token must be implemented")
 
     def with_trust_boundary(self, trust_boundary):
         """Returns a copy of these credentials with a modified trust boundary.

--- a/google/auth/external_account.py
+++ b/google/auth/external_account.py
@@ -420,7 +420,7 @@ class Credentials(
         source credentials and the impersonated credentials. For non-impersonated
         credentials, it will refresh the access token and the trust boundary.
         """
-        self._refresh_token(request)
+        self._perform_refresh_token(request)
         self._handle_trust_boundary(request)
 
     def _handle_trust_boundary(self, request):
@@ -432,7 +432,7 @@ class Credentials(
             # Otherwise, refresh the trust boundary for the external account.
             self._refresh_trust_boundary(request)
 
-    def _refresh_token(self, request, cert_fingerprint=None):
+    def _perform_refresh_token(self, request, cert_fingerprint=None):
         scopes = self._scopes if self._scopes is not None else self._default_scopes
 
         # Inject client certificate into request.

--- a/google/auth/external_account_authorized_user.py
+++ b/google/auth/external_account_authorized_user.py
@@ -124,7 +124,7 @@ class Credentials(
         self.token = token
         self.expiry = expiry
         self._audience = audience
-        self._refresh_token_val = refresh_token
+        self._refresh_token = refresh_token
         self._token_url = token_url
         self._token_info_url = token_info_url
         self._client_id = client_id
@@ -171,7 +171,7 @@ class Credentials(
     def constructor_args(self):
         return {
             "audience": self._audience,
-            "refresh_token": self._refresh_token_val,
+            "refresh_token": self._refresh_token,
             "token_url": self._token_url,
             "token_info_url": self._token_info_url,
             "client_id": self._client_id,
@@ -215,7 +215,7 @@ class Credentials(
     @property
     def refresh_token(self):
         """Optional[str]: The OAuth 2.0 refresh token."""
-        return self._refresh_token_val
+        return self._refresh_token
 
     @property
     def token_url(self):
@@ -241,7 +241,7 @@ class Credentials(
     def can_refresh(self):
         return all(
             (
-                self._refresh_token_val,
+                self._refresh_token,
                 self._token_url,
                 self._client_id,
                 self._client_secret,
@@ -279,7 +279,7 @@ class Credentials(
         strip = strip if strip else []
         return json.dumps({k: v for (k, v) in self.info.items() if k not in strip})
 
-    def _refresh_token(self, request):
+    def _perform_refresh_token(self, request):
         """Refreshes the access token.
 
         Args:
@@ -298,7 +298,7 @@ class Credentials(
             )
 
         now = _helpers.utcnow()
-        response_data = self._sts_client.refresh_token(request, self._refresh_token_val)
+        response_data = self._sts_client.refresh_token(request, self._refresh_token)
 
         self.token = response_data.get("access_token")
 
@@ -306,7 +306,7 @@ class Credentials(
         self.expiry = now + lifetime
 
         if "refresh_token" in response_data:
-            self._refresh_token_val = response_data["refresh_token"]
+            self._refresh_token = response_data["refresh_token"]
 
     def _build_trust_boundary_lookup_url(self):
         """Builds and returns the URL for the trust boundary lookup API."""
@@ -333,7 +333,7 @@ class Credentials(
             google.auth.exceptions.OAuthError: If the token could not be
                 revoked.
         """
-        if not self._revoke_url or not self._refresh_token_val:
+        if not self._revoke_url or not self._refresh_token:
             raise exceptions.OAuthError(
                 "The credentials do not contain the necessary fields to "
                 "revoke the refresh token. You must specify revoke_url and "
@@ -341,7 +341,7 @@ class Credentials(
             )
 
         self._sts_client.revoke_token(
-            request, self._refresh_token_val, "refresh_token", self._revoke_url
+            request, self._refresh_token, "refresh_token", self._revoke_url
         )
         self.token = None
         self._refresh_token = None

--- a/google/auth/identity_pool.py
+++ b/google/auth/identity_pool.py
@@ -571,5 +571,5 @@ class Credentials(external_account.Credentials):
                     _agent_identity_utils.calculate_certificate_fingerprint(cert)
                 )
 
-        self._refresh_token(request, cert_fingerprint=cert_fingerprint)
+        self._perform_refresh_token(request, cert_fingerprint=cert_fingerprint)
         self._handle_trust_boundary(request)

--- a/google/auth/impersonated_credentials.py
+++ b/google/auth/impersonated_credentials.py
@@ -272,7 +272,7 @@ class Credentials(
     def _metric_header_for_usage(self):
         return metrics.CRED_TYPE_SA_IMPERSONATE
 
-    def _refresh_token(self, request):
+    def _perform_refresh_token(self, request):
         """Updates credentials with a new access_token representing
         the impersonated account.
 

--- a/google/oauth2/service_account.py
+++ b/google/oauth2/service_account.py
@@ -434,7 +434,7 @@ class Credentials(
         return metrics.CRED_TYPE_SA_ASSERTION
 
     @_helpers.copy_docstring(credentials.CredentialsWithTrustBoundary)
-    def _refresh_token(self, request):
+    def _perform_refresh_token(self, request):
         if self._always_use_jwt_access and not self._jwt_credentials:
             # If self signed jwt should be used but jwt credential is not
             # created, try to create one with scopes

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -26,7 +26,7 @@ from google.oauth2 import _client
 
 
 class CredentialsImpl(credentials.CredentialsWithTrustBoundary):
-    def _refresh_token(self, request):
+    def _perform_refresh_token(self, request):
         self.token = "refreshed-token"
         self.expiry = (
             datetime.datetime.utcnow()

--- a/tests/test_external_account.py
+++ b/tests/test_external_account.py
@@ -737,7 +737,7 @@ class TestCredentials(object):
         credentials.apply(headers_applied)
         assert "x-allowed-locations" not in headers_applied
 
-    def test_refresh_token_with_cert_fingerprint(self):
+    def test_perform_refresh_token_with_cert_fingerprint(self):
         credentials = self.make_credentials()
         credentials._sts_client = mock.MagicMock()
         credentials._sts_client.exchange_token.return_value = {
@@ -748,7 +748,7 @@ class TestCredentials(object):
             return_value="subject_token"
         )
 
-        credentials._refresh_token(
+        credentials._perform_refresh_token(
             request=mock.sentinel.request, cert_fingerprint="my-fingerprint"
         )
 

--- a/tests/test_external_account_authorized_user.py
+++ b/tests/test_external_account_authorized_user.py
@@ -194,7 +194,7 @@ class TestCredentials(object):
         assert creds.valid
         assert not creds.requires_scopes
         assert creds.is_user
-        assert creds._refresh_token_val == REFRESH_TOKEN
+        assert creds._refresh_token == REFRESH_TOKEN
 
         request.assert_called_once_with(
             url=TOKEN_URL,
@@ -228,7 +228,7 @@ class TestCredentials(object):
         assert creds.valid
         assert not creds.requires_scopes
         assert creds.is_user
-        assert creds._refresh_token_val == NEW_REFRESH_TOKEN
+        assert creds._refresh_token == NEW_REFRESH_TOKEN
 
         request.assert_called_once_with(
             url=TOKEN_URL,
@@ -510,7 +510,7 @@ class TestCredentials(object):
         )
         new_creds = creds.with_quota_project(QUOTA_PROJECT_ID)
         assert new_creds._audience == creds._audience
-        assert new_creds._refresh_token_val == creds.refresh_token
+        assert new_creds._refresh_token == creds.refresh_token
         assert new_creds._token_url == creds._token_url
         assert new_creds._token_info_url == creds._token_info_url
         assert new_creds._client_id == creds._client_id
@@ -529,7 +529,7 @@ class TestCredentials(object):
         )
         new_creds = creds.with_token_uri("https://google.com")
         assert new_creds._audience == creds._audience
-        assert new_creds._refresh_token_val == creds.refresh_token
+        assert new_creds._refresh_token == creds.refresh_token
         assert new_creds._token_url == "https://google.com"
         assert new_creds._token_info_url == creds._token_info_url
         assert new_creds._client_id == creds._client_id
@@ -548,7 +548,7 @@ class TestCredentials(object):
         )
         new_creds = creds.with_universe_domain(FAKE_UNIVERSE_DOMAIN)
         assert new_creds._audience == creds._audience
-        assert new_creds._refresh_token_val == creds.refresh_token
+        assert new_creds._refresh_token == creds.refresh_token
         assert new_creds._token_url == creds._token_url
         assert new_creds._token_info_url == creds._token_info_url
         assert new_creds._client_id == creds._client_id
@@ -568,7 +568,7 @@ class TestCredentials(object):
         )
         new_creds = creds.with_trust_boundary({"encodedLocations": "new_boundary"})
         assert new_creds._audience == creds._audience
-        assert new_creds._refresh_token_val == creds.refresh_token
+        assert new_creds._refresh_token == creds.refresh_token
         assert new_creds._token_url == creds._token_url
         assert new_creds._token_info_url == creds._token_info_url
         assert new_creds._client_id == creds._client_id

--- a/tests/test_identity_pool.py
+++ b/tests/test_identity_pool.py
@@ -1784,7 +1784,7 @@ class TestCredentials(object):
     @mock.patch.object(
         identity_pool.Credentials, "_get_cert_bytes", return_value=b"cert"
     )
-    @mock.patch.object(external_account.Credentials, "_refresh_token")
+    @mock.patch.object(external_account.Credentials, "_perform_refresh_token")
     def test_refresh_with_agent_identity(
         self,
         mock_refresh_token,
@@ -1811,7 +1811,7 @@ class TestCredentials(object):
     @mock.patch.object(
         identity_pool.Credentials, "_get_cert_bytes", return_value=b"cert"
     )
-    @mock.patch.object(external_account.Credentials, "_refresh_token")
+    @mock.patch.object(external_account.Credentials, "_perform_refresh_token")
     def test_refresh_with_agent_identity_opt_out_or_not_agent(
         self,
         mock_refresh_token,

--- a/tests/test_impersonated_credentials.py
+++ b/tests/test_impersonated_credentials.py
@@ -678,7 +678,8 @@ class TestImpersonatedCredentials(object):
         credentials._source_credentials.token = "Token"
 
         with mock.patch(
-            "google.oauth2.service_account.Credentials._perform_refresh_token", autospec=True
+            "google.oauth2.service_account.Credentials._perform_refresh_token",
+            autospec=True,
         ) as source_cred_refresh_token:
             expire_time = (
                 _helpers.utcnow().replace(microsecond=0)

--- a/tests/test_impersonated_credentials.py
+++ b/tests/test_impersonated_credentials.py
@@ -678,7 +678,7 @@ class TestImpersonatedCredentials(object):
         credentials._source_credentials.token = "Token"
 
         with mock.patch(
-            "google.oauth2.service_account.Credentials._refresh_token", autospec=True
+            "google.oauth2.service_account.Credentials._perform_refresh_token", autospec=True
         ) as source_cred_refresh_token:
             expire_time = (
                 _helpers.utcnow().replace(microsecond=0)


### PR DESCRIPTION
[A recent change](https://github.com/googleapis/google-auth-library-python/commit/36ecb1d65883477d27faf9c2281fc289659b9903#diff-4762e5cf4088fa77af8bf63829f842548a4cad6e76be593786876e314807cd8f) added an internal _refresh_token method to some credentials files.

Parts of the codebase were already using `_refresh_token` as an internal variable, holding a token value

This causes some inconsistencies in the codebase, where it's not always clear if `_refresh_token` is referring to an action or an object

It was also causing complications in internal code that depended on _refresh_token objects

This PR renames the methods to `_perform_refresh_token`, to avoid the duplicate naming