### PR TITLE
chore: librarian release pull request: 20260126T121420Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
 libraries:
   - id: google-auth
-    version: 2.48.0
+    version: 2.49.0-dev0
     last_generated_commit: 102d9f92ac6ed649a61efd9b208e4d1de278e9bb
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-auth/#history
 
+## [2.49.0-dev0](https://github.com/googleapis/google-auth-library-python/compare/v2.48.0...v2.49.0-dev0) (2026-01-26)
+
+
+### Bug Fixes
+
+* remove deprecated rsa dependency ([e98cf69284d3620619a70b54fb0b9533caf11878](https://github.com/googleapis/google-auth-library-python/commit/e98cf69284d3620619a70b54fb0b9533caf11878))
+
 ## [2.48.0](https://github.com/googleapis/google-auth-library-python/compare/v2.47.0...v2.48.0) (2026-01-22)
 
 

--- a/google/auth/crypt/rsa.py
+++ b/google/auth/crypt/rsa.py
@@ -24,7 +24,6 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from google.auth import _helpers
 from google.auth.crypt import _cryptography_rsa
-from google.auth.crypt import _python_rsa
 from google.auth.crypt import base
 
 RSA_KEY_MODULE_PREFIX = "rsa.key"
@@ -37,6 +36,7 @@ class RSAVerifier(base.Verifier):
         public_key (Union["rsa.key.PublicKey", cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey]):
             The public key used to verify signatures.
     Raises:
+        ImportError: if called with an rsa.key.PublicKey, when the rsa library is not installed
         ValueError: if an unrecognized public key is provided
     """
 
@@ -45,6 +45,8 @@ class RSAVerifier(base.Verifier):
         if isinstance(public_key, RSAPublicKey):
             impl_lib = _cryptography_rsa
         elif module_str.startswith(RSA_KEY_MODULE_PREFIX):
+            from google.auth.crypt import _python_rsa
+
             impl_lib = _python_rsa
         else:
             raise ValueError(f"unrecognized public key type: {type(public_key)}")
@@ -85,6 +87,7 @@ class RSASigner(base.Signer, base.FromServiceAccountMixin):
             public key or certificate.
 
     Raises:
+        ImportError: if called with an rsa.key.PrivateKey, when the rsa library is not installed
         ValueError: if an unrecognized public key is provided
     """
 
@@ -93,6 +96,8 @@ class RSASigner(base.Signer, base.FromServiceAccountMixin):
         if isinstance(private_key, RSAPrivateKey):
             impl_lib = _cryptography_rsa
         elif module_str.startswith(RSA_KEY_MODULE_PREFIX):
+            from google.auth.crypt import _python_rsa
+
             impl_lib = _python_rsa
         else:
             raise ValueError(f"unrecognized private key type: {type(private_key)}")

--- a/google/auth/version.py
+++ b/google/auth/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.48.0"
+__version__ = "2.49.0-dev0"

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,6 @@ cryptography_base_require = [
 DEPENDENCIES = (
     "pyasn1-modules>=0.2.1",
     cryptography_base_require,
-    # TODO: remove rsa from dependencies in next release (replaced with cryptography)i
-    # https://github.com/googleapis/google-auth-library-python/issues/1810
-    "rsa>=3.1.4,<5",
 )
 
 requests_extra_require = ["requests >= 2.20.0, < 3.0.0"]
@@ -73,6 +70,9 @@ testing_extra_require = [
     # TODO(https://github.com/googleapis/google-auth-library-python/issues/1722): `test_aiohttp_requests` depend on
     # aiohttp < 3.10.0 which is a bug. Investigate and remove the pinned aiohttp version.
     "aiohttp < 3.10.0",
+    # rsa library was removed as a dependency, but we still have some code paths that support it
+    # TODO: remove dependency when google.auth.crypt._python_rsa is removed
+    "rsa>=3.1.4,<5",
 ]
 
 extras = {

--- a/testing/constraints-3.8.txt
+++ b/testing/constraints-3.8.txt
@@ -7,7 +7,6 @@
 # Then this file should have foo==1.14.0
 pyasn1-modules==0.2.1
 setuptools==40.3.0
-rsa==3.1.4
 cryptography==38.0.3
 aiohttp==3.6.2
 requests==2.20.0

--- a/tests/crypt/test_rsa.py
+++ b/tests/crypt/test_rsa.py
@@ -18,7 +18,7 @@ from unittest import mock
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives import serialization
 import pytest
-import rsa as rsa_lib
+import rsa as rsa_lib  # type: ignore
 
 from google.auth.crypt import _cryptography_rsa
 from google.auth.crypt import _python_rsa


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
<details><summary>google-auth: 2.49.0-dev0</summary>

## [2.49.0-dev0](https://github.com/googleapis/google-auth-library-python/compare/v2.48.0...v2.49.0-dev0) (2026-01-26)

### Bug Fixes

* remove deprecated rsa dependency ([e98cf692](https://github.com/googleapis/google-auth-library-python/commit/e98cf692))

</details>