### PR TITLE
chore: add warning for rsa library

### DIFF
--- a/google/auth/crypt/_python_rsa.py
+++ b/google/auth/crypt/_python_rsa.py
@@ -22,6 +22,7 @@ certificates. There is no support for p12 files.
 from __future__ import absolute_import
 
 import io
+import warnings
 
 from pyasn1.codec.der import decoder  # type: ignore
 from pyasn1_modules import pem  # type: ignore
@@ -38,6 +39,16 @@ _CERTIFICATE_MARKER = b"-----BEGIN CERTIFICATE-----"
 _PKCS1_MARKER = ("-----BEGIN RSA PRIVATE KEY-----", "-----END RSA PRIVATE KEY-----")
 _PKCS8_MARKER = ("-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----")
 _PKCS8_SPEC = PrivateKeyInfo()
+
+warnings.warn(
+    (
+        "The 'rsa' library is deprecated and will be removed in a future release. "
+        "Please migrate to 'cryptography'. To keep using the legacy library, "
+        "install 'google-auth[rsa]'."
+    ),
+    category=FutureWarning,
+    stacklevel=2,
+)
 
 
 def _bit_list_to_bytes(bit_list):

--- a/google/auth/crypt/_python_rsa.py
+++ b/google/auth/crypt/_python_rsa.py
@@ -45,7 +45,7 @@ warnings.warn(
         "The 'rsa' library is deprecated and will be removed in a future release. "
         "Please migrate to 'cryptography'."
     ),
-    category=FutureWarning,
+    category=DeprecationWarning,
     stacklevel=2,
 )
 

--- a/google/auth/crypt/_python_rsa.py
+++ b/google/auth/crypt/_python_rsa.py
@@ -74,6 +74,10 @@ def _bit_list_to_bytes(bit_list):
 class RSAVerifier(base.Verifier):
     """Verifies RSA cryptographic signatures using public keys.
 
+    .. deprecated::
+        The `rsa` library has been archived. Please migrate to
+        `cryptography`.
+
     Args:
         public_key (rsa.key.PublicKey): The public key used to verify
             signatures.
@@ -125,6 +129,10 @@ class RSAVerifier(base.Verifier):
 
 class RSASigner(base.Signer, base.FromServiceAccountMixin):
     """Signs messages with an RSA private key.
+
+    .. deprecated::
+        The `rsa` library has been archived. Please migrate to
+        `cryptography`.
 
     Args:
         private_key (rsa.key.PrivateKey): The private key to sign with.

--- a/google/auth/crypt/_python_rsa.py
+++ b/google/auth/crypt/_python_rsa.py
@@ -43,8 +43,7 @@ _PKCS8_SPEC = PrivateKeyInfo()
 warnings.warn(
     (
         "The 'rsa' library is deprecated and will be removed in a future release. "
-        "Please migrate to 'cryptography'. To keep using the legacy library, "
-        "install 'google-auth[rsa]'."
+        "Please migrate to 'cryptography'."
     ),
     category=FutureWarning,
     stacklevel=2,

--- a/noxfile.py
+++ b/noxfile.py
@@ -129,6 +129,7 @@ def unit(session):
         "--cov-report=term-missing",
         "tests",
         "tests_async",
+        *session.posargs,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ pyopenssl_extra_require = ["pyopenssl>=20.0.0", cryptography_base_require]
 # TODO(https://github.com/googleapis/google-auth-library-python/issues/1739): Add bounds for urllib3 and packaging dependencies.
 urllib3_extra_require = ["urllib3", "packaging"]
 
+rsa_extra_require = ["rsa>=3.1.4,<5"]
+
 # Unit test requirements.
 testing_extra_require = [
     # TODO(https://github.com/googleapis/google-auth-library-python/issues/1735): Remove `grpcio` from testing requirements once an extra is added for `grpcio` dependency.
@@ -85,6 +87,7 @@ extras = {
     "requests": requests_extra_require,
     "testing": testing_extra_require,
     "urllib3": urllib3_extra_require,
+    "rsa": rsa_extra_require,
     # TODO(https://github.com/googleapis/google-auth-library-python/issues/1735): Add an extra for `grpcio` dependency.
     # TODO(https://github.com/googleapis/google-auth-library-python/issues/1736): Add an extra for `oauth2client` dependency.
 }

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ pyopenssl_extra_require = ["pyopenssl>=20.0.0", cryptography_base_require]
 # TODO(https://github.com/googleapis/google-auth-library-python/issues/1739): Add bounds for urllib3 and packaging dependencies.
 urllib3_extra_require = ["urllib3", "packaging"]
 
+# TODO: rsa is archived. Remove optional dependency in future release
 rsa_extra_require = ["rsa>=3.1.4,<5"]
 
 # Unit test requirements.

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,6 @@ pyopenssl_extra_require = ["pyopenssl>=20.0.0", cryptography_base_require]
 # TODO(https://github.com/googleapis/google-auth-library-python/issues/1739): Add bounds for urllib3 and packaging dependencies.
 urllib3_extra_require = ["urllib3", "packaging"]
 
-# TODO: rsa is archived. Remove optional dependency in future release
-rsa_extra_require = ["rsa>=3.1.4,<5"]
-
 # Unit test requirements.
 testing_extra_require = [
     # TODO(https://github.com/googleapis/google-auth-library-python/issues/1735): Remove `grpcio` from testing requirements once an extra is added for `grpcio` dependency.
@@ -88,7 +85,6 @@ extras = {
     "requests": requests_extra_require,
     "testing": testing_extra_require,
     "urllib3": urllib3_extra_require,
-    "rsa": rsa_extra_require,
     # TODO(https://github.com/googleapis/google-auth-library-python/issues/1735): Add an extra for `grpcio` dependency.
     # TODO(https://github.com/googleapis/google-auth-library-python/issues/1736): Add an extra for `oauth2client` dependency.
 }

--- a/tests/crypt/test__python_rsa.py
+++ b/tests/crypt/test__python_rsa.py
@@ -198,5 +198,5 @@ class TestModule(object):
         import importlib
         from google.auth.crypt import _python_rsa
 
-        with pytest.warns(FutureWarning, match="The 'rsa' library is deprecated"):
+        with pytest.warns(DeprecationWarning, match="The 'rsa' library is deprecated"):
             importlib.reload(_python_rsa)

--- a/tests/crypt/test__python_rsa.py
+++ b/tests/crypt/test__python_rsa.py
@@ -191,3 +191,12 @@ class TestRSASigner(object):
 
         assert signer.key_id == SERVICE_ACCOUNT_INFO[base._JSON_FILE_PRIVATE_KEY_ID]
         assert isinstance(signer._key, rsa.key.PrivateKey)
+
+
+class TestModule(object):
+    def test_import_warning(self):
+        import importlib
+        from google.auth.crypt import _python_rsa
+
+        with pytest.warns(FutureWarning, match="The 'rsa' library is deprecated"):
+            importlib.reload(_python_rsa)


### PR DESCRIPTION
The `rsa` library is archived, and scheduled to be removed. `google-auth` already supports an alternate implementation, using `cryptography`. This PR adds a warning to users still relying on the old library, and adds `rsa` as an optional dependency to allow users to continue to opt-in to rsa during deprecation persion

After release, a follow-up version will remove rsa as a required dependency, leaving it only for opt-in users