### PR TITLE
fix(typing): import of Sequence from typing module (issue: #1915)

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -17,19 +17,21 @@
 Implements application default credentials and project ID detection.
 """
 
-from collections.abc import Sequence
+from __future__ import annotations
+
 import io
 import json
 import logging
 import os
-from typing import Optional, TYPE_CHECKING
 import warnings
+from typing import TYPE_CHECKING
 
-from google.auth import environment_vars
-from google.auth import exceptions
 import google.auth.transport._http_client
+from google.auth import environment_vars, exceptions
 
-if TYPE_CHECKING:  # pragma: NO COVER
+if TYPE_CHECKING:  # pragma: NO COVER    
+    from typing import Optional, Sequence
+
     from google.auth.credentials import Credentials  # noqa: F401
     from google.auth.transport import Request  # noqa: F401
 
@@ -696,8 +698,10 @@ def default(
             If no credentials were found, or if the credentials found were
             invalid.
     """
-    from google.auth.credentials import with_scopes_if_required
-    from google.auth.credentials import CredentialsWithQuotaProject
+    from google.auth.credentials import (
+        CredentialsWithQuotaProject,
+        with_scopes_if_required,
+    )
 
     explicit_project_id = os.environ.get(
         environment_vars.PROJECT, os.environ.get(environment_vars.LEGACY_PROJECT)


### PR DESCRIPTION
- Fix for #1915
Updates import of Sequence from typing instead of collections.abc
[google-auth-library-python/google/auth/_default.py](https://github.com/googleapis/google-auth-library-python/blob/5c07e1c4f52bc77a1b16fa3b7b3c5269c242f6f4/google/auth/_default.py#L20)

```python 
 from collections.abc import Sequence
 ```
 with 
 
 ```python
 from typing import Sequence
 ```
 Below are enhancements over PR #1915
 
-  Also moves the typing import under if TYPE_CHECKING check
-  Added below import, in start of module file to defer the evaluation of type annotations to "runtime"
 ```python
 from __future__  import annotations 
 ```
 - ruff format of import organization