### PR TITLE
chore: extracts unit tests to individual github actions

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: ['3.8']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -51,14 +51,7 @@ nox.options.sessions = [
     "lint",
     "blacken",
     "mypy",
-    "unit-3.9",
-    "unit-3.10",
-    "unit-3.11",
-    "unit-3.12",
-    "unit-3.13",
-    "unit-3.14",
     # cover must be last to avoid error `No data to report`
-    "cover",
     "docs",
 ]
 


### PR DESCRIPTION
Extracts unit tests into individual github actions to help parallelize the tests and increase development velocity.