### PR TITLE
chore: dedent deprecation warning message

### DIFF
--- a/google/auth/__init__.py
+++ b/google/auth/__init__.py
@@ -42,12 +42,12 @@ class Python37DeprecationWarning(DeprecationWarning):  # pragma: NO COVER
 
 
 # Raise warnings for deprecated versions
-eol_message = """
-    You are using a Python version {} past its end of life. Google will update
-    google-auth with critical bug fixes on a best-effort basis, but not
-    with any other fixes or features. Please upgrade your Python version,
-    and then update google-auth.
-    """
+eol_message = (
+    "You are using a Python version {} past its end of life. Google will update "
+    "google-auth with critical bug fixes on a best-effort basis, but not "
+    "with any other fixes or features. Please upgrade your Python version, "
+    "and then update google-auth."
+)
 if sys.version_info.major == 3 and sys.version_info.minor == 8:  # pragma: NO COVER
     warnings.warn(eol_message.format("3.8"), FutureWarning)
 elif sys.version_info.major == 3 and sys.version_info.minor == 9:  # pragma: NO COVER

--- a/google/oauth2/__init__.py
+++ b/google/oauth2/__init__.py
@@ -28,12 +28,12 @@ class Python37DeprecationWarning(DeprecationWarning):  # pragma: NO COVER
 
 
 # Raise warnings for deprecated versions
-eol_message = """
-    You are using a Python version {} past its end of life. Google will update
-    google-auth with critical bug fixes on a best-effort basis, but not
-    with any other fixes or features. Please upgrade your Python version,
-    and then update google-auth.
-    """
+eol_message = (
+    "You are using a Python version {} past its end of life. Google will update "
+    "google-auth with critical bug fixes on a best-effort basis, but not "
+    "with any other fixes or features. Please upgrade your Python version, "
+    "and then update google-auth."
+)
 if sys.version_info.major == 3 and sys.version_info.minor == 8:  # pragma: NO COVER
     warnings.warn(eol_message.format("3.8"), FutureWarning)
 elif sys.version_info.major == 3 and sys.version_info.minor == 9:  # pragma: NO COVER


### PR DESCRIPTION
The indentation and leading/trailing newlines made it a little harder than necessary to `filterwarnings` the deprecation warning.

(For instance, for pytest's filterwarnings, you'd need `"ignore:\\s+You are using a Python version 3.8:FutureWarning",`...)

