### PR TITLE
fix: change sequence import (#1915)

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -17,12 +17,11 @@
 Implements application default credentials and project ID detection.
 """
 
-from collections.abc import Sequence
 import io
 import json
 import logging
 import os
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, Sequence
 import warnings
 
 from google.auth import environment_vars


### PR DESCRIPTION
Fixes #1915

### What
Fix `TypeError: 'ABCMeta' object is not subscriptable` on Python 3.7/3.8 by avoiding `collections.abc.Sequence[str]` usage during import.

### How
Switch typing annotations to use `typing.Sequence` (or use postponed evaluation of annotations) to keep compatibility with Python 3.7/3.8.