### PR TITLE
chore: remove deprecated deprecation warning

### DIFF
--- a/google/auth/__init__.py
+++ b/google/auth/__init__.py
@@ -32,15 +32,6 @@ __version__ = google_auth_version.__version__
 __all__ = ["default", "load_credentials_from_file", "load_credentials_from_dict"]
 
 
-class Python37DeprecationWarning(DeprecationWarning):  # pragma: NO COVER
-    """
-    Deprecation warning raised when Python 3.7 runtime is detected.
-    Python 3.7 support will be dropped after January 1, 2024.
-    """
-
-    pass
-
-
 # Raise warnings for deprecated versions
 eol_message = """
     You are using a Python version {} past its end of life. Google will update

--- a/google/oauth2/__init__.py
+++ b/google/oauth2/__init__.py
@@ -17,16 +17,6 @@
 import sys
 import warnings
 
-
-class Python37DeprecationWarning(DeprecationWarning):  # pragma: NO COVER
-    """
-    Deprecation warning raised when Python 3.7 runtime is detected.
-    Python 3.7 support will be dropped after January 1, 2024.
-    """
-
-    pass
-
-
 # Raise warnings for deprecated versions
 eol_message = """
     You are using a Python version {} past its end of life. Google will update


### PR DESCRIPTION
I looked through [GitHub search](https://github.com/search?q=Python37DeprecationWarning&type=code), and it looks like no external code is referencing this deprecation warning, so I suppose it's good to go the way of the dodo post #1919.