### PR TITLE
feat: Recognize workload certificate config in has_default_client_cert_source for mTLS for Agentic Identities

### DIFF
--- a/google/auth/transport/mtls.py
+++ b/google/auth/transport/mtls.py
@@ -14,6 +14,8 @@
 
 """Utilites for mutual TLS."""
 
+from os import getenv
+
 from google.auth import exceptions
 from google.auth.transport import _mtls_helper
 
@@ -34,6 +36,12 @@ def has_default_client_cert_source():
             _mtls_helper.CERTIFICATE_CONFIGURATION_DEFAULT_PATH
         )
         is not None
+    ):
+        return True
+    cert_config_path = getenv("GOOGLE_API_CERTIFICATE_CONFIG")
+    if (
+        cert_config_path
+        and _mtls_helper._check_config_path(cert_config_path) is not None
     ):
         return True
     return False

--- a/tests/transport/test_mtls.py
+++ b/tests/transport/test_mtls.py
@@ -17,6 +17,7 @@ from unittest import mock
 import pytest  # type: ignore
 
 from google.auth import exceptions
+from google.auth.transport import _mtls_helper
 from google.auth.transport import mtls
 
 
@@ -43,34 +44,6 @@ def test_has_default_client_cert_source_env_var_success(check_config_path, mock_
     assert mtls.has_default_client_cert_source()
 
     # 4. Verify the env var path was checked
-    check_config_path.assert_called_with("path/to/cert.json")
-
-
-@mock.patch("google.auth.transport.mtls.getenv", autospec=True)
-@mock.patch("google.auth.transport._mtls_helper._check_config_path", autospec=True)
-def test_has_default_client_cert_source_config_path_success(
-    check_config_path, mock_getenv
-):
-    # 1. Mock getenv to return our custom path for the env var
-    mock_getenv.side_effect = (
-        lambda var: "path/to/cert.json"
-        if var == "GOOGLE_API_CERTIFICATE_CONFIG"
-        else None
-    )
-
-    # 2. Configure side_effect to return None for default paths,
-    # and a value ONLY for our custom path.
-    def side_effect(path):
-        if path == "path/to/cert.json":
-            return "/absolute/path/to/cert.json"
-        return None
-
-    check_config_path.side_effect = side_effect
-
-    # 3. Now the first two checks will return None, reaching the third check.
-    assert mtls.has_default_client_cert_source()
-
-    # 4. Verify that the last call made was indeed with our env var path.
     check_config_path.assert_called_with("path/to/cert.json")
 
 

--- a/tests/transport/test_mtls.py
+++ b/tests/transport/test_mtls.py
@@ -17,30 +17,74 @@ from unittest import mock
 import pytest  # type: ignore
 
 from google.auth import exceptions
-from google.auth.transport import _mtls_helper
 from google.auth.transport import mtls
 
 
+@mock.patch("google.auth.transport.mtls.getenv", autospec=True)
 @mock.patch("google.auth.transport._mtls_helper._check_config_path", autospec=True)
-def test_has_default_client_cert_source(check_config_path):
-    def return_path_for_metadata(path):
-        return mock.Mock() if path == _mtls_helper.CONTEXT_AWARE_METADATA_PATH else None
+def test_has_default_client_cert_source_env_var_success(check_config_path, mock_getenv):
+    # 1. Mock getenv to return our test path
+    mock_getenv.side_effect = (
+        lambda var: "path/to/cert.json"
+        if var == "GOOGLE_API_CERTIFICATE_CONFIG"
+        else None
+    )
 
-    check_config_path.side_effect = return_path_for_metadata
+    # 2. Mock _check_config_path side effect
+    def side_effect(path):
+        # Return None for legacy paths to ensure we reach the env var logic
+        if path == "path/to/cert.json":
+            return "/absolute/path/to/cert.json"
+        return None
+
+    check_config_path.side_effect = side_effect
+
+    # 3. This should now return True
     assert mtls.has_default_client_cert_source()
 
-    def return_path_for_cert_config(path):
-        return (
-            mock.Mock()
-            if path == _mtls_helper.CERTIFICATE_CONFIGURATION_DEFAULT_PATH
-            else None
-        )
+    # 4. Verify the env var path was checked
+    check_config_path.assert_called_with("path/to/cert.json")
 
-    check_config_path.side_effect = return_path_for_cert_config
+
+@mock.patch("google.auth.transport.mtls.getenv", autospec=True)
+@mock.patch("google.auth.transport._mtls_helper._check_config_path", autospec=True)
+def test_has_default_client_cert_source_config_path_success(
+    check_config_path, mock_getenv
+):
+    # 1. Mock getenv to return our custom path for the env var
+    mock_getenv.side_effect = (
+        lambda var: "path/to/cert.json"
+        if var == "GOOGLE_API_CERTIFICATE_CONFIG"
+        else None
+    )
+
+    # 2. Configure side_effect to return None for default paths,
+    # and a value ONLY for our custom path.
+    def side_effect(path):
+        if path == "path/to/cert.json":
+            return "/absolute/path/to/cert.json"
+        return None
+
+    check_config_path.side_effect = side_effect
+
+    # 3. Now the first two checks will return None, reaching the third check.
     assert mtls.has_default_client_cert_source()
 
-    check_config_path.side_effect = None
+    # 4. Verify that the last call made was indeed with our env var path.
+    check_config_path.assert_called_with("path/to/cert.json")
+
+
+@mock.patch("google.auth.transport.mtls.getenv", autospec=True)
+@mock.patch("google.auth.transport._mtls_helper._check_config_path", autospec=True)
+def test_has_default_client_cert_source_env_var_invalid_config_path(
+    check_config_path, mock_getenv
+):
+    # Set the env var but make the check fail
+    mock_getenv.side_effect = (
+        lambda var: "invalid/path" if var == "GOOGLE_API_CERTIFICATE_CONFIG" else None
+    )
     check_config_path.return_value = None
+
     assert not mtls.has_default_client_cert_source()
 
 

--- a/tests/transport/test_mtls.py
+++ b/tests/transport/test_mtls.py
@@ -21,6 +21,55 @@ from google.auth.transport import _mtls_helper
 from google.auth.transport import mtls
 
 
+@mock.patch("google.auth.transport._mtls_helper._check_config_path")
+def test_has_default_client_cert_source_with_context_aware_metadata(mock_check):
+    """
+    Directly tests the logic: if CONTEXT_AWARE_METADATA_PATH is found, return True.
+    """
+
+    # Setup: Return a path only for the Context Aware Metadata Path
+    def side_effect(path):
+        if path == _mtls_helper.CONTEXT_AWARE_METADATA_PATH:
+            return "/path/to/context_aware_metadata.json"
+        return None
+
+    mock_check.side_effect = side_effect
+
+    # Execute
+    result = mtls.has_default_client_cert_source()
+
+    # Assert
+    assert result is True
+    mock_check.assert_any_call(_mtls_helper.CONTEXT_AWARE_METADATA_PATH)
+
+
+@mock.patch("google.auth.transport._mtls_helper._check_config_path")
+def test_has_default_client_cert_source_falls_back(mock_check):
+    """
+    Tests that it skips CONTEXT_AWARE_METADATA_PATH if None, and checks the next path.
+    """
+
+    # Setup: First path is None, second path is valid
+    def side_effect(path):
+        if path == _mtls_helper.CERTIFICATE_CONFIGURATION_DEFAULT_PATH:
+            return "/path/to/default_cert.json"
+        return None
+
+    mock_check.side_effect = side_effect
+
+    # Execute
+    result = mtls.has_default_client_cert_source()
+
+    # Assert
+    assert result is True
+    # Verify the sequence of calls
+    expected_calls = [
+        mock.call(_mtls_helper.CONTEXT_AWARE_METADATA_PATH),
+        mock.call(_mtls_helper.CERTIFICATE_CONFIGURATION_DEFAULT_PATH),
+    ]
+    mock_check.assert_has_calls(expected_calls)
+
+
 @mock.patch("google.auth.transport.mtls.getenv", autospec=True)
 @mock.patch("google.auth.transport._mtls_helper._check_config_path", autospec=True)
 def test_has_default_client_cert_source_env_var_success(check_config_path, mock_getenv):

--- a/tests/transport/test_mtls.py
+++ b/tests/transport/test_mtls.py
@@ -41,6 +41,7 @@ def test_has_default_client_cert_source_with_context_aware_metadata(mock_check):
     # Assert
     assert result is True
     mock_check.assert_any_call(_mtls_helper.CONTEXT_AWARE_METADATA_PATH)
+    assert side_effect("non-matching-path") is None
 
 
 @mock.patch("google.auth.transport._mtls_helper._check_config_path")


### PR DESCRIPTION
feat: Recognize workload certificate config in `mTLS.has_default_client_cert_source` for mTLS for Agentic Identities. This is done as part of a fix for auto-enablement of mTLS, which depends on `mTLS.has_default_client_cert_source`. This method returned `False` because it only checked for gcloud cert configs and secure connect metadata, but not the workload-provided certificate_config.json. Thus, this change is necessary to help enable mTLS for Agentic Identities on GKE and Cloud Run Workloads.