### PR TITLE
chore: replace aion-sdk and platform teams with updated names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,27 +4,27 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/googleapis-auth and @googleapis/python-core-client-libraries is the default owner for changes in this repo
-*                                                           @googleapis/googleapis-auth @googleapis/python-core-client-libraries
-google/auth/_default.py                                     @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-google/auth/aws.py                                          @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-google/auth/credentials.py                                  @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-google/auth/downscoped.py                                   @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-google/auth/external_account.py                             @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-google/auth/external_account_authorized_user.py             @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-google/auth/identity_pool.py                                @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-google/auth/pluggable.py                                    @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-google/auth/sts.py                                          @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-google/auth/impersonated_credentials.py                     @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-tests/test__default.py                                      @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-tests/test_aws.py                                           @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-tests/test_credentials.py                                   @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-tests/test_downscoped.py                                    @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-tests/test_external_account.py                              @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-tests/test_external_account_authorized_user.py              @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-tests/test_identity_pool.py                                 @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-tests/test_pluggable.py                                     @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-tests/test_sts.py                                           @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-tests/test_impersonated_credentials.py                      @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-core-client-libraries
-/samples/                                                   @googleapis/googleapis-auth @googleapis/aion-sdk @googleapis/python-samples-owners @googleapis/python-core-client-libraries
+# The @googleapis/googleapis-auth and @googleapis/cloud-sdk-python-team is the default owner for changes in this repo
+*                                                           @googleapis/googleapis-auth @googleapis/cloud-sdk-python-team
+google/auth/_default.py                                     @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+google/auth/aws.py                                          @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+google/auth/credentials.py                                  @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+google/auth/downscoped.py                                   @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+google/auth/external_account.py                             @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+google/auth/external_account_authorized_user.py             @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+google/auth/identity_pool.py                                @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+google/auth/pluggable.py                                    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+google/auth/sts.py                                          @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+google/auth/impersonated_credentials.py                     @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+tests/test__default.py                                      @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+tests/test_aws.py                                           @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+tests/test_credentials.py                                   @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+tests/test_downscoped.py                                    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+tests/test_external_account.py                              @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+tests/test_external_account_authorized_user.py              @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+tests/test_identity_pool.py                                 @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+tests/test_pluggable.py                                     @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+tests/test_sts.py                                           @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+tests/test_impersonated_credentials.py                      @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-python-team
+/samples/                                                   @googleapis/googleapis-auth @googleapis/aion-team @googleapis/python-samples-owners @googleapis/cloud-sdk-python-team
 system_tests/secrets.tar.enc # Remove noise from test creds.


### PR DESCRIPTION
This PR replaces @googleapis/aion-sdk and @googleapis/python-core-client-libraries with their updated team names. b/478003109