### PR TITLE
fix: removes `content-header` from AWS IMDS get request

### DIFF
--- a/google/auth/aws.py
+++ b/google/auth/aws.py
@@ -530,7 +530,7 @@ class _DefaultAwsSecurityCredentialsSupplier(AwsSecurityCredentialsSupplier):
             google.auth.exceptions.RefreshError: If an error occurs while
                 retrieving the AWS security credentials.
         """
-        headers = {"Content-Type": "application/json"}
+        headers = None
         if imdsv2_session_token is not None:
             headers["X-aws-ec2-metadata-token"] = imdsv2_session_token
 

--- a/google/auth/aws.py
+++ b/google/auth/aws.py
@@ -530,9 +530,11 @@ class _DefaultAwsSecurityCredentialsSupplier(AwsSecurityCredentialsSupplier):
             google.auth.exceptions.RefreshError: If an error occurs while
                 retrieving the AWS security credentials.
         """
-        headers = None
         if imdsv2_session_token is not None:
             headers = {"X-aws-ec2-metadata-token": imdsv2_session_token}
+        else:
+            headers = None
+
 
         response = request(
             url="{}/{}".format(self._security_credentials_url, role_name),

--- a/google/auth/aws.py
+++ b/google/auth/aws.py
@@ -535,7 +535,6 @@ class _DefaultAwsSecurityCredentialsSupplier(AwsSecurityCredentialsSupplier):
         else:
             headers = None
 
-
         response = request(
             url="{}/{}".format(self._security_credentials_url, role_name),
             method="GET",

--- a/google/auth/aws.py
+++ b/google/auth/aws.py
@@ -532,7 +532,7 @@ class _DefaultAwsSecurityCredentialsSupplier(AwsSecurityCredentialsSupplier):
         """
         headers = None
         if imdsv2_session_token is not None:
-            headers["X-aws-ec2-metadata-token"] = imdsv2_session_token
+            headers = {"X-aws-ec2-metadata-token": imdsv2_session_token}
 
         response = request(
             url="{}/{}".format(self._security_credentials_url, role_name),

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1430,7 +1430,6 @@ class TestCredentials(object):
             new_request.call_args_list[2][1],
             "{}/{}".format(SECURITY_CREDS_URL, self.AWS_ROLE),
             {
-                "Content-Type": "application/json",
                 "X-aws-ec2-metadata-token": self.AWS_IMDSV2_SESSION_TOKEN,
             },
         )
@@ -1487,7 +1486,6 @@ class TestCredentials(object):
             request.call_args_list[2][1],
             "{}/{}".format(SECURITY_CREDS_URL, self.AWS_ROLE),
             {
-                "Content-Type": "application/json",
                 "X-aws-ec2-metadata-token": self.AWS_IMDSV2_SESSION_TOKEN,
             },
         )
@@ -1544,7 +1542,6 @@ class TestCredentials(object):
             request.call_args_list[2][1],
             "{}/{}".format(SECURITY_CREDS_URL, self.AWS_ROLE),
             {
-                "Content-Type": "application/json",
                 "X-aws-ec2-metadata-token": self.AWS_IMDSV2_SESSION_TOKEN,
             },
         )
@@ -1595,7 +1592,6 @@ class TestCredentials(object):
             request.call_args_list[2][1],
             "{}/{}".format(SECURITY_CREDS_URL, self.AWS_ROLE),
             {
-                "Content-Type": "application/json",
                 "X-aws-ec2-metadata-token": self.AWS_IMDSV2_SESSION_TOKEN,
             },
         )

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1306,7 +1306,7 @@ class TestCredentials(object):
         self.assert_aws_metadata_request_kwargs(
             request.call_args_list[2][1],
             "{}/{}".format(SECURITY_CREDS_URL, self.AWS_ROLE),
-            {"Content-Type": "application/json"},
+            None,
         )
 
         # Retrieve subject_token again. Region should not be queried again.
@@ -1329,7 +1329,7 @@ class TestCredentials(object):
         self.assert_aws_metadata_request_kwargs(
             new_request.call_args_list[1][1],
             "{}/{}".format(SECURITY_CREDS_URL, self.AWS_ROLE),
-            {"Content-Type": "application/json"},
+            None,
         )
 
     @mock.patch("google.auth._helpers.utcnow")
@@ -1394,7 +1394,6 @@ class TestCredentials(object):
             request.call_args_list[4][1],
             "{}/{}".format(SECURITY_CREDS_URL, self.AWS_ROLE),
             {
-                "Content-Type": "application/json",
                 "X-aws-ec2-metadata-token": self.AWS_IMDSV2_SESSION_TOKEN,
             },
         )
@@ -1684,7 +1683,6 @@ class TestCredentials(object):
             request.call_args_list[4][1],
             "{}/{}".format(SECURITY_CREDS_URL_IPV6, self.AWS_ROLE),
             {
-                "Content-Type": "application/json",
                 "X-aws-ec2-metadata-token": self.AWS_IMDSV2_SESSION_TOKEN,
             },
         )


### PR DESCRIPTION
When performing a IMDS request, the code incorrectly adds a content-type header to the request:

`content-type: application/json` to AWS metadata (IMDS) GET requests.`

Some services at AWS (such as AWS SageMaker Jupyter notebook) have a stricter than normal metadata server (IMDS, both v1 and v2) when it comes to handling incoming http requests.

This PR removes the default content-header and replaces it with `None`.

NOTE: initializing headers to `None` (instead of an empty `dict`) when no session token is present matches the existing behavior in `_get_metadata_role_name` and allows the transport adapter to handle default headers cleanly.

This PR updates existing unit tests (`tests/test_aws.py`) to match the new behavior.

NOTE: closing PR #1489 due to inactivity as we make the push to migrate this library to the `google-cloud-python` monorepo

For more information about the genesis of this, see the following issue: https://issuetracker.google.com/issues/328089077