### PR TITLE
chore: remove Python 3.7 support

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,7 +19,7 @@ A few notes on making changes to ``google-auth-library-python``.
   using ``nox -s docs``.
 
 - The change must work fully on the following CPython versions:
-  3.7, 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13 across macOS, Linux, and Windows.
+  3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 across macOS, Linux, and Windows.
 
 - The codebase *must* have 100% test statement coverage after each commit.
   You can test coverage via ``nox -e cover``.

--- a/README.rst
+++ b/README.rst
@@ -35,15 +35,16 @@ Note that the extras pyopenssl and enterprise_cert should not be used together b
 
 Supported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Python >= 3.7
+Python >= 3.8
 
 **NOTE**:
-Python 3.7 was marked as `unsupported`_ by the python community in June 2023.
-We recommend that all developers upgrade to Python 3.8 and newer as soon as
-they can. Support for Python 3.7 will be removed from this library after
-January 1 2024. Previous releases that support Python 3.7 will continue to be available
-for download, but releases after January 1 2024 will only target Python 3.8 and
-newer.
+Python 3.8 and Python 3.9 were marked as `unsupported`_ by the python community in 
+October 2024 and October 2025 respectively.
+We recommend that all developers upgrade to Python 3.10 and newer as soon as
+they can. Support for end-of-life Python runtimes will be removed from this
+library in future updates.
+Previous releases that support end-of-life Python versions will continue to be available
+for download, but future releases will only target supported versions.
 
 .. _unsupported: https://devguide.python.org/versions/#unsupported-versions
 
@@ -57,6 +58,10 @@ Unsupported Python Versions
 
 - Python 3.6:   The last version of this library with support for Python 3.6
   was `google.auth == 2.22.0`.
+
+- Python 3.7:   The last version of this library with support for Python 3.7
+  was `google.auth == 2.45.0`.
+
 
 Documentation
 -------------

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Python >= 3.8
 
 **NOTE**:
 Python 3.8 and Python 3.9 were marked as `unsupported`_ by the python community in 
-October 2024 and October 2025 respectively.
+October 2024 and October 2025, respectively.
 We recommend that all developers upgrade to Python 3.10 and newer as soon as
 they can. Support for end-of-life Python runtimes will be removed from this
 library in future updates.

--- a/google/auth/__init__.py
+++ b/google/auth/__init__.py
@@ -41,13 +41,17 @@ class Python37DeprecationWarning(DeprecationWarning):  # pragma: NO COVER
     pass
 
 
-# Checks if the current runtime is Python 3.7.
-if sys.version_info.major == 3 and sys.version_info.minor == 7:  # pragma: NO COVER
-    message = (
-        "After January 1, 2024, new releases of this library will drop support "
-        "for Python 3.7."
-    )
-    warnings.warn(message, Python37DeprecationWarning)
+# Raise warnings for deprecated versions
+eol_message = """
+    You are using a Python version {} past its end of life. Google will update
+    google-auth with critical bug fixes on a best-effort basis, but not
+    with any other fixes or features. Please upgrade your Python version,
+    and then update google-auth.
+    """
+if sys.version_info.major == 3 and sys.version_info.minor == 8:  # pragma: NO COVER
+    warnings.warn(eol_message.format("3.8"), FutureWarning)
+elif sys.version_info.major == 3 and sys.version_info.minor == 9:  # pragma: NO COVER
+    warnings.warn(eol_message.format("3.9"), FutureWarning)
 
 # Set default logging handler to avoid "No handler found" warnings.
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/google/auth/_helpers.py
+++ b/google/auth/_helpers.py
@@ -334,7 +334,8 @@ def is_python_3():
     Returns:
         bool: True if the Python interpreter is Python 3 and False otherwise.
     """
-    return sys.version_info > (3, 0)
+
+    return sys.version_info > (3, 0)  # pragma: NO COVER
 
 
 def _hash_sensitive_info(data: Union[dict, list]) -> Union[dict, list, str]:

--- a/google/auth/pluggable.py
+++ b/google/auth/pluggable.py
@@ -201,11 +201,6 @@ class Credentials(external_account.Credentials):
                 else:
                     return subject_token
 
-        if not _helpers.is_python_3():
-            raise exceptions.RefreshError(
-                "Pluggable auth is only supported for python 3.7+"
-            )
-
         # Inject env vars.
         env = os.environ.copy()
         self._inject_env_variables(env)
@@ -262,11 +257,6 @@ class Credentials(external_account.Credentials):
                 "Revoke is only enabled under interactive mode."
             )
         self._validate_running_mode()
-
-        if not _helpers.is_python_3():
-            raise exceptions.RefreshError(
-                "Pluggable auth is only supported for python 3.7+"
-            )
 
         # Inject variables
         env = os.environ.copy()

--- a/google/oauth2/__init__.py
+++ b/google/oauth2/__init__.py
@@ -27,10 +27,14 @@ class Python37DeprecationWarning(DeprecationWarning):  # pragma: NO COVER
     pass
 
 
-# Checks if the current runtime is Python 3.7.
-if sys.version_info.major == 3 and sys.version_info.minor == 7:  # pragma: NO COVER
-    message = (
-        "After January 1, 2024, new releases of this library will drop support "
-        "for Python 3.7."
-    )
-    warnings.warn(message, Python37DeprecationWarning)
+# Raise warnings for deprecated versions
+eol_message = """
+    You are using a Python version {} past its end of life. Google will update
+    google-auth with critical bug fixes on a best-effort basis, but not
+    with any other fixes or features. Please upgrade your Python version,
+    and then update google-auth.
+    """
+if sys.version_info.major == 3 and sys.version_info.minor == 8:  # pragma: NO COVER
+    warnings.warn(eol_message.format("3.8"), FutureWarning)
+elif sys.version_info.major == 3 and sys.version_info.minor == 9:  # pragma: NO COVER
+    warnings.warn(eol_message.format("3.9"), FutureWarning)

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,8 @@ DEPENDENCIES = (
     "rsa>=3.1.4,<5",
 )
 
-# TODO(https://github.com/googleapis/google-auth-library-python/issues/1737): Unit test fails with
-#  `No module named 'cryptography.hazmat.backends.openssl.x509' for Python 3.7``.
 cryptography_base_require = [
     "cryptography >= 38.0.3",
-    "cryptography < 39.0.0; python_version < '3.8'",
 ]
 
 requests_extra_require = ["requests >= 2.20.0, < 3.0.0"]
@@ -116,12 +113,11 @@ setup(
     package_data={"google.auth": ["py.typed"], "google.oauth2": ["py.typed"]},
     install_requires=DEPENDENCIES,
     extras_require=extras,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     license="Apache 2.0",
     keywords="google auth oauth client",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tests/test_pluggable.py
+++ b/tests/test_pluggable.py
@@ -1231,16 +1231,6 @@ class TestCredentials(object):
             _ = credentials.revoke(None)
 
     @mock.patch.dict(os.environ, {"GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES": "1"})
-    def test_retrieve_subject_token_python_2(self):
-        with mock.patch("sys.version_info", (2, 7)):
-            credentials = self.make_pluggable(credential_source=self.CREDENTIAL_SOURCE)
-
-            with pytest.raises(exceptions.RefreshError) as excinfo:
-                _ = credentials.retrieve_subject_token(None)
-
-            assert excinfo.match(r"Pluggable auth is only supported for python 3.7+")
-
-    @mock.patch.dict(os.environ, {"GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES": "1"})
     def test_retrieve_subject_token_with_quoted_command(self):
         command_with_spaces = '"/path/with spaces/to/executable" "arg with spaces"'
         credential_source = {
@@ -1269,17 +1259,3 @@ class TestCredentials(object):
                 stderr=subprocess.STDOUT,
                 env=mock.ANY,
             )
-
-    @mock.patch.dict(os.environ, {"GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES": "1"})
-    def test_revoke_subject_token_python_2(self):
-        with mock.patch("sys.version_info", (2, 7)):
-            credentials = self.make_pluggable(
-                audience=WORKFORCE_AUDIENCE,
-                credential_source=self.CREDENTIAL_SOURCE,
-                interactive=True,
-            )
-
-            with pytest.raises(exceptions.RefreshError) as excinfo:
-                _ = credentials.revoke(None)
-
-            assert excinfo.match(r"Pluggable auth is only supported for python 3.7+")

--- a/tests/test_version_warnings.py
+++ b/tests/test_version_warnings.py
@@ -14,8 +14,8 @@
 
 import importlib
 import sys
-import warnings
 from unittest import mock
+import warnings
 
 import pytest
 

--- a/tests/test_version_warnings.py
+++ b/tests/test_version_warnings.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import sys
+import warnings
+from unittest import mock
+
+import pytest
+
+import google.auth
+import google.oauth2
+
+
+@pytest.mark.parametrize("module", [google.auth, google.oauth2])
+@pytest.mark.parametrize(
+    "version, expected_warning",
+    [
+        ((3, 8), True),
+        ((3, 9), True),
+        ((3, 10), False),
+        ((3, 13), False),
+    ],
+)
+def test_python_version_warnings(module, version, expected_warning):
+    # Mock sys.version_info
+    # We use a MagicMock that has major and minor attributes
+    mock_version = mock.Mock()
+    mock_version.major = version[0]
+    mock_version.minor = version[1]
+
+    with mock.patch.object(sys, "version_info", mock_version):
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+            importlib.reload(module)
+
+            future_warnings = [
+                w
+                for w in caught_warnings
+                if issubclass(w.category, FutureWarning)
+                and "past its end of life" in str(w.message)
+            ]
+
+            if expected_warning:
+                assert (
+                    len(future_warnings) > 0
+                ), f"Expected FutureWarning for Python {version} in {module.__name__}"
+                assert str(version[1]) in str(future_warnings[0].message)
+            else:
+                assert (
+                    len(future_warnings) == 0
+                ), f"Did not expect FutureWarning for Python {version} in {module.__name__}"


### PR DESCRIPTION
Removing support for EOL Python 3.7. 

A warning was present in the README that support would be removed after January 2024

Also added a warning that Python 3.8 and 3.9 are also EOL, and will be removed in future updates