### PR TITLE
chore: librarian release pull request: 20260106T130342Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
 libraries:
   - id: google-auth
-    version: 2.46.0
+    version: 2.47.0
     last_generated_commit: 102d9f92ac6ed649a61efd9b208e4d1de278e9bb
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 [1]: https://pypi.org/project/google-auth/#history
 
+## [2.47.0](https://github.com/googleapis/google-auth-library-python/compare/v2.46.0...v2.47.0) (2026-01-06)
+
+
+### Features
+
+* drop `cachetools` dependency in favor of simple local implementation (#1590) ([5c07e1c4f52bc77a1b16fa3b7b3c5269c242f6f4](https://github.com/googleapis/google-auth-library-python/commit/5c07e1c4f52bc77a1b16fa3b7b3c5269c242f6f4))
+
+
+### Bug Fixes
+
+* Python 3.8 support (#1918) ([60dc20014a35ec4ba71e8065b9a33ecbdbeca97a](https://github.com/googleapis/google-auth-library-python/commit/60dc20014a35ec4ba71e8065b9a33ecbdbeca97a))
+
 ## [2.46.0](https://github.com/googleapis/google-auth-library-python/compare/v2.45.0...v2.46.0) (2026-01-05)
 
 

--- a/google/auth/version.py
+++ b/google/auth/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.46.0"
+__version__ = "2.47.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.1
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
<details><summary>google-auth: 2.47.0</summary>

## [2.47.0](https://github.com/googleapis/google-auth-library-python/compare/v2.46.0...v2.47.0) (2026-01-06)

### Features

* drop `cachetools` dependency in favor of simple local implementation (#1590) ([5c07e1c4](https://github.com/googleapis/google-auth-library-python/commit/5c07e1c4))

### Bug Fixes

* Python 3.8 support (#1918) ([60dc2001](https://github.com/googleapis/google-auth-library-python/commit/60dc2001))

</details>