### PR TITLE
feat: Support timeout as aiohttp.ClientTimeout and total_attempts (max retries) in AsyncAuthorizedSession

### DIFF
--- a/google/auth/aio/transport/aiohttp.py
+++ b/google/auth/aio/transport/aiohttp.py
@@ -27,7 +27,7 @@ except ImportError as caught_exc:  # pragma: NO COVER
     ) from caught_exc
 
 if typing.TYPE_CHECKING:
-    from aiohttp import ClientTimeout
+    from aiohttp import ClientTimeout  # type: ignore
 
 else:
     ClientTimeout = Any

--- a/google/auth/aio/transport/aiohttp.py
+++ b/google/auth/aio/transport/aiohttp.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Transport adapter for Asynchronous HTTP Requests based on aiohttp.
-"""
+"""Transport adapter for Asynchronous HTTP Requests based on aiohttp."""
 
 import asyncio
 import logging
@@ -29,8 +28,9 @@ except ImportError as caught_exc:  # pragma: NO COVER
 
 if typing.TYPE_CHECKING:
     from aiohttp import ClientTimeout
+
 else:
-    ClientTimeout: typing.Type = Any
+    ClientTimeout = Any
     try:
         from aiohttp import ClientTimeout
     except ImportError:
@@ -189,8 +189,12 @@ class Request(transport.Request):
             raise client_exc from caught_exc
 
         except asyncio.TimeoutError as caught_exc:
+            if isinstance(timeout, aiohttp.ClientTimeout):
+                timeout_seconds = timeout.total
+            else:
+                timeout_seconds = timeout
             timeout_exc = exceptions.TimeoutError(
-                f"Request timed out after {timeout} seconds."
+                f"Request timed out after {timeout_seconds} seconds."
             )
             raise timeout_exc from caught_exc
 

--- a/google/auth/aio/transport/aiohttp.py
+++ b/google/auth/aio/transport/aiohttp.py
@@ -34,10 +34,9 @@ if TYPE_CHECKING:  # pragma: NO COVER
     from aiohttp import ClientTimeout  # type: ignore
 
 else:
-    ClientTimeout = Any
     try:
         from aiohttp import ClientTimeout
-    except ImportError:
+    except (ImportError, AttributeError):
         ClientTimeout = None
 
 _LOGGER = logging.getLogger(__name__)

--- a/google/auth/aio/transport/aiohttp.py
+++ b/google/auth/aio/transport/aiohttp.py
@@ -16,7 +16,7 @@
 
 import asyncio
 import logging
-from typing import Any, AsyncGenerator, Mapping, Optional, TYPE_CHECKING, Union
+from typing import AsyncGenerator, Mapping, Optional, TYPE_CHECKING, Union
 
 try:
     import aiohttp  # type: ignore

--- a/google/auth/aio/transport/aiohttp.py
+++ b/google/auth/aio/transport/aiohttp.py
@@ -16,8 +16,7 @@
 
 import asyncio
 import logging
-import typing
-from typing import Any, AsyncGenerator, Mapping, Optional, Union
+from typing import Any, AsyncGenerator, Mapping, Optional, TYPE_CHECKING, Union
 
 try:
     import aiohttp  # type: ignore
@@ -26,7 +25,12 @@ except ImportError as caught_exc:  # pragma: NO COVER
         "The aiohttp library is not installed from please install the aiohttp package to use the aiohttp transport."
     ) from caught_exc
 
-if typing.TYPE_CHECKING:
+from google.auth import _helpers
+from google.auth import exceptions
+from google.auth.aio import _helpers as _helpers_async
+from google.auth.aio import transport
+
+if TYPE_CHECKING:  # pragma: NO COVER
     from aiohttp import ClientTimeout  # type: ignore
 
 else:
@@ -35,11 +39,6 @@ else:
         from aiohttp import ClientTimeout
     except ImportError:
         ClientTimeout = None
-
-from google.auth import _helpers
-from google.auth import exceptions
-from google.auth.aio import _helpers as _helpers_async
-from google.auth.aio import transport
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/google/auth/aio/transport/aiohttp.py
+++ b/google/auth/aio/transport/aiohttp.py
@@ -171,7 +171,7 @@ class Request(transport.Request):
             if isinstance(timeout, aiohttp.ClientTimeout):
                 client_timeout = timeout
             else:
-              client_timeout = aiohttp.ClientTimeout(total=timeout)
+                client_timeout = aiohttp.ClientTimeout(total=timeout)
             _helpers.request_log(_LOGGER, method, url, body, headers)
             response = await self._session.request(
                 method,

--- a/google/auth/aio/transport/sessions.py
+++ b/google/auth/aio/transport/sessions.py
@@ -16,7 +16,7 @@ import asyncio
 from contextlib import asynccontextmanager
 import functools
 import time
-from typing import Any, Mapping, Optional, TYPE_CHECKING, Union
+from typing import Mapping, Optional, TYPE_CHECKING, Union
 
 from google.auth import _exponential_backoff, exceptions
 from google.auth.aio import transport

--- a/google/auth/aio/transport/sessions.py
+++ b/google/auth/aio/transport/sessions.py
@@ -215,7 +215,7 @@ class AsyncAuthorizedSession:
         **kwargs,
     ) -> transport.Response:
         return await self.request(
-            "GET", url, data, headers, max_allowed_time, timeout, **kwargs
+            "GET", url, data, headers, max_allowed_time, timeout, total_attempts, **kwargs
         )
 
     @functools.wraps(request)
@@ -230,7 +230,7 @@ class AsyncAuthorizedSession:
         **kwargs,
     ) -> transport.Response:
         return await self.request(
-            "POST", url, data, headers, max_allowed_time, timeout, **kwargs
+            "POST", url, data, headers, max_allowed_time, timeout, total_attempts, **kwargs
         )
 
     @functools.wraps(request)
@@ -245,7 +245,7 @@ class AsyncAuthorizedSession:
         **kwargs,
     ) -> transport.Response:
         return await self.request(
-            "PUT", url, data, headers, max_allowed_time, timeout, **kwargs
+            "PUT", url, data, headers, max_allowed_time, timeout, total_attempts, **kwargs
         )
 
     @functools.wraps(request)
@@ -260,7 +260,7 @@ class AsyncAuthorizedSession:
         **kwargs,
     ) -> transport.Response:
         return await self.request(
-            "PATCH", url, data, headers, max_allowed_time, timeout, **kwargs
+            "PATCH", url, data, headers, max_allowed_time, timeout, total_attempts, **kwargs
         )
 
     @functools.wraps(request)
@@ -275,7 +275,7 @@ class AsyncAuthorizedSession:
         **kwargs,
     ) -> transport.Response:
         return await self.request(
-            "DELETE", url, data, headers, max_allowed_time, timeout, **kwargs
+            "DELETE", url, data, headers, max_allowed_time, timeout, total_attempts, **kwargs
         )
 
     async def close(self) -> None:

--- a/google/auth/aio/transport/sessions.py
+++ b/google/auth/aio/transport/sessions.py
@@ -27,10 +27,9 @@ if TYPE_CHECKING:  # pragma: NO COVER
     from aiohttp import ClientTimeout  # type: ignore
 
 else:
-    ClientTimeout = Any
     try:
         from aiohttp import ClientTimeout
-    except ImportError:
+    except (ImportError, AttributeError):
         ClientTimeout = None
 
 try:

--- a/google/auth/aio/transport/sessions.py
+++ b/google/auth/aio/transport/sessions.py
@@ -39,8 +39,7 @@ else:
         from aiohttp import ClientTimeout
     except ImportError:
         ClientTimeout = None
-        
-    
+
 @asynccontextmanager
 async def timeout_guard(timeout):
     """
@@ -212,6 +211,7 @@ class AsyncAuthorizedSession:
         headers: Optional[Mapping[str, str]] = None,
         max_allowed_time: float = transport._DEFAULT_TIMEOUT_SECONDS,
         timeout: Union[float, ClientTimeout] = transport._DEFAULT_TIMEOUT_SECONDS,
+        total_attempts: Optional[int] = transport.DEFAULT_MAX_RETRY_ATTEMPTS,
         **kwargs,
     ) -> transport.Response:
         return await self.request(
@@ -226,6 +226,7 @@ class AsyncAuthorizedSession:
         headers: Optional[Mapping[str, str]] = None,
         max_allowed_time: float = transport._DEFAULT_TIMEOUT_SECONDS,
         timeout: Union[float, ClientTimeout] = transport._DEFAULT_TIMEOUT_SECONDS,
+        total_attempts: Optional[int] = transport.DEFAULT_MAX_RETRY_ATTEMPTS,
         **kwargs,
     ) -> transport.Response:
         return await self.request(
@@ -240,6 +241,7 @@ class AsyncAuthorizedSession:
         headers: Optional[Mapping[str, str]] = None,
         max_allowed_time: float = transport._DEFAULT_TIMEOUT_SECONDS,
         timeout: Union[float, ClientTimeout] = transport._DEFAULT_TIMEOUT_SECONDS,
+        total_attempts: Optional[int] = transport.DEFAULT_MAX_RETRY_ATTEMPTS,
         **kwargs,
     ) -> transport.Response:
         return await self.request(
@@ -254,6 +256,7 @@ class AsyncAuthorizedSession:
         headers: Optional[Mapping[str, str]] = None,
         max_allowed_time: float = transport._DEFAULT_TIMEOUT_SECONDS,
         timeout: Union[float, ClientTimeout] = transport._DEFAULT_TIMEOUT_SECONDS,
+        total_attempts: Optional[int] = transport.DEFAULT_MAX_RETRY_ATTEMPTS,
         **kwargs,
     ) -> transport.Response:
         return await self.request(
@@ -268,6 +271,7 @@ class AsyncAuthorizedSession:
         headers: Optional[Mapping[str, str]] = None,
         max_allowed_time: float = transport._DEFAULT_TIMEOUT_SECONDS,
         timeout: float = transport._DEFAULT_TIMEOUT_SECONDS,
+        total_attempts: Optional[int] = transport.DEFAULT_MAX_RETRY_ATTEMPTS,
         **kwargs,
     ) -> transport.Response:
         return await self.request(

--- a/google/auth/aio/transport/sessions.py
+++ b/google/auth/aio/transport/sessions.py
@@ -32,7 +32,7 @@ except ImportError:  # pragma: NO COVER
     AIOHTTP_INSTALLED = False
 
 if typing.TYPE_CHECKING:
-    from aiohttp import ClientTimeout
+    from aiohttp import ClientTimeout  # type: ignore
 
 else:
     ClientTimeout = Any

--- a/google/auth/aio/transport/sessions.py
+++ b/google/auth/aio/transport/sessions.py
@@ -16,22 +16,14 @@ import asyncio
 from contextlib import asynccontextmanager
 import functools
 import time
-import typing
-from typing import Any, Mapping, Optional, Union
+from typing import Any, Mapping, Optional, TYPE_CHECKING, Union
 
 from google.auth import _exponential_backoff, exceptions
 from google.auth.aio import transport
 from google.auth.aio.credentials import Credentials
 from google.auth.exceptions import TimeoutError
 
-try:
-    from google.auth.aio.transport.aiohttp import Request as AiohttpRequest
-
-    AIOHTTP_INSTALLED = True
-except ImportError:  # pragma: NO COVER
-    AIOHTTP_INSTALLED = False
-
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: NO COVER
     from aiohttp import ClientTimeout  # type: ignore
 
 else:
@@ -40,6 +32,13 @@ else:
         from aiohttp import ClientTimeout
     except ImportError:
         ClientTimeout = None
+
+try:
+    from google.auth.aio.transport.aiohttp import Request as AiohttpRequest
+
+    AIOHTTP_INSTALLED = True
+except ImportError:  # pragma: NO COVER
+    AIOHTTP_INSTALLED = False
 
 
 @asynccontextmanager
@@ -221,14 +220,14 @@ class AsyncAuthorizedSession:
                 url (str): The URI to be requested.
                 data (Optional[bytes]): The payload or body in HTTP request.
                 headers (Optional[Mapping[str, str]]): Request headers.
-                timeout (float, aiohttp.ClientTimeout):
-                The amount of time in seconds to wait for the server response
-                with each individual request.
                 max_allowed_time (float):
                 If the method runs longer than this, a ``Timeout`` exception is
                 automatically raised. Unlike the ``timeout`` parameter, this
                 value applies to the total method execution time, even if
                 multiple requests are made under the hood.
+                timeout (float, aiohttp.ClientTimeout):
+                The amount of time in seconds to wait for the server response
+                with each individual request.
                 total_attempts (int):
                 The total number of retry attempts.
 
@@ -274,14 +273,14 @@ class AsyncAuthorizedSession:
                 url (str): The URI to be requested.
                 data (Optional[bytes]): The payload or body in HTTP request.
                 headers (Optional[Mapping[str, str]]): Request headers.
-                timeout (float, aiohttp.ClientTimeout):
-                The amount of time in seconds to wait for the server response
-                with each individual request.
                 max_allowed_time (float):
                 If the method runs longer than this, a ``Timeout`` exception is
                 automatically raised. Unlike the ``timeout`` parameter, this
                 value applies to the total method execution time, even if
                 multiple requests are made under the hood.
+                timeout (float, aiohttp.ClientTimeout):
+                The amount of time in seconds to wait for the server response
+                with each individual request.
                 total_attempts (int):
                 The total number of retry attempts.
 
@@ -327,14 +326,14 @@ class AsyncAuthorizedSession:
                 url (str): The URI to be requested.
                 data (Optional[bytes]): The payload or body in HTTP request.
                 headers (Optional[Mapping[str, str]]): Request headers.
-                timeout (float, aiohttp.ClientTimeout):
-                The amount of time in seconds to wait for the server response
-                with each individual request.
                 max_allowed_time (float):
                 If the method runs longer than this, a ``Timeout`` exception is
                 automatically raised. Unlike the ``timeout`` parameter, this
                 value applies to the total method execution time, even if
                 multiple requests are made under the hood.
+                timeout (float, aiohttp.ClientTimeout):
+                The amount of time in seconds to wait for the server response
+                with each individual request.
                 total_attempts (int):
                 The total number of retry attempts.
 
@@ -380,14 +379,14 @@ class AsyncAuthorizedSession:
                 url (str): The URI to be requested.
                 data (Optional[bytes]): The payload or body in HTTP request.
                 headers (Optional[Mapping[str, str]]): Request headers.
-                timeout (float, aiohttp.ClientTimeout):
-                The amount of time in seconds to wait for the server response
-                with each individual request.
                 max_allowed_time (float):
                 If the method runs longer than this, a ``Timeout`` exception is
                 automatically raised. Unlike the ``timeout`` parameter, this
                 value applies to the total method execution time, even if
                 multiple requests are made under the hood.
+                timeout (float, aiohttp.ClientTimeout):
+                The amount of time in seconds to wait for the server response
+                with each individual request.
                 total_attempts (int):
                 The total number of retry attempts.
 
@@ -433,14 +432,14 @@ class AsyncAuthorizedSession:
                 url (str): The URI to be requested.
                 data (Optional[bytes]): The payload or body in HTTP request.
                 headers (Optional[Mapping[str, str]]): Request headers.
-                timeout (float, aiohttp.ClientTimeout):
-                The amount of time in seconds to wait for the server response
-                with each individual request.
                 max_allowed_time (float):
                 If the method runs longer than this, a ``Timeout`` exception is
                 automatically raised. Unlike the ``timeout`` parameter, this
                 value applies to the total method execution time, even if
                 multiple requests are made under the hood.
+                timeout (float, aiohttp.ClientTimeout):
+                The amount of time in seconds to wait for the server response
+                with each individual request.
                 total_attempts (int):
                 The total number of retry attempts.
 

--- a/google/auth/aio/transport/sessions.py
+++ b/google/auth/aio/transport/sessions.py
@@ -33,12 +33,14 @@ except ImportError:  # pragma: NO COVER
 
 if typing.TYPE_CHECKING:
     from aiohttp import ClientTimeout
+
 else:
-    ClientTimeout: typing.Type = Any
+    ClientTimeout = Any
     try:
         from aiohttp import ClientTimeout
     except ImportError:
         ClientTimeout = None
+
 
 @asynccontextmanager
 async def timeout_guard(timeout):
@@ -214,8 +216,46 @@ class AsyncAuthorizedSession:
         total_attempts: Optional[int] = transport.DEFAULT_MAX_RETRY_ATTEMPTS,
         **kwargs,
     ) -> transport.Response:
+        """
+        Args:
+                url (str): The URI to be requested.
+                data (Optional[bytes]): The payload or body in HTTP request.
+                headers (Optional[Mapping[str, str]]): Request headers.
+                timeout (float, aiohttp.ClientTimeout):
+                The amount of time in seconds to wait for the server response
+                with each individual request.
+                max_allowed_time (float):
+                If the method runs longer than this, a ``Timeout`` exception is
+                automatically raised. Unlike the ``timeout`` parameter, this
+                value applies to the total method execution time, even if
+                multiple requests are made under the hood.
+                total_attempts (int):
+                The total number of retry attempts.
+
+                Mind that it is not guaranteed that the timeout error is raised
+                at ``max_allowed_time``. It might take longer, for example, if
+                an underlying request takes a lot of time, but the request
+                itself does not timeout, e.g. if a large file is being
+                transmitted. The timeout error will be raised after such
+                request completes.
+
+        Returns:
+                google.auth.aio.transport.Response: The HTTP response.
+
+        Raises:
+                google.auth.exceptions.TimeoutError: If the method does not complete within
+                the configured `max_allowed_time` or the request exceeds the configured
+                `timeout`.
+        """
         return await self.request(
-            "GET", url, data, headers, max_allowed_time, timeout, total_attempts, **kwargs
+            "GET",
+            url,
+            data,
+            headers,
+            max_allowed_time,
+            timeout,
+            total_attempts,
+            **kwargs,
         )
 
     @functools.wraps(request)
@@ -229,8 +269,46 @@ class AsyncAuthorizedSession:
         total_attempts: Optional[int] = transport.DEFAULT_MAX_RETRY_ATTEMPTS,
         **kwargs,
     ) -> transport.Response:
+        """
+        Args:
+                url (str): The URI to be requested.
+                data (Optional[bytes]): The payload or body in HTTP request.
+                headers (Optional[Mapping[str, str]]): Request headers.
+                timeout (float, aiohttp.ClientTimeout):
+                The amount of time in seconds to wait for the server response
+                with each individual request.
+                max_allowed_time (float):
+                If the method runs longer than this, a ``Timeout`` exception is
+                automatically raised. Unlike the ``timeout`` parameter, this
+                value applies to the total method execution time, even if
+                multiple requests are made under the hood.
+                total_attempts (int):
+                The total number of retry attempts.
+
+                Mind that it is not guaranteed that the timeout error is raised
+                at ``max_allowed_time``. It might take longer, for example, if
+                an underlying request takes a lot of time, but the request
+                itself does not timeout, e.g. if a large file is being
+                transmitted. The timeout error will be raised after such
+                request completes.
+
+        Returns:
+                google.auth.aio.transport.Response: The HTTP response.
+
+        Raises:
+                google.auth.exceptions.TimeoutError: If the method does not complete within
+                the configured `max_allowed_time` or the request exceeds the configured
+                `timeout`.
+        """
         return await self.request(
-            "POST", url, data, headers, max_allowed_time, timeout, total_attempts, **kwargs
+            "POST",
+            url,
+            data,
+            headers,
+            max_allowed_time,
+            timeout,
+            total_attempts,
+            **kwargs,
         )
 
     @functools.wraps(request)
@@ -244,8 +322,46 @@ class AsyncAuthorizedSession:
         total_attempts: Optional[int] = transport.DEFAULT_MAX_RETRY_ATTEMPTS,
         **kwargs,
     ) -> transport.Response:
+        """
+        Args:
+                url (str): The URI to be requested.
+                data (Optional[bytes]): The payload or body in HTTP request.
+                headers (Optional[Mapping[str, str]]): Request headers.
+                timeout (float, aiohttp.ClientTimeout):
+                The amount of time in seconds to wait for the server response
+                with each individual request.
+                max_allowed_time (float):
+                If the method runs longer than this, a ``Timeout`` exception is
+                automatically raised. Unlike the ``timeout`` parameter, this
+                value applies to the total method execution time, even if
+                multiple requests are made under the hood.
+                total_attempts (int):
+                The total number of retry attempts.
+
+                Mind that it is not guaranteed that the timeout error is raised
+                at ``max_allowed_time``. It might take longer, for example, if
+                an underlying request takes a lot of time, but the request
+                itself does not timeout, e.g. if a large file is being
+                transmitted. The timeout error will be raised after such
+                request completes.
+
+        Returns:
+                google.auth.aio.transport.Response: The HTTP response.
+
+        Raises:
+                google.auth.exceptions.TimeoutError: If the method does not complete within
+                the configured `max_allowed_time` or the request exceeds the configured
+                `timeout`.
+        """
         return await self.request(
-            "PUT", url, data, headers, max_allowed_time, timeout, total_attempts, **kwargs
+            "PUT",
+            url,
+            data,
+            headers,
+            max_allowed_time,
+            timeout,
+            total_attempts,
+            **kwargs,
         )
 
     @functools.wraps(request)
@@ -259,8 +375,46 @@ class AsyncAuthorizedSession:
         total_attempts: Optional[int] = transport.DEFAULT_MAX_RETRY_ATTEMPTS,
         **kwargs,
     ) -> transport.Response:
+        """
+        Args:
+                url (str): The URI to be requested.
+                data (Optional[bytes]): The payload or body in HTTP request.
+                headers (Optional[Mapping[str, str]]): Request headers.
+                timeout (float, aiohttp.ClientTimeout):
+                The amount of time in seconds to wait for the server response
+                with each individual request.
+                max_allowed_time (float):
+                If the method runs longer than this, a ``Timeout`` exception is
+                automatically raised. Unlike the ``timeout`` parameter, this
+                value applies to the total method execution time, even if
+                multiple requests are made under the hood.
+                total_attempts (int):
+                The total number of retry attempts.
+
+                Mind that it is not guaranteed that the timeout error is raised
+                at ``max_allowed_time``. It might take longer, for example, if
+                an underlying request takes a lot of time, but the request
+                itself does not timeout, e.g. if a large file is being
+                transmitted. The timeout error will be raised after such
+                request completes.
+
+        Returns:
+                google.auth.aio.transport.Response: The HTTP response.
+
+        Raises:
+                google.auth.exceptions.TimeoutError: If the method does not complete within
+                the configured `max_allowed_time` or the request exceeds the configured
+                `timeout`.
+        """
         return await self.request(
-            "PATCH", url, data, headers, max_allowed_time, timeout, total_attempts, **kwargs
+            "PATCH",
+            url,
+            data,
+            headers,
+            max_allowed_time,
+            timeout,
+            total_attempts,
+            **kwargs,
         )
 
     @functools.wraps(request)
@@ -270,12 +424,50 @@ class AsyncAuthorizedSession:
         data: Optional[bytes] = None,
         headers: Optional[Mapping[str, str]] = None,
         max_allowed_time: float = transport._DEFAULT_TIMEOUT_SECONDS,
-        timeout: float = transport._DEFAULT_TIMEOUT_SECONDS,
+        timeout: Union[float, ClientTimeout] = transport._DEFAULT_TIMEOUT_SECONDS,
         total_attempts: Optional[int] = transport.DEFAULT_MAX_RETRY_ATTEMPTS,
         **kwargs,
     ) -> transport.Response:
+        """
+        Args:
+                url (str): The URI to be requested.
+                data (Optional[bytes]): The payload or body in HTTP request.
+                headers (Optional[Mapping[str, str]]): Request headers.
+                timeout (float, aiohttp.ClientTimeout):
+                The amount of time in seconds to wait for the server response
+                with each individual request.
+                max_allowed_time (float):
+                If the method runs longer than this, a ``Timeout`` exception is
+                automatically raised. Unlike the ``timeout`` parameter, this
+                value applies to the total method execution time, even if
+                multiple requests are made under the hood.
+                total_attempts (int):
+                The total number of retry attempts.
+
+                Mind that it is not guaranteed that the timeout error is raised
+                at ``max_allowed_time``. It might take longer, for example, if
+                an underlying request takes a lot of time, but the request
+                itself does not timeout, e.g. if a large file is being
+                transmitted. The timeout error will be raised after such
+                request completes.
+
+        Returns:
+                google.auth.aio.transport.Response: The HTTP response.
+
+        Raises:
+                google.auth.exceptions.TimeoutError: If the method does not complete within
+                the configured `max_allowed_time` or the request exceeds the configured
+                `timeout`.
+        """
         return await self.request(
-            "DELETE", url, data, headers, max_allowed_time, timeout, total_attempts, **kwargs
+            "DELETE",
+            url,
+            data,
+            headers,
+            max_allowed_time,
+            timeout,
+            total_attempts,
+            **kwargs,
         )
 
     async def close(self) -> None:

--- a/system_tests/noxfile.py
+++ b/system_tests/noxfile.py
@@ -284,7 +284,7 @@ def compute_engine(session):
 def grpc(session):
     session.install(LIBRARY_DIR)
     session.install("six")
-    session.install(*TEST_DEPENDENCIES_SYNC, "google-cloud-pubsub==1.7.2")
+    session.install(*TEST_DEPENDENCIES_SYNC, "setuptools", "google-cloud-pubsub==1.7.2")
     session.env[EXPLICIT_CREDENTIALS_ENV] = SERVICE_ACCOUNT_FILE
     default(
         session,

--- a/system_tests/noxfile.py
+++ b/system_tests/noxfile.py
@@ -284,7 +284,7 @@ def compute_engine(session):
 def grpc(session):
     session.install(LIBRARY_DIR)
     session.install("six")
-    session.install(*TEST_DEPENDENCIES_SYNC, "setuptools", "google-cloud-pubsub==1.7.2")
+    session.install(*TEST_DEPENDENCIES_SYNC, "google-cloud-pubsub")
     session.env[EXPLICIT_CREDENTIALS_ENV] = SERVICE_ACCOUNT_FILE
     default(
         session,

--- a/tests/transport/aio/test_aiohttp.py
+++ b/tests/transport/aio/test_aiohttp.py
@@ -22,7 +22,6 @@ import pytest_asyncio  # type: ignore
 from google.auth import exceptions
 import google.auth.aio.transport.aiohttp as auth_aiohttp
 
-
 try:
     import aiohttp  # type: ignore
 except ImportError as caught_exc:  # pragma: NO COVER
@@ -153,9 +152,11 @@ class TestRequest:
             m.get("http://example.com", exception=asyncio.TimeoutError)
 
             with pytest.raises(exceptions.TimeoutError) as exc:
-                await aiohttp_request("http://example.com")
+                await aiohttp_request(
+                    "http://example.com", timeout=aiohttp.ClientTimeout(total=120)
+                )
 
-            exc.match("Request timed out after 180 seconds.")
+            exc.match("Request timed out after 120 seconds.")
 
     async def test_request_call_raises_transport_error_for_closed_session(
         self, aiohttp_request


### PR DESCRIPTION
b/485304839